### PR TITLE
Encapsulate all unsafe behind primitives modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,15 +157,17 @@ provide the same reuse for one-shot compression.
 
 ## Safety
 
-All compression and decompression logic is `#![forbid(unsafe_code)]`. Unsafe
-is confined to two places:
+zrip uses unsafe for performance, not a zero-unsafe codebase. All algorithm
+and control-flow code is `#![forbid(unsafe_code)]`. Unsafe is confined to
+small, auditable leaf modules:
 
-- `unchecked.rs` modules inside `bitstream/`, `decode/`, `encode/`, `fse/`,
-  `huffman/`: small `unsafe fn` wrappers (`get_unchecked`, `read_unaligned`)
-  with `debug_assert!` guards, called only after block-level bounds checks.
-- `simd/`: intrinsics and raw pointer arithmetic for wildcopy, copy-match,
-  and the SIMD sequence decoder. Dispatch happens at block boundaries, not
-  per-sequence.
+- `primitives.rs` modules in `bitstream/`, `huffman/`, `encode/`, `decode/`:
+  `#[inline(always)]` wrappers around `get_unchecked`, `read_unaligned`,
+  `set_len`, and `copy_nonoverlapping` with `debug_assert!` guards.
+- `simd/` and `simd_decode/`: intrinsics and raw pointer arithmetic for
+  wildcopy, copy-match, and the fused SIMD sequence decoder.
+- `huffman/decode_4stream.rs`: pointer-based interleaved 4-stream Huffman
+  decoder.
 
 ## Levels
 

--- a/crates/core/src/bitstream/mod.rs
+++ b/crates/core/src/bitstream/mod.rs
@@ -1,3 +1,4 @@
+pub(crate) mod primitives;
 pub mod reader;
 pub mod reader_reverse;
 pub mod writer;

--- a/crates/core/src/bitstream/primitives.rs
+++ b/crates/core/src/bitstream/primitives.rs
@@ -1,0 +1,28 @@
+#[cfg(feature = "alloc")]
+use alloc::vec::Vec;
+
+#[inline(always)]
+pub(crate) fn read_u64_le_unaligned(data: &[u8], offset: usize) -> u64 {
+    debug_assert!(offset + 8 <= data.len());
+    unsafe { u64::from_le((data.as_ptr().add(offset) as *const u64).read_unaligned()) }
+}
+
+#[inline(always)]
+pub(crate) fn get_byte_unchecked(data: &[u8], idx: usize) -> u8 {
+    debug_assert!(idx < data.len());
+    unsafe { *data.get_unchecked(idx) }
+}
+
+#[inline(always)]
+pub(crate) fn write_u64_le_unaligned(buf: &mut Vec<u8>, pos: usize, val: u64) {
+    debug_assert!(pos + 8 <= buf.capacity());
+    unsafe {
+        (buf.as_mut_ptr().add(pos) as *mut u64).write_unaligned(val.to_le());
+    }
+}
+
+#[inline(always)]
+pub(crate) fn set_vec_len(vec: &mut Vec<u8>, len: usize) {
+    debug_assert!(len <= vec.capacity());
+    unsafe { vec.set_len(len) }
+}

--- a/crates/core/src/bitstream/reader_reverse.rs
+++ b/crates/core/src/bitstream/reader_reverse.rs
@@ -1,3 +1,6 @@
+#![forbid(unsafe_code)]
+
+use crate::bitstream::primitives;
 use crate::error::DecompressError;
 
 /// Reverse bitstream reader using C zstd's bitsConsumed model.
@@ -30,7 +33,7 @@ impl<'a> ReverseBitReader<'a> {
         let ptr = if data.len() >= 8 { data.len() - 8 } else { 0 };
 
         let container = if data.len() >= 8 {
-            unsafe { u64::from_le((data.as_ptr().add(ptr) as *const u64).read_unaligned()) }
+            primitives::read_u64_le_unaligned(data, ptr)
         } else {
             let mut val = 0u64;
             for (i, &b) in data.iter().enumerate() {
@@ -66,14 +69,12 @@ impl<'a> ReverseBitReader<'a> {
         self.ptr -= actual_shift;
         self.bits_consumed -= (actual_shift as u32) * 8;
         if self.ptr + 8 <= self.data.len() {
-            self.container = unsafe {
-                u64::from_le((self.data.as_ptr().add(self.ptr) as *const u64).read_unaligned())
-            };
+            self.container = primitives::read_u64_le_unaligned(self.data, self.ptr);
         } else {
             let mut val = 0u64;
             let avail = self.data.len() - self.ptr;
             for i in 0..avail {
-                val |= (unsafe { *self.data.get_unchecked(self.ptr + i) } as u64) << (i * 8);
+                val |= (primitives::get_byte_unchecked(self.data, self.ptr + i) as u64) << (i * 8);
             }
             self.container = val;
         }
@@ -140,9 +141,7 @@ impl<'a> ReverseBitReader<'a> {
         let byte_shift = (self.bits_consumed >> 3) as usize;
         self.ptr -= byte_shift;
         self.bits_consumed -= (byte_shift as u32) * 8;
-        self.container = unsafe {
-            u64::from_le((self.data.as_ptr().add(self.ptr) as *const u64).read_unaligned())
-        };
+        self.container = primitives::read_u64_le_unaligned(self.data, self.ptr);
     }
 
     #[inline]

--- a/crates/core/src/bitstream/writer.rs
+++ b/crates/core/src/bitstream/writer.rs
@@ -1,5 +1,9 @@
+#![forbid(unsafe_code)]
+
 #[cfg(feature = "alloc")]
 use alloc::vec::Vec;
+
+use super::primitives;
 
 pub struct BitWriter {
     #[cfg(feature = "alloc")]
@@ -55,9 +59,7 @@ impl BitWriter {
     #[inline(always)]
     fn ensure_capacity(&mut self) {
         if self.pos + 8 > self.buf.capacity() {
-            unsafe {
-                self.buf.set_len(self.pos);
-            }
+            primitives::set_vec_len(&mut self.buf, self.pos);
             self.buf.reserve(64);
         }
     }
@@ -73,21 +75,16 @@ impl BitWriter {
         self.bits_used += n;
         if self.bits_used >= 32 {
             self.ensure_capacity();
-            unsafe {
-                let ptr = self.buf.as_mut_ptr().add(self.pos);
-                (ptr as *mut u64).write_unaligned(self.bits.to_le());
-                let nb = (self.bits_used >> 3) as usize;
-                self.pos += nb;
-                self.bits >>= nb << 3;
-                self.bits_used &= 7;
-            }
+            primitives::write_u64_le_unaligned(&mut self.buf, self.pos, self.bits);
+            let nb = (self.bits_used >> 3) as usize;
+            self.pos += nb;
+            self.bits >>= nb << 3;
+            self.bits_used &= 7;
         }
     }
 
     pub fn flush_remaining(&mut self) {
-        unsafe {
-            self.buf.set_len(self.pos);
-        }
+        primitives::set_vec_len(&mut self.buf, self.pos);
         while self.bits_used > 0 {
             self.buf.push(self.bits as u8);
             self.bits >>= 8;
@@ -111,9 +108,7 @@ impl BitWriter {
     }
 
     pub fn as_bytes(&mut self) -> &[u8] {
-        unsafe {
-            self.buf.set_len(self.pos);
-        }
+        primitives::set_vec_len(&mut self.buf, self.pos);
         &self.buf
     }
 

--- a/crates/core/src/huffman/decode.rs
+++ b/crates/core/src/huffman/decode.rs
@@ -1,8 +1,11 @@
+#![forbid(unsafe_code)]
+
 #[cfg(feature = "alloc")]
 use alloc::vec;
 #[cfg(feature = "alloc")]
 use alloc::vec::Vec;
 
+use super::primitives;
 use crate::bitstream::reader_reverse::ReverseBitReader;
 use crate::error::DecompressError;
 use crate::huffman::HuffmanDecodeEntry;
@@ -21,7 +24,7 @@ pub fn decode_single_stream(
     while output.len() + 4 <= output_size && reader.bits_remaining() >= tl + tl + tl + tl {
         for _ in 0..4 {
             let bits = reader.peek_bits(table_log);
-            let entry = unsafe { table.get_unchecked(bits as usize) };
+            let entry = primitives::huf_table_lookup(table, bits as usize);
             output.push(entry.symbol);
             reader.consume_bits(entry.num_bits);
         }
@@ -38,7 +41,7 @@ pub fn decode_single_stream(
         } else {
             reader.peek_bits(remaining as u8) << (tl - remaining)
         };
-        let entry = unsafe { table.get_unchecked(bits as usize) };
+        let entry = primitives::huf_table_lookup(table, bits as usize);
         if entry.num_bits as usize > remaining {
             return Err(DecompressError::BadHuffmanStream);
         }
@@ -67,32 +70,56 @@ pub fn decode_single_stream_vec(
     output: &mut Vec<u8>,
 ) -> Result<(), DecompressError> {
     output.clear();
-    #[allow(clippy::uninit_vec)]
-    unsafe {
-        output.reserve(output_size);
-        output.set_len(output_size);
-    }
+    output.reserve(output_size);
+    primitives::set_vec_len(output, output_size);
     #[cfg(target_arch = "x86_64")]
     {
         if crate::simd::cpu_tier() >= crate::simd::CpuTier::Bmi2 {
-            return unsafe { decode_single_stream_bmi2(table, table_log, data, output) };
+            return super::decode_4stream::decode_single_stream_bmi2_safe(
+                table, table_log, data, output,
+            );
         }
     }
     decode_single_stream_into(table, table_log, data, output)
 }
 
-#[cfg(target_arch = "x86_64")]
-#[target_feature(enable = "bmi2")]
-unsafe fn decode_single_stream_bmi2(
+pub fn decode_4_streams(
     table: &[HuffmanDecodeEntry],
     table_log: u8,
     data: &[u8],
-    output: &mut [u8],
-) -> Result<(), DecompressError> {
-    decode_single_stream_into(table, table_log, data, output)
+    output_size: usize,
+) -> Result<Vec<u8>, DecompressError> {
+    let mut output = vec![0u8; output_size];
+    super::decode_4stream::decode_4_streams_core(table, table_log, data, output_size, &mut output)?;
+    Ok(output)
 }
 
-fn decode_stream_tail(
+pub fn decode_4_streams_into(
+    table: &[HuffmanDecodeEntry],
+    table_log: u8,
+    data: &[u8],
+    output_size: usize,
+    output: &mut Vec<u8>,
+) -> Result<(), DecompressError> {
+    output.clear();
+    output.reserve(output_size);
+    primitives::set_vec_len(output, output_size);
+    #[cfg(target_arch = "x86_64")]
+    {
+        if crate::simd::cpu_tier() >= crate::simd::CpuTier::Bmi2 {
+            return super::decode_4stream::decode_4_streams_core_bmi2_safe(
+                table,
+                table_log,
+                data,
+                output_size,
+                output,
+            );
+        }
+    }
+    super::decode_4stream::decode_4_streams_core(table, table_log, data, output_size, output)
+}
+
+pub(super) fn decode_stream_tail(
     table: &[HuffmanDecodeEntry],
     table_log: u8,
     reader: &mut ReverseBitReader,
@@ -106,8 +133,8 @@ fn decode_stream_tail(
     while pos + 4 <= output_size && reader.bits_remaining() >= tl + tl + tl + tl {
         for _ in 0..4 {
             let bits = reader.peek_bits(table_log);
-            let entry = unsafe { table.get_unchecked(bits as usize) };
-            unsafe { *output.get_unchecked_mut(pos) = entry.symbol };
+            let entry = primitives::huf_table_lookup(table, bits as usize);
+            primitives::huf_output_write(output, pos, entry.symbol);
             pos += 1;
             reader.consume_bits(entry.num_bits);
         }
@@ -124,227 +151,14 @@ fn decode_stream_tail(
         } else {
             reader.peek_bits(remaining as u8) << (tl - remaining)
         };
-        let entry = unsafe { table.get_unchecked(bits as usize) };
+        let entry = primitives::huf_table_lookup(table, bits as usize);
         if entry.num_bits as usize > remaining {
             return Err(DecompressError::BadHuffmanStream);
         }
-        unsafe { *output.get_unchecked_mut(pos) = entry.symbol };
+        primitives::huf_output_write(output, pos, entry.symbol);
         pos += 1;
         let _ = reader.read_bits(entry.num_bits)?;
     }
-
-    Ok(())
-}
-
-pub fn decode_4_streams(
-    table: &[HuffmanDecodeEntry],
-    table_log: u8,
-    data: &[u8],
-    output_size: usize,
-) -> Result<Vec<u8>, DecompressError> {
-    let mut output = vec![0u8; output_size];
-    decode_4_streams_core(table, table_log, data, output_size, &mut output)?;
-    Ok(output)
-}
-
-pub fn decode_4_streams_into(
-    table: &[HuffmanDecodeEntry],
-    table_log: u8,
-    data: &[u8],
-    output_size: usize,
-    output: &mut Vec<u8>,
-) -> Result<(), DecompressError> {
-    output.clear();
-    #[allow(clippy::uninit_vec)]
-    unsafe {
-        output.reserve(output_size);
-        output.set_len(output_size);
-    }
-    #[cfg(target_arch = "x86_64")]
-    {
-        if crate::simd::cpu_tier() >= crate::simd::CpuTier::Bmi2 {
-            return unsafe {
-                decode_4_streams_core_bmi2(table, table_log, data, output_size, output)
-            };
-        }
-    }
-    decode_4_streams_core(table, table_log, data, output_size, output)
-}
-
-#[cfg(target_arch = "x86_64")]
-#[target_feature(enable = "bmi2")]
-unsafe fn decode_4_streams_core_bmi2(
-    table: &[HuffmanDecodeEntry],
-    table_log: u8,
-    data: &[u8],
-    output_size: usize,
-    output: &mut [u8],
-) -> Result<(), DecompressError> {
-    decode_4_streams_core(table, table_log, data, output_size, output)
-}
-
-fn decode_4_streams_core(
-    table: &[HuffmanDecodeEntry],
-    table_log: u8,
-    data: &[u8],
-    output_size: usize,
-    output: &mut [u8],
-) -> Result<(), DecompressError> {
-    if data.len() < 6 {
-        return Err(DecompressError::BadHuffmanStream);
-    }
-
-    let s1_size = u16::from_le_bytes([data[0], data[1]]) as usize;
-    let s2_size = u16::from_le_bytes([data[2], data[3]]) as usize;
-    let s3_size = u16::from_le_bytes([data[4], data[5]]) as usize;
-
-    let jump_table_size = 6;
-    let s1_start = jump_table_size;
-    let s2_start = s1_start + s1_size;
-    let s3_start = s2_start + s2_size;
-    let s4_start = s3_start + s3_size;
-
-    if s4_start > data.len() {
-        return Err(DecompressError::BadHuffmanStream);
-    }
-
-    let seg = output_size.div_ceil(4);
-    if seg * 3 >= output_size {
-        return Err(DecompressError::BadHuffmanStream);
-    }
-    let remaining = output_size - seg * 3;
-
-    let mut r1 = ReverseBitReader::new(&data[s1_start..s2_start])
-        .map_err(|_| DecompressError::BadHuffmanStream)?;
-    let mut r2 = ReverseBitReader::new(&data[s2_start..s3_start])
-        .map_err(|_| DecompressError::BadHuffmanStream)?;
-    let mut r3 = ReverseBitReader::new(&data[s3_start..s4_start])
-        .map_err(|_| DecompressError::BadHuffmanStream)?;
-    let mut r4 =
-        ReverseBitReader::new(&data[s4_start..]).map_err(|_| DecompressError::BadHuffmanStream)?;
-
-    let seg1_end = seg;
-    let seg2_end = seg * 2;
-    let seg3_end = seg * 3;
-    let seg4_end = seg * 3 + remaining;
-
-    let tbl = table.as_ptr();
-
-    let mut c1 = r1.container;
-    let mut bc1 = r1.bits_consumed;
-    let mut p1_ptr = unsafe { r1.data.as_ptr().add(r1.ptr) };
-
-    let mut c2 = r2.container;
-    let mut bc2 = r2.bits_consumed;
-    let mut p2_ptr = unsafe { r2.data.as_ptr().add(r2.ptr) };
-
-    let mut c3 = r3.container;
-    let mut bc3 = r3.bits_consumed;
-    let mut p3_ptr = unsafe { r3.data.as_ptr().add(r3.ptr) };
-
-    let mut c4 = r4.container;
-    let mut bc4 = r4.bits_consumed;
-    let mut p4_ptr = unsafe { r4.data.as_ptr().add(r4.ptr) };
-
-    let fast1 = unsafe { r1.data.as_ptr().add(r1.limit_ptr + 8) };
-    let fast2 = unsafe { r2.data.as_ptr().add(r2.limit_ptr + 8) };
-    let fast3 = unsafe { r3.data.as_ptr().add(r3.limit_ptr + 8) };
-    let fast4 = unsafe { r4.data.as_ptr().add(r4.limit_ptr + 8) };
-
-    let out_base = output.as_mut_ptr();
-    let mut o1 = unsafe { out_base.add(0) };
-    let mut o2 = unsafe { out_base.add(seg) };
-    let mut o3 = unsafe { out_base.add(seg * 2) };
-    let mut o4 = unsafe { out_base.add(seg * 3) };
-
-    let o1_end = unsafe { out_base.add(seg1_end) };
-    let o2_end = unsafe { out_base.add(seg2_end) };
-    let o3_end = unsafe { out_base.add(seg3_end) };
-    let o4_end = unsafe { out_base.add(seg4_end) };
-
-    let tl = table_log as u32;
-
-    macro_rules! refill {
-        ($c:expr, $bc:expr, $p:expr) => {{
-            let byte_shift = ($bc >> 3) as usize;
-            $p = unsafe { $p.sub(byte_shift) };
-            $bc -= (byte_shift as u32) * 8;
-            $c = unsafe { ($p as *const u64).read_unaligned() };
-        }};
-    }
-
-    macro_rules! decode_one {
-        ($c:expr, $bc:expr, $o:expr) => {{
-            let idx = (($c << ($bc & 63)) >> (64 - tl)) as usize;
-            let e = unsafe { *tbl.add(idx) };
-            unsafe { *$o = e.symbol };
-            $bc += e.num_bits as u32;
-            $o = unsafe { $o.add(1) };
-        }};
-    }
-
-    while unsafe { o1.add(5) } <= o1_end
-        && unsafe { o2.add(5) } <= o2_end
-        && unsafe { o3.add(5) } <= o3_end
-        && unsafe { o4.add(5) } <= o4_end
-        && p1_ptr >= fast1
-        && p2_ptr >= fast2
-        && p3_ptr >= fast3
-        && p4_ptr >= fast4
-    {
-        refill!(c1, bc1, p1_ptr);
-        refill!(c2, bc2, p2_ptr);
-        refill!(c3, bc3, p3_ptr);
-        refill!(c4, bc4, p4_ptr);
-
-        decode_one!(c1, bc1, o1);
-        decode_one!(c2, bc2, o2);
-        decode_one!(c3, bc3, o3);
-        decode_one!(c4, bc4, o4);
-
-        decode_one!(c1, bc1, o1);
-        decode_one!(c2, bc2, o2);
-        decode_one!(c3, bc3, o3);
-        decode_one!(c4, bc4, o4);
-
-        decode_one!(c1, bc1, o1);
-        decode_one!(c2, bc2, o2);
-        decode_one!(c3, bc3, o3);
-        decode_one!(c4, bc4, o4);
-
-        decode_one!(c1, bc1, o1);
-        decode_one!(c2, bc2, o2);
-        decode_one!(c3, bc3, o3);
-        decode_one!(c4, bc4, o4);
-
-        decode_one!(c1, bc1, o1);
-        decode_one!(c2, bc2, o2);
-        decode_one!(c3, bc3, o3);
-        decode_one!(c4, bc4, o4);
-    }
-
-    r1.container = c1;
-    r1.bits_consumed = bc1;
-    r1.ptr = unsafe { p1_ptr.offset_from(r1.data.as_ptr()) } as usize;
-    r2.container = c2;
-    r2.bits_consumed = bc2;
-    r2.ptr = unsafe { p2_ptr.offset_from(r2.data.as_ptr()) } as usize;
-    r3.container = c3;
-    r3.bits_consumed = bc3;
-    r3.ptr = unsafe { p3_ptr.offset_from(r3.data.as_ptr()) } as usize;
-    r4.container = c4;
-    r4.bits_consumed = bc4;
-    r4.ptr = unsafe { p4_ptr.offset_from(r4.data.as_ptr()) } as usize;
-
-    let p1 = unsafe { o1.offset_from(out_base) } as usize;
-    let p2 = unsafe { o2.offset_from(out_base) } as usize;
-    let p3 = unsafe { o3.offset_from(out_base) } as usize;
-    let p4 = unsafe { o4.offset_from(out_base) } as usize;
-
-    decode_stream_tail(table, table_log, &mut r1, &mut output[p1..seg1_end])?;
-    decode_stream_tail(table, table_log, &mut r2, &mut output[p2..seg2_end])?;
-    decode_stream_tail(table, table_log, &mut r3, &mut output[p3..seg3_end])?;
-    decode_stream_tail(table, table_log, &mut r4, &mut output[p4..seg4_end])?;
 
     Ok(())
 }

--- a/crates/core/src/huffman/decode_4stream.rs
+++ b/crates/core/src/huffman/decode_4stream.rs
@@ -1,0 +1,213 @@
+use crate::bitstream::reader_reverse::ReverseBitReader;
+use crate::error::DecompressError;
+use crate::huffman::HuffmanDecodeEntry;
+
+#[cfg(target_arch = "x86_64")]
+#[target_feature(enable = "bmi2")]
+unsafe fn decode_single_stream_bmi2(
+    table: &[HuffmanDecodeEntry],
+    table_log: u8,
+    data: &[u8],
+    output: &mut [u8],
+) -> Result<(), DecompressError> {
+    super::decode::decode_single_stream_into(table, table_log, data, output)
+}
+
+#[cfg(target_arch = "x86_64")]
+pub(super) fn decode_single_stream_bmi2_safe(
+    table: &[HuffmanDecodeEntry],
+    table_log: u8,
+    data: &[u8],
+    output: &mut [u8],
+) -> Result<(), DecompressError> {
+    unsafe { decode_single_stream_bmi2(table, table_log, data, output) }
+}
+
+#[cfg(target_arch = "x86_64")]
+#[target_feature(enable = "bmi2")]
+unsafe fn decode_4_streams_core_bmi2(
+    table: &[HuffmanDecodeEntry],
+    table_log: u8,
+    data: &[u8],
+    output_size: usize,
+    output: &mut [u8],
+) -> Result<(), DecompressError> {
+    decode_4_streams_core(table, table_log, data, output_size, output)
+}
+
+#[cfg(target_arch = "x86_64")]
+pub(super) fn decode_4_streams_core_bmi2_safe(
+    table: &[HuffmanDecodeEntry],
+    table_log: u8,
+    data: &[u8],
+    output_size: usize,
+    output: &mut [u8],
+) -> Result<(), DecompressError> {
+    unsafe { decode_4_streams_core_bmi2(table, table_log, data, output_size, output) }
+}
+
+pub(super) fn decode_4_streams_core(
+    table: &[HuffmanDecodeEntry],
+    table_log: u8,
+    data: &[u8],
+    output_size: usize,
+    output: &mut [u8],
+) -> Result<(), DecompressError> {
+    if data.len() < 6 {
+        return Err(DecompressError::BadHuffmanStream);
+    }
+
+    let s1_size = u16::from_le_bytes([data[0], data[1]]) as usize;
+    let s2_size = u16::from_le_bytes([data[2], data[3]]) as usize;
+    let s3_size = u16::from_le_bytes([data[4], data[5]]) as usize;
+
+    let jump_table_size = 6;
+    let s1_start = jump_table_size;
+    let s2_start = s1_start + s1_size;
+    let s3_start = s2_start + s2_size;
+    let s4_start = s3_start + s3_size;
+
+    if s4_start > data.len() {
+        return Err(DecompressError::BadHuffmanStream);
+    }
+
+    let seg = output_size.div_ceil(4);
+    if seg * 3 >= output_size {
+        return Err(DecompressError::BadHuffmanStream);
+    }
+    let remaining = output_size - seg * 3;
+
+    let mut r1 = ReverseBitReader::new(&data[s1_start..s2_start])
+        .map_err(|_| DecompressError::BadHuffmanStream)?;
+    let mut r2 = ReverseBitReader::new(&data[s2_start..s3_start])
+        .map_err(|_| DecompressError::BadHuffmanStream)?;
+    let mut r3 = ReverseBitReader::new(&data[s3_start..s4_start])
+        .map_err(|_| DecompressError::BadHuffmanStream)?;
+    let mut r4 =
+        ReverseBitReader::new(&data[s4_start..]).map_err(|_| DecompressError::BadHuffmanStream)?;
+
+    let seg1_end = seg;
+    let seg2_end = seg * 2;
+    let seg3_end = seg * 3;
+    let seg4_end = seg * 3 + remaining;
+
+    let tbl = table.as_ptr();
+
+    let mut c1 = r1.container;
+    let mut bc1 = r1.bits_consumed;
+    let mut p1_ptr = unsafe { r1.data.as_ptr().add(r1.ptr) };
+
+    let mut c2 = r2.container;
+    let mut bc2 = r2.bits_consumed;
+    let mut p2_ptr = unsafe { r2.data.as_ptr().add(r2.ptr) };
+
+    let mut c3 = r3.container;
+    let mut bc3 = r3.bits_consumed;
+    let mut p3_ptr = unsafe { r3.data.as_ptr().add(r3.ptr) };
+
+    let mut c4 = r4.container;
+    let mut bc4 = r4.bits_consumed;
+    let mut p4_ptr = unsafe { r4.data.as_ptr().add(r4.ptr) };
+
+    let fast1 = unsafe { r1.data.as_ptr().add(r1.limit_ptr + 8) };
+    let fast2 = unsafe { r2.data.as_ptr().add(r2.limit_ptr + 8) };
+    let fast3 = unsafe { r3.data.as_ptr().add(r3.limit_ptr + 8) };
+    let fast4 = unsafe { r4.data.as_ptr().add(r4.limit_ptr + 8) };
+
+    let out_base = output.as_mut_ptr();
+    let mut o1 = unsafe { out_base.add(0) };
+    let mut o2 = unsafe { out_base.add(seg) };
+    let mut o3 = unsafe { out_base.add(seg * 2) };
+    let mut o4 = unsafe { out_base.add(seg * 3) };
+
+    let o1_end = unsafe { out_base.add(seg1_end) };
+    let o2_end = unsafe { out_base.add(seg2_end) };
+    let o3_end = unsafe { out_base.add(seg3_end) };
+    let o4_end = unsafe { out_base.add(seg4_end) };
+
+    let tl = table_log as u32;
+
+    macro_rules! refill {
+        ($c:expr, $bc:expr, $p:expr) => {{
+            let byte_shift = ($bc >> 3) as usize;
+            $p = unsafe { $p.sub(byte_shift) };
+            $bc -= (byte_shift as u32) * 8;
+            $c = unsafe { ($p as *const u64).read_unaligned() };
+        }};
+    }
+
+    macro_rules! decode_one {
+        ($c:expr, $bc:expr, $o:expr) => {{
+            let idx = (($c << ($bc & 63)) >> (64 - tl)) as usize;
+            let e = unsafe { *tbl.add(idx) };
+            unsafe { *$o = e.symbol };
+            $bc += e.num_bits as u32;
+            $o = unsafe { $o.add(1) };
+        }};
+    }
+
+    while unsafe { o1.add(5) } <= o1_end
+        && unsafe { o2.add(5) } <= o2_end
+        && unsafe { o3.add(5) } <= o3_end
+        && unsafe { o4.add(5) } <= o4_end
+        && p1_ptr >= fast1
+        && p2_ptr >= fast2
+        && p3_ptr >= fast3
+        && p4_ptr >= fast4
+    {
+        refill!(c1, bc1, p1_ptr);
+        refill!(c2, bc2, p2_ptr);
+        refill!(c3, bc3, p3_ptr);
+        refill!(c4, bc4, p4_ptr);
+
+        decode_one!(c1, bc1, o1);
+        decode_one!(c2, bc2, o2);
+        decode_one!(c3, bc3, o3);
+        decode_one!(c4, bc4, o4);
+
+        decode_one!(c1, bc1, o1);
+        decode_one!(c2, bc2, o2);
+        decode_one!(c3, bc3, o3);
+        decode_one!(c4, bc4, o4);
+
+        decode_one!(c1, bc1, o1);
+        decode_one!(c2, bc2, o2);
+        decode_one!(c3, bc3, o3);
+        decode_one!(c4, bc4, o4);
+
+        decode_one!(c1, bc1, o1);
+        decode_one!(c2, bc2, o2);
+        decode_one!(c3, bc3, o3);
+        decode_one!(c4, bc4, o4);
+
+        decode_one!(c1, bc1, o1);
+        decode_one!(c2, bc2, o2);
+        decode_one!(c3, bc3, o3);
+        decode_one!(c4, bc4, o4);
+    }
+
+    r1.container = c1;
+    r1.bits_consumed = bc1;
+    r1.ptr = unsafe { p1_ptr.offset_from(r1.data.as_ptr()) } as usize;
+    r2.container = c2;
+    r2.bits_consumed = bc2;
+    r2.ptr = unsafe { p2_ptr.offset_from(r2.data.as_ptr()) } as usize;
+    r3.container = c3;
+    r3.bits_consumed = bc3;
+    r3.ptr = unsafe { p3_ptr.offset_from(r3.data.as_ptr()) } as usize;
+    r4.container = c4;
+    r4.bits_consumed = bc4;
+    r4.ptr = unsafe { p4_ptr.offset_from(r4.data.as_ptr()) } as usize;
+
+    let p1 = unsafe { o1.offset_from(out_base) } as usize;
+    let p2 = unsafe { o2.offset_from(out_base) } as usize;
+    let p3 = unsafe { o3.offset_from(out_base) } as usize;
+    let p4 = unsafe { o4.offset_from(out_base) } as usize;
+
+    super::decode::decode_stream_tail(table, table_log, &mut r1, &mut output[p1..seg1_end])?;
+    super::decode::decode_stream_tail(table, table_log, &mut r2, &mut output[p2..seg2_end])?;
+    super::decode::decode_stream_tail(table, table_log, &mut r3, &mut output[p3..seg3_end])?;
+    super::decode::decode_stream_tail(table, table_log, &mut r4, &mut output[p4..seg4_end])?;
+
+    Ok(())
+}

--- a/crates/core/src/huffman/encode.rs
+++ b/crates/core/src/huffman/encode.rs
@@ -1,8 +1,11 @@
+#![forbid(unsafe_code)]
+
 #[cfg(feature = "alloc")]
 use alloc::vec;
 #[cfg(feature = "alloc")]
 use alloc::vec::Vec;
 
+use super::primitives;
 use crate::huffman::{MAX_BITS, MAX_SYMBOL_VALUE};
 
 pub struct HuffmanEncodeTable {
@@ -35,8 +38,6 @@ impl HuffmanEncodeTable {
             return None;
         }
 
-        // Direct weight encoding supports at most 128 explicit symbols.
-        // Fall back to raw literals for blocks with more distinct values.
         if max_sym as usize > 128 {
             return None;
         }
@@ -96,25 +97,18 @@ impl HuffmanEncodeTable {
         let mut bits: u64 = 0;
         let mut bits_used: u8 = 0;
         let mut wpos: usize = 0;
-        let codes = self.codes.as_ptr();
-        let nbits = self.num_bits.as_ptr();
 
         macro_rules! flush_bits {
             () => {
                 if wpos + 8 > buf.capacity() {
-                    unsafe {
-                        buf.set_len(wpos);
-                    }
+                    primitives::set_vec_len(buf, wpos);
                     buf.reserve(64);
                 }
-                unsafe {
-                    let ptr = buf.as_mut_ptr().add(wpos);
-                    (ptr as *mut u64).write_unaligned(bits.to_le());
-                    let nb = (bits_used >> 3) as usize;
-                    wpos += nb;
-                    bits >>= nb << 3;
-                    bits_used &= 7;
-                }
+                primitives::bitstream_flush_vec(buf, wpos, bits);
+                let nb = (bits_used >> 3) as usize;
+                wpos += nb;
+                bits >>= nb << 3;
+                bits_used &= 7;
             };
         }
 
@@ -122,9 +116,9 @@ impl HuffmanEncodeTable {
         while pos >= unroll {
             pos -= unroll;
             for j in 0..unroll {
-                let b = unsafe { *data.get_unchecked(pos + (unroll - 1 - j)) };
-                let c = unsafe { *codes.add(b as usize) } as u64;
-                let n = unsafe { *nbits.add(b as usize) };
+                let b = primitives::get_unchecked_byte(data, pos + (unroll - 1 - j));
+                let c = primitives::get_unchecked_u16(&self.codes, b as usize) as u64;
+                let n = primitives::get_unchecked_u8_arr(&self.num_bits, b as usize);
                 bits |= c << bits_used;
                 bits_used += n;
             }
@@ -134,9 +128,9 @@ impl HuffmanEncodeTable {
         }
         while pos > 0 {
             pos -= 1;
-            let b = unsafe { *data.get_unchecked(pos) };
-            let c = unsafe { *codes.add(b as usize) } as u64;
-            let n = unsafe { *nbits.add(b as usize) };
+            let b = primitives::get_unchecked_byte(data, pos);
+            let c = primitives::get_unchecked_u16(&self.codes, b as usize) as u64;
+            let n = primitives::get_unchecked_u8_arr(&self.num_bits, b as usize);
             bits |= c << bits_used;
             bits_used += n;
             if bits_used >= 32 {
@@ -144,9 +138,7 @@ impl HuffmanEncodeTable {
             }
         }
 
-        unsafe {
-            buf.set_len(wpos);
-        }
+        primitives::set_vec_len(buf, wpos);
         bits |= 1u64 << bits_used;
         bits_used += 1;
         while bits_used > 0 {

--- a/crates/core/src/huffman/mod.rs
+++ b/crates/core/src/huffman/mod.rs
@@ -1,5 +1,7 @@
 pub mod decode;
+pub(crate) mod decode_4stream;
 pub mod encode;
+pub(crate) mod primitives;
 pub mod weights;
 
 pub const MAX_SYMBOL_VALUE: usize = 255;

--- a/crates/core/src/huffman/primitives.rs
+++ b/crates/core/src/huffman/primitives.rs
@@ -1,0 +1,50 @@
+#[cfg(feature = "alloc")]
+use alloc::vec::Vec;
+
+use super::HuffmanDecodeEntry;
+
+#[inline(always)]
+pub(crate) fn huf_table_lookup(table: &[HuffmanDecodeEntry], idx: usize) -> HuffmanDecodeEntry {
+    debug_assert!(idx < table.len());
+    unsafe { *table.get_unchecked(idx) }
+}
+
+#[inline(always)]
+pub(crate) fn huf_output_write(output: &mut [u8], pos: usize, val: u8) {
+    debug_assert!(pos < output.len());
+    unsafe { *output.get_unchecked_mut(pos) = val }
+}
+
+#[cfg(feature = "alloc")]
+#[inline(always)]
+pub(crate) fn set_vec_len(vec: &mut Vec<u8>, len: usize) {
+    debug_assert!(len <= vec.capacity());
+    unsafe { vec.set_len(len) }
+}
+
+#[inline(always)]
+pub(crate) fn get_unchecked_byte(data: &[u8], idx: usize) -> u8 {
+    debug_assert!(idx < data.len());
+    unsafe { *data.get_unchecked(idx) }
+}
+
+#[inline(always)]
+pub(crate) fn get_unchecked_u16(data: &[u16], idx: usize) -> u16 {
+    debug_assert!(idx < data.len());
+    unsafe { *data.get_unchecked(idx) }
+}
+
+#[inline(always)]
+pub(crate) fn get_unchecked_u8_arr(data: &[u8], idx: usize) -> u8 {
+    debug_assert!(idx < data.len());
+    unsafe { *data.get_unchecked(idx) }
+}
+
+#[cfg(feature = "alloc")]
+#[inline(always)]
+pub(crate) fn bitstream_flush_vec(buf: &mut Vec<u8>, pos: usize, bits: u64) {
+    debug_assert!(pos + 8 <= buf.capacity());
+    unsafe {
+        (buf.as_mut_ptr().add(pos) as *mut u64).write_unaligned(bits.to_le());
+    }
+}

--- a/crates/core/src/xxhash/mod.rs
+++ b/crates/core/src/xxhash/mod.rs
@@ -1,20 +1,10 @@
+mod primitives;
+
 const PRIME64_1: u64 = 0x9E3779B185EBCA87;
 const PRIME64_2: u64 = 0xC2B2AE3D27D4EB4F;
 const PRIME64_3: u64 = 0x165667B19E3779F9;
 const PRIME64_4: u64 = 0x85EBCA77C2B2AE63;
 const PRIME64_5: u64 = 0x27D4EB2F165667C5;
-
-#[inline(always)]
-fn read_u32_le(data: &[u8], offset: usize) -> u32 {
-    debug_assert!(offset + 4 <= data.len());
-    u32::from_le(unsafe { (data.as_ptr().add(offset) as *const u32).read_unaligned() })
-}
-
-#[inline(always)]
-fn read_u64_le(data: &[u8], offset: usize) -> u64 {
-    debug_assert!(offset + 8 <= data.len());
-    u64::from_le(unsafe { (data.as_ptr().add(offset) as *const u64).read_unaligned() })
-}
 
 #[inline]
 fn xxh64_round(mut acc: u64, input: u64) -> u64 {
@@ -41,43 +31,7 @@ pub fn xxh64(data: &[u8], seed: u64) -> u64 {
         let mut v3 = seed;
         let mut v4 = seed.wrapping_sub(PRIME64_1);
 
-        unsafe {
-            let mut p = data.as_ptr();
-            let bulk_end = data.as_ptr().add(len & !31);
-            let unroll_end = data.as_ptr().add(len & !127);
-
-            while p < unroll_end {
-                v1 = xxh64_round(v1, (p as *const u64).read_unaligned().to_le());
-                v2 = xxh64_round(v2, (p.add(8) as *const u64).read_unaligned().to_le());
-                v3 = xxh64_round(v3, (p.add(16) as *const u64).read_unaligned().to_le());
-                v4 = xxh64_round(v4, (p.add(24) as *const u64).read_unaligned().to_le());
-
-                v1 = xxh64_round(v1, (p.add(32) as *const u64).read_unaligned().to_le());
-                v2 = xxh64_round(v2, (p.add(40) as *const u64).read_unaligned().to_le());
-                v3 = xxh64_round(v3, (p.add(48) as *const u64).read_unaligned().to_le());
-                v4 = xxh64_round(v4, (p.add(56) as *const u64).read_unaligned().to_le());
-
-                v1 = xxh64_round(v1, (p.add(64) as *const u64).read_unaligned().to_le());
-                v2 = xxh64_round(v2, (p.add(72) as *const u64).read_unaligned().to_le());
-                v3 = xxh64_round(v3, (p.add(80) as *const u64).read_unaligned().to_le());
-                v4 = xxh64_round(v4, (p.add(88) as *const u64).read_unaligned().to_le());
-
-                v1 = xxh64_round(v1, (p.add(96) as *const u64).read_unaligned().to_le());
-                v2 = xxh64_round(v2, (p.add(104) as *const u64).read_unaligned().to_le());
-                v3 = xxh64_round(v3, (p.add(112) as *const u64).read_unaligned().to_le());
-                v4 = xxh64_round(v4, (p.add(120) as *const u64).read_unaligned().to_le());
-
-                p = p.add(128);
-            }
-
-            while p < bulk_end {
-                v1 = xxh64_round(v1, (p as *const u64).read_unaligned().to_le());
-                v2 = xxh64_round(v2, (p.add(8) as *const u64).read_unaligned().to_le());
-                v3 = xxh64_round(v3, (p.add(16) as *const u64).read_unaligned().to_le());
-                v4 = xxh64_round(v4, (p.add(24) as *const u64).read_unaligned().to_le());
-                p = p.add(32);
-            }
-        }
+        primitives::bulk_rounds(data, &mut v1, &mut v2, &mut v3, &mut v4);
 
         h64 = v1
             .rotate_left(1)
@@ -98,7 +52,7 @@ pub fn xxh64(data: &[u8], seed: u64) -> u64 {
     let tail = &data[len & !31..];
     let mut remaining = tail;
     while remaining.len() >= 8 {
-        let k1 = xxh64_round(0, read_u64_le(remaining, 0));
+        let k1 = xxh64_round(0, primitives::read_u64_le(remaining, 0));
         h64 ^= k1;
         h64 = h64
             .rotate_left(27)
@@ -108,7 +62,7 @@ pub fn xxh64(data: &[u8], seed: u64) -> u64 {
     }
 
     while remaining.len() >= 4 {
-        h64 ^= (read_u32_le(remaining, 0) as u64).wrapping_mul(PRIME64_1);
+        h64 ^= (primitives::read_u32_le(remaining, 0) as u64).wrapping_mul(PRIME64_1);
         h64 = h64
             .rotate_left(23)
             .wrapping_mul(PRIME64_2)
@@ -171,65 +125,17 @@ impl Xxh64State {
             self.buf[self.buf_used..32].copy_from_slice(&data[..fill]);
             data = &data[fill..];
 
-            self.v1 = xxh64_round(self.v1, read_u64_le(&self.buf, 0));
-            self.v2 = xxh64_round(self.v2, read_u64_le(&self.buf, 8));
-            self.v3 = xxh64_round(self.v3, read_u64_le(&self.buf, 16));
-            self.v4 = xxh64_round(self.v4, read_u64_le(&self.buf, 24));
+            self.v1 = xxh64_round(self.v1, primitives::read_u64_le(&self.buf, 0));
+            self.v2 = xxh64_round(self.v2, primitives::read_u64_le(&self.buf, 8));
+            self.v3 = xxh64_round(self.v3, primitives::read_u64_le(&self.buf, 16));
+            self.v4 = xxh64_round(self.v4, primitives::read_u64_le(&self.buf, 24));
             self.buf_used = 0;
             self.large = true;
         }
 
         if data.len() >= 32 {
             self.large = true;
-
-            let mut v1 = self.v1;
-            let mut v2 = self.v2;
-            let mut v3 = self.v3;
-            let mut v4 = self.v4;
-
-            unsafe {
-                let mut p = data.as_ptr();
-                let bulk_end = data.as_ptr().add(data.len() & !31);
-                let unroll_end = data.as_ptr().add(data.len() & !127);
-
-                while p < unroll_end {
-                    v1 = xxh64_round(v1, (p as *const u64).read_unaligned().to_le());
-                    v2 = xxh64_round(v2, (p.add(8) as *const u64).read_unaligned().to_le());
-                    v3 = xxh64_round(v3, (p.add(16) as *const u64).read_unaligned().to_le());
-                    v4 = xxh64_round(v4, (p.add(24) as *const u64).read_unaligned().to_le());
-
-                    v1 = xxh64_round(v1, (p.add(32) as *const u64).read_unaligned().to_le());
-                    v2 = xxh64_round(v2, (p.add(40) as *const u64).read_unaligned().to_le());
-                    v3 = xxh64_round(v3, (p.add(48) as *const u64).read_unaligned().to_le());
-                    v4 = xxh64_round(v4, (p.add(56) as *const u64).read_unaligned().to_le());
-
-                    v1 = xxh64_round(v1, (p.add(64) as *const u64).read_unaligned().to_le());
-                    v2 = xxh64_round(v2, (p.add(72) as *const u64).read_unaligned().to_le());
-                    v3 = xxh64_round(v3, (p.add(80) as *const u64).read_unaligned().to_le());
-                    v4 = xxh64_round(v4, (p.add(88) as *const u64).read_unaligned().to_le());
-
-                    v1 = xxh64_round(v1, (p.add(96) as *const u64).read_unaligned().to_le());
-                    v2 = xxh64_round(v2, (p.add(104) as *const u64).read_unaligned().to_le());
-                    v3 = xxh64_round(v3, (p.add(112) as *const u64).read_unaligned().to_le());
-                    v4 = xxh64_round(v4, (p.add(120) as *const u64).read_unaligned().to_le());
-
-                    p = p.add(128);
-                }
-
-                while p < bulk_end {
-                    v1 = xxh64_round(v1, (p as *const u64).read_unaligned().to_le());
-                    v2 = xxh64_round(v2, (p.add(8) as *const u64).read_unaligned().to_le());
-                    v3 = xxh64_round(v3, (p.add(16) as *const u64).read_unaligned().to_le());
-                    v4 = xxh64_round(v4, (p.add(24) as *const u64).read_unaligned().to_le());
-                    p = p.add(32);
-                }
-            }
-
-            self.v1 = v1;
-            self.v2 = v2;
-            self.v3 = v3;
-            self.v4 = v4;
-
+            primitives::bulk_rounds(data, &mut self.v1, &mut self.v2, &mut self.v3, &mut self.v4);
             let consumed = data.len() & !31;
             data = &data[consumed..];
         }
@@ -266,7 +172,7 @@ impl Xxh64State {
         let mut offset = 0;
 
         while offset + 8 <= len {
-            let k1 = xxh64_round(0, read_u64_le(data, offset));
+            let k1 = xxh64_round(0, primitives::read_u64_le(data, offset));
             h64 ^= k1;
             h64 = h64
                 .rotate_left(27)
@@ -276,7 +182,7 @@ impl Xxh64State {
         }
 
         while offset + 4 <= len {
-            h64 ^= (read_u32_le(data, offset) as u64).wrapping_mul(PRIME64_1);
+            h64 ^= (primitives::read_u32_le(data, offset) as u64).wrapping_mul(PRIME64_1);
             h64 = h64
                 .rotate_left(23)
                 .wrapping_mul(PRIME64_2)
@@ -317,7 +223,6 @@ mod tests {
     fn large_input() {
         let data: Vec<u8> = (0u8..=255).cycle().take(1000).collect();
         let h = xxh64(&data, 0);
-        // Verify streaming produces the same result
         let mut state = Xxh64State::new(0);
         state.update(&data);
         assert_eq!(state.finish(), h);

--- a/crates/core/src/xxhash/primitives.rs
+++ b/crates/core/src/xxhash/primitives.rs
@@ -1,0 +1,55 @@
+#[inline(always)]
+pub(crate) fn read_u32_le(data: &[u8], offset: usize) -> u32 {
+    debug_assert!(offset + 4 <= data.len());
+    u32::from_le(unsafe { (data.as_ptr().add(offset) as *const u32).read_unaligned() })
+}
+
+#[inline(always)]
+pub(crate) fn read_u64_le(data: &[u8], offset: usize) -> u64 {
+    debug_assert!(offset + 8 <= data.len());
+    u64::from_le(unsafe { (data.as_ptr().add(offset) as *const u64).read_unaligned() })
+}
+
+#[inline(always)]
+pub(super) fn bulk_rounds(data: &[u8], v1: &mut u64, v2: &mut u64, v3: &mut u64, v4: &mut u64) {
+    let len = data.len();
+    debug_assert!(len >= 32);
+
+    unsafe {
+        let mut p = data.as_ptr();
+        let bulk_end = data.as_ptr().add(len & !31);
+        let unroll_end = data.as_ptr().add(len & !127);
+
+        while p < unroll_end {
+            *v1 = super::xxh64_round(*v1, (p as *const u64).read_unaligned().to_le());
+            *v2 = super::xxh64_round(*v2, (p.add(8) as *const u64).read_unaligned().to_le());
+            *v3 = super::xxh64_round(*v3, (p.add(16) as *const u64).read_unaligned().to_le());
+            *v4 = super::xxh64_round(*v4, (p.add(24) as *const u64).read_unaligned().to_le());
+
+            *v1 = super::xxh64_round(*v1, (p.add(32) as *const u64).read_unaligned().to_le());
+            *v2 = super::xxh64_round(*v2, (p.add(40) as *const u64).read_unaligned().to_le());
+            *v3 = super::xxh64_round(*v3, (p.add(48) as *const u64).read_unaligned().to_le());
+            *v4 = super::xxh64_round(*v4, (p.add(56) as *const u64).read_unaligned().to_le());
+
+            *v1 = super::xxh64_round(*v1, (p.add(64) as *const u64).read_unaligned().to_le());
+            *v2 = super::xxh64_round(*v2, (p.add(72) as *const u64).read_unaligned().to_le());
+            *v3 = super::xxh64_round(*v3, (p.add(80) as *const u64).read_unaligned().to_le());
+            *v4 = super::xxh64_round(*v4, (p.add(88) as *const u64).read_unaligned().to_le());
+
+            *v1 = super::xxh64_round(*v1, (p.add(96) as *const u64).read_unaligned().to_le());
+            *v2 = super::xxh64_round(*v2, (p.add(104) as *const u64).read_unaligned().to_le());
+            *v3 = super::xxh64_round(*v3, (p.add(112) as *const u64).read_unaligned().to_le());
+            *v4 = super::xxh64_round(*v4, (p.add(120) as *const u64).read_unaligned().to_le());
+
+            p = p.add(128);
+        }
+
+        while p < bulk_end {
+            *v1 = super::xxh64_round(*v1, (p as *const u64).read_unaligned().to_le());
+            *v2 = super::xxh64_round(*v2, (p.add(8) as *const u64).read_unaligned().to_le());
+            *v3 = super::xxh64_round(*v3, (p.add(16) as *const u64).read_unaligned().to_le());
+            *v4 = super::xxh64_round(*v4, (p.add(24) as *const u64).read_unaligned().to_le());
+            p = p.add(32);
+        }
+    }
+}

--- a/crates/decode/src/exec.rs
+++ b/crates/decode/src/exec.rs
@@ -1,6 +1,9 @@
+#![forbid(unsafe_code)]
+
 #[cfg(feature = "alloc")]
 use alloc::vec::Vec;
 
+use crate::primitives;
 use crate::sequences::{SequenceDecodeTables, compute_offset};
 use zrip_core::bitstream::reader_reverse::ReverseBitReader;
 use zrip_core::error::DecompressError;
@@ -30,8 +33,8 @@ pub fn decode_execute_sequences(
     output.reserve(zrip_core::frame::MAX_BLOCK_SIZE + WILDCOPY_OVERLENGTH);
 
     let out_base = output.as_mut_ptr();
-    let mut op = unsafe { out_base.add(output.len()) };
-    let op_limit = unsafe { out_base.add(output.capacity() - WILDCOPY_OVERLENGTH) };
+    let mut op = primitives::ptr_add_mut(out_base, output.len());
+    let op_limit = primitives::ptr_add_mut(out_base, output.capacity() - WILDCOPY_OVERLENGTH);
     let lit_ptr = literals.as_ptr();
     let mut lit_off: usize = 0;
     let of_mask = ((1u32 << tables.of_accuracy) - 1) as usize;
@@ -42,27 +45,30 @@ pub fn decode_execute_sequences(
         ($literal_length:expr, $match_length:expr, $offset:expr) => {{
             let ll = $literal_length as usize;
             let ml_check = $match_length as usize;
-            if unlikely(unsafe { op.add(ll + ml_check) } > op_limit) {
+            if unlikely(primitives::ptr_gt(
+                primitives::ptr_add_mut(op, ll + ml_check) as *const u8,
+                op_limit as *const u8,
+            )) {
                 return Err(DecompressError::CorruptSequences);
             }
             if unlikely(lit_off + ll > literals.len()) {
                 return Err(DecompressError::CorruptLiterals);
             }
-            unsafe {
-                let src = lit_ptr.add(lit_off);
-                let lit_remaining = literals.len() - lit_off;
-                if lit_remaining >= 16 {
-                    (op as *mut u64).write_unaligned((src as *const u64).read_unaligned());
-                    (op.add(8) as *mut u64)
-                        .write_unaligned((src.add(8) as *const u64).read_unaligned());
-                    if ll > 16 {
-                        core::ptr::copy_nonoverlapping(src.add(16), op.add(16), ll - 16);
-                    }
-                } else {
-                    core::ptr::copy_nonoverlapping(src, op, ll);
+            let src = primitives::ptr_add_const(lit_ptr, lit_off);
+            let lit_remaining = literals.len() - lit_off;
+            if lit_remaining >= 16 {
+                primitives::output_write_16(op, src);
+                if ll > 16 {
+                    primitives::output_copy(
+                        primitives::ptr_add_const(src, 16),
+                        primitives::ptr_add_mut(op, 16),
+                        ll - 16,
+                    );
                 }
+            } else {
+                primitives::output_copy(src, op, ll);
             }
-            op = unsafe { op.add(ll) };
+            op = primitives::ptr_add_mut(op, ll);
             lit_off += ll;
 
             let ml = $match_length as usize;
@@ -70,26 +76,24 @@ pub fn decode_execute_sequences(
             if unlikely(off == 0) {
                 return Err(DecompressError::CorruptSequences);
             }
-            let out_pos = unsafe { op.offset_from(out_base) } as usize;
+            let out_pos = primitives::ptr_offset_from_mut(op, out_base);
             if unlikely(off > out_pos + history.len()) {
                 return Err(DecompressError::CorruptSequences);
             }
-            unsafe {
-                if likely(off <= out_pos) {
-                    zrip_core::simd::scalar::copy_match(op, off, ml);
-                } else {
-                    copy_match_from_history(op, history, off, out_pos, ml);
-                }
+            if likely(off <= out_pos) {
+                primitives::copy_match_inbuf(op, off, ml);
+            } else {
+                primitives::copy_match_from_history(op, history, off, out_pos, ml);
             }
-            op = unsafe { op.add(ml) };
+            op = primitives::ptr_add_mut(op, ml);
         }};
     }
 
     macro_rules! decode_and_execute_update {
         ($rev_reader:expr, $offsets:expr) => {{
-            let of_e = unsafe { *tables.of_table.get_unchecked(of_state as usize & of_mask) };
-            let ml_e = unsafe { *tables.ml_table.get_unchecked(ml_state as usize & ml_mask) };
-            let ll_e = unsafe { *tables.ll_table.get_unchecked(ll_state as usize & ll_mask) };
+            let of_e = primitives::fse_table_lookup(&tables.of_table, of_state as usize & of_mask);
+            let ml_e = primitives::fse_table_lookup(&tables.ml_table, ml_state as usize & ml_mask);
+            let ll_e = primitives::fse_table_lookup(&tables.ll_table, ll_state as usize & ll_mask);
 
             let of_extra = $rev_reader.read_bits_branchless(of_e.extra_bits);
             let offset_value = of_e.baseline_value + of_extra;
@@ -130,9 +134,9 @@ pub fn decode_execute_sequences(
     }
     while seq_idx < last_seq {
         rev_reader.refill();
-        let of_e = unsafe { *tables.of_table.get_unchecked(of_state as usize & of_mask) };
-        let ml_e = unsafe { *tables.ml_table.get_unchecked(ml_state as usize & ml_mask) };
-        let ll_e = unsafe { *tables.ll_table.get_unchecked(ll_state as usize & ll_mask) };
+        let of_e = primitives::fse_table_lookup(&tables.of_table, of_state as usize & of_mask);
+        let ml_e = primitives::fse_table_lookup(&tables.ml_table, ml_state as usize & ml_mask);
+        let ll_e = primitives::fse_table_lookup(&tables.ll_table, ll_state as usize & ll_mask);
 
         let of_extra = rev_reader.read_bits_branchless(of_e.extra_bits);
         let offset_value = of_e.baseline_value + of_extra;
@@ -154,9 +158,9 @@ pub fn decode_execute_sequences(
     // Last sequence: no FSE state update
     {
         rev_reader.refill();
-        let of_e = unsafe { *tables.of_table.get_unchecked(of_state as usize & of_mask) };
-        let ml_e = unsafe { *tables.ml_table.get_unchecked(ml_state as usize & ml_mask) };
-        let ll_e = unsafe { *tables.ll_table.get_unchecked(ll_state as usize & ll_mask) };
+        let of_e = primitives::fse_table_lookup(&tables.of_table, of_state as usize & of_mask);
+        let ml_e = primitives::fse_table_lookup(&tables.ml_table, ml_state as usize & ml_mask);
+        let ll_e = primitives::fse_table_lookup(&tables.ll_table, ll_state as usize & ll_mask);
 
         let of_extra = rev_reader.read_bits_branchless(of_e.extra_bits);
         let offset_value = of_e.baseline_value + of_extra;
@@ -171,44 +175,21 @@ pub fn decode_execute_sequences(
 
     if lit_off < literals.len() {
         let remaining = literals.len() - lit_off;
-        if unsafe { op.add(remaining) } > unsafe { out_base.add(output.capacity()) } {
+        if primitives::ptr_gt(
+            primitives::ptr_add_mut(op, remaining) as *const u8,
+            primitives::ptr_add_mut(out_base, output.capacity()) as *const u8,
+        ) {
             return Err(DecompressError::CorruptSequences);
         }
-        unsafe {
-            core::ptr::copy_nonoverlapping(lit_ptr.add(lit_off), op, remaining);
-        }
-        op = unsafe { op.add(remaining) };
+        primitives::output_copy(primitives::ptr_add_const(lit_ptr, lit_off), op, remaining);
+        op = primitives::ptr_add_mut(op, remaining);
     }
 
-    let new_len = unsafe { op.offset_from(out_base) } as usize;
+    let new_len = primitives::ptr_offset_from_mut(op, out_base);
     if new_len > output.capacity() {
         return Err(DecompressError::CorruptSequences);
     }
-    unsafe {
-        output.set_len(new_len);
-    }
+    primitives::set_output_len(output, new_len);
 
     Ok(())
-}
-
-#[inline(always)]
-unsafe fn copy_match_from_history(
-    op: *mut u8,
-    history: &[u8],
-    offset: usize,
-    out_pos: usize,
-    match_length: usize,
-) {
-    let history_reach = offset - out_pos;
-    let history_start = history.len() - history_reach;
-    let from_history = history_reach.min(match_length);
-    unsafe {
-        core::ptr::copy_nonoverlapping(history.as_ptr().add(history_start), op, from_history);
-    }
-    let remaining = match_length - from_history;
-    if remaining > 0 {
-        unsafe {
-            zrip_core::simd::scalar::copy_match(op.add(from_history), offset, remaining);
-        }
-    }
 }

--- a/crates/decode/src/lib.rs
+++ b/crates/decode/src/lib.rs
@@ -9,6 +9,7 @@ pub(crate) mod block_decoder;
 pub mod context;
 pub(crate) mod exec;
 pub(crate) mod literals;
+pub(crate) mod primitives;
 pub(crate) mod ring_buffer;
 pub(crate) mod sequences;
 #[cfg(feature = "std")]

--- a/crates/decode/src/primitives.rs
+++ b/crates/decode/src/primitives.rs
@@ -1,0 +1,76 @@
+#[cfg(feature = "alloc")]
+use alloc::vec::Vec;
+
+use zrip_core::fse::FseSeqDecodeEntry;
+
+#[inline(always)]
+pub(crate) fn fse_table_lookup(table: &[FseSeqDecodeEntry], idx: usize) -> FseSeqDecodeEntry {
+    debug_assert!(idx < table.len());
+    unsafe { *table.get_unchecked(idx) }
+}
+
+#[inline(always)]
+pub(crate) fn ptr_add_mut(base: *mut u8, offset: usize) -> *mut u8 {
+    unsafe { base.add(offset) }
+}
+
+#[inline(always)]
+pub(crate) fn ptr_add_const(base: *const u8, offset: usize) -> *const u8 {
+    unsafe { base.add(offset) }
+}
+
+#[inline(always)]
+pub(crate) fn ptr_gt(a: *const u8, b: *const u8) -> bool {
+    a > b
+}
+
+#[inline(always)]
+pub(crate) fn ptr_offset_from_mut(a: *mut u8, b: *mut u8) -> usize {
+    unsafe { a.offset_from(b) as usize }
+}
+
+#[inline(always)]
+pub(crate) fn output_write_16(dst: *mut u8, src: *const u8) {
+    unsafe {
+        (dst as *mut u64).write_unaligned((src as *const u64).read_unaligned());
+        (dst.add(8) as *mut u64).write_unaligned((src.add(8) as *const u64).read_unaligned());
+    }
+}
+
+#[inline(always)]
+pub(crate) fn output_copy(src: *const u8, dst: *mut u8, len: usize) {
+    unsafe { core::ptr::copy_nonoverlapping(src, dst, len) }
+}
+
+#[inline(always)]
+pub(crate) fn set_output_len(vec: &mut Vec<u8>, len: usize) {
+    debug_assert!(len <= vec.capacity());
+    unsafe { vec.set_len(len) }
+}
+
+#[inline(always)]
+pub(crate) fn copy_match_from_history(
+    op: *mut u8,
+    history: &[u8],
+    offset: usize,
+    out_pos: usize,
+    match_length: usize,
+) {
+    let history_reach = offset - out_pos;
+    let history_start = history.len() - history_reach;
+    let from_history = history_reach.min(match_length);
+    unsafe {
+        core::ptr::copy_nonoverlapping(history.as_ptr().add(history_start), op, from_history);
+    }
+    let remaining = match_length - from_history;
+    if remaining > 0 {
+        unsafe {
+            zrip_core::simd::scalar::copy_match(op.add(from_history), offset, remaining);
+        }
+    }
+}
+
+#[inline(always)]
+pub(crate) fn copy_match_inbuf(op: *mut u8, offset: usize, match_length: usize) {
+    unsafe { zrip_core::simd::scalar::copy_match(op, offset, match_length) }
+}

--- a/crates/encode/src/block_encoder.rs
+++ b/crates/encode/src/block_encoder.rs
@@ -1,6 +1,9 @@
+#![forbid(unsafe_code)]
+
 #[cfg(feature = "alloc")]
 use alloc::vec::Vec;
 
+use crate::primitives;
 use zrip_core::Sequence;
 use zrip_core::fse::table_builder::{
     build_decode_table, normalize_counts, serialize_fse_table_description,
@@ -134,11 +137,11 @@ impl FseEncodeTable {
 
     #[inline]
     fn init_state(&self, symbol: u8) -> u32 {
-        let tt = unsafe { self.symbol_tt.get_unchecked(symbol as usize) };
+        let tt = primitives::slice_get_ref(&self.symbol_tt, symbol as usize);
         let nb_bits_out = tt.delta_nb_bits.wrapping_add(1 << 15) >> 16;
         let base_state = (nb_bits_out << 16).wrapping_sub(tt.delta_nb_bits);
         let idx = (base_state >> nb_bits_out) as i32 + tt.delta_find_state;
-        (unsafe { *self.state_table.get_unchecked(idx as usize) }) as u32
+        primitives::slice_get(&self.state_table, idx as usize) as u32
     }
 }
 
@@ -224,137 +227,7 @@ pub(crate) fn encode_compressed_block(
 
     let saved_rep = *rep_offsets;
 
-    workspace.lit_buf.clear();
-    workspace.lit_buf.reserve(src.len() + 16);
-    workspace.packed_seqs.clear();
-    workspace.packed_seqs.reserve(n);
-    let lit_dst = workspace.lit_buf.as_mut_ptr();
-    let src_ptr = src.as_ptr();
-    let mut lit_pos = 0usize;
-    let mut lit_offset = 0usize;
-
-    let do_codes = n >= 64;
-    let mut ll_freq = [0u32; 36];
-    let mut ml_freq = [0u32; 53];
-    let mut of_freq = [0u32; 32];
-    let mut total_extra_bits: u64 = 0;
-
-    // Local rep offsets: avoids &mut aliasing barrier per iteration
-    let mut rep0 = rep_offsets[0];
-    let mut rep1 = rep_offsets[1];
-    let mut rep2 = rep_offsets[2];
-
-    let packed_ptr = workspace.packed_seqs.as_mut_ptr();
-    let seq_ptr = sequences.as_ptr();
-    let src_len = src.len();
-
-    for i in 0..n {
-        let seq = unsafe { &*seq_ptr.add(i) };
-        let ll = seq.literal_length as usize;
-        if lit_offset + ll <= src_len {
-            unsafe {
-                let s = src_ptr.add(lit_offset);
-                let d = lit_dst.add(lit_pos);
-                if ll <= 16 && lit_offset + 16 <= src_len {
-                    (d as *mut u64).write_unaligned((s as *const u64).read_unaligned());
-                    (d.add(8) as *mut u64)
-                        .write_unaligned((s.add(8) as *const u64).read_unaligned());
-                } else {
-                    core::ptr::copy_nonoverlapping(s, d, ll);
-                }
-            }
-            lit_pos += ll;
-        }
-        lit_offset += ll + seq.match_length as usize;
-
-        let actual_offset = seq.offset;
-        let ov = if seq.literal_length > 0 {
-            if actual_offset == rep0 {
-                1
-            } else if actual_offset == rep1 {
-                rep1 = rep0;
-                rep0 = actual_offset;
-                2
-            } else if actual_offset == rep2 {
-                rep2 = rep1;
-                rep1 = rep0;
-                rep0 = actual_offset;
-                3
-            } else {
-                rep2 = rep1;
-                rep1 = rep0;
-                rep0 = actual_offset;
-                actual_offset + 3
-            }
-        } else if actual_offset == rep1 {
-            rep1 = rep0;
-            rep0 = actual_offset;
-            1
-        } else if actual_offset == rep2 {
-            rep2 = rep1;
-            rep1 = rep0;
-            rep0 = actual_offset;
-            2
-        } else if rep0 > 1 && actual_offset == rep0 - 1 {
-            rep2 = rep1;
-            rep1 = rep0;
-            rep0 = actual_offset;
-            3
-        } else {
-            rep2 = rep1;
-            rep1 = rep0;
-            rep0 = actual_offset;
-            actual_offset + 3
-        };
-
-        let ll_c = ll_code(seq.literal_length);
-        let ml_c = ml_code(seq.match_length);
-        let of_c = of_code(ov);
-
-        let ll_nb = LL_BITS_TABLE[ll_c as usize];
-        let ml_nb = ML_BITS_TABLE[ml_c as usize];
-        let ll_extra = seq.literal_length - LL_BASELINE_TABLE[ll_c as usize];
-        let ml_extra = seq.match_length - ML_BASELINE_TABLE[ml_c as usize];
-        let of_extra = ov - (1u32 << of_c);
-        let extra_bits = (ll_extra as u64)
-            | ((ml_extra as u64) << ll_nb)
-            | ((of_extra as u64) << (ll_nb + ml_nb));
-        let extra_nbits = ll_nb + ml_nb + of_c;
-
-        unsafe {
-            packed_ptr.add(i).write(PackedSeq {
-                extra_bits,
-                ll_c,
-                ml_c,
-                of_c,
-                extra_nbits,
-            });
-        }
-
-        if do_codes {
-            ll_freq[ll_c as usize] += 1;
-            ml_freq[ml_c as usize] += 1;
-            of_freq[of_c as usize] += 1;
-            total_extra_bits += extra_nbits as u64;
-        }
-    }
-    unsafe {
-        workspace.packed_seqs.set_len(n);
-    }
-    rep_offsets[0] = rep0;
-    rep_offsets[1] = rep1;
-    rep_offsets[2] = rep2;
-
-    if lit_offset < src_len {
-        let tail = src_len - lit_offset;
-        unsafe {
-            core::ptr::copy_nonoverlapping(src_ptr.add(lit_offset), lit_dst.add(lit_pos), tail);
-        }
-        lit_pos += tail;
-    }
-    unsafe {
-        workspace.lit_buf.set_len(lit_pos);
-    }
+    pack_sequences_and_literals(src, sequences, rep_offsets, workspace);
 
     encode_literals_section(
         &workspace.lit_buf,
@@ -364,7 +237,10 @@ pub(crate) fn encode_compressed_block(
         &mut workspace.prev_huffman,
     );
 
+    let do_codes = n >= 64;
     let seq_data = if do_codes {
+        let (ll_freq, ml_freq, of_freq, total_extra_bits) =
+            compute_frequencies(&workspace.packed_seqs);
         let pred_est = estimate_predefined_cost(&ll_freq, &ml_freq, &of_freq, total_extra_bits, n);
         let use_custom = encode_seq_custom(
             &workspace.packed_seqs,
@@ -437,37 +313,58 @@ pub(crate) fn encode_compressed_block_raw(
 
     let saved_rep = *rep_offsets;
 
+    pack_sequences_and_literals(src, sequences, rep_offsets, workspace);
+
+    workspace.lit_section.clear();
+    encode_raw_literals_section(&workspace.lit_buf, &mut workspace.lit_section);
+
+    encode_seq_predefined(
+        &workspace.packed_seqs,
+        &mut workspace.pred_seq,
+        &mut workspace.pred_writer_buf,
+    );
+
+    let block_len = workspace.lit_section.len() + workspace.pred_seq.len();
+    if block_len >= src.len() {
+        *rep_offsets = saved_rep;
+        encode_raw_block(src, last, output);
+        return;
+    }
+
+    let block_size = block_len as u32;
+    let header = (block_size << 3) | 0x04 | if last { 1 } else { 0 };
+    output.push(header as u8);
+    output.push((header >> 8) as u8);
+    output.push((header >> 16) as u8);
+    output.extend_from_slice(&workspace.lit_section);
+    output.extend_from_slice(&workspace.pred_seq);
+}
+
+fn pack_sequences_and_literals(
+    src: &[u8],
+    sequences: &[Sequence],
+    rep_offsets: &mut [u32; 3],
+    workspace: &mut BlockEncodeWorkspace,
+) {
+    let n = sequences.len();
+    let src_len = src.len();
+
     workspace.lit_buf.clear();
-    workspace.lit_buf.reserve(src.len() + 16);
+    workspace.lit_buf.reserve(src_len + 16);
     workspace.packed_seqs.clear();
     workspace.packed_seqs.reserve(n);
-    let lit_dst = workspace.lit_buf.as_mut_ptr();
-    let src_ptr = src.as_ptr();
+
     let mut lit_pos = 0usize;
     let mut lit_offset = 0usize;
 
     let mut rep0 = rep_offsets[0];
     let mut rep1 = rep_offsets[1];
     let mut rep2 = rep_offsets[2];
-    let packed_ptr = workspace.packed_seqs.as_mut_ptr();
-    let seq_ptr = sequences.as_ptr();
-    let src_len = src.len();
 
-    for i in 0..n {
-        let seq = unsafe { &*seq_ptr.add(i) };
+    for seq in &sequences[..n] {
         let ll = seq.literal_length as usize;
         if lit_offset + ll <= src_len {
-            unsafe {
-                let s = src_ptr.add(lit_offset);
-                let d = lit_dst.add(lit_pos);
-                if ll <= 16 && lit_offset + 16 <= src_len {
-                    (d as *mut u64).write_unaligned((s as *const u64).read_unaligned());
-                    (d.add(8) as *mut u64)
-                        .write_unaligned((s.add(8) as *const u64).read_unaligned());
-                } else {
-                    core::ptr::copy_nonoverlapping(s, d, ll);
-                }
-            }
+            primitives::copy_literals_fast(src, lit_offset, &mut workspace.lit_buf, lit_pos, ll);
             lit_pos += ll;
         }
         lit_offset += ll + seq.match_length as usize;
@@ -526,18 +423,13 @@ pub(crate) fn encode_compressed_block_raw(
             | ((of_extra as u64) << (ll_nb + ml_nb));
         let extra_nbits = ll_nb + ml_nb + of_c;
 
-        unsafe {
-            packed_ptr.add(i).write(PackedSeq {
-                extra_bits,
-                ll_c,
-                ml_c,
-                of_c,
-                extra_nbits,
-            });
-        }
-    }
-    unsafe {
-        workspace.packed_seqs.set_len(n);
+        workspace.packed_seqs.push(PackedSeq {
+            extra_bits,
+            ll_c,
+            ml_c,
+            of_c,
+            extra_nbits,
+        });
     }
     rep_offsets[0] = rep0;
     rep_offsets[1] = rep1;
@@ -545,38 +437,24 @@ pub(crate) fn encode_compressed_block_raw(
 
     if lit_offset < src_len {
         let tail = src_len - lit_offset;
-        unsafe {
-            core::ptr::copy_nonoverlapping(src_ptr.add(lit_offset), lit_dst.add(lit_pos), tail);
-        }
+        primitives::copy_literals_fast(src, lit_offset, &mut workspace.lit_buf, lit_pos, tail);
         lit_pos += tail;
     }
-    unsafe {
-        workspace.lit_buf.set_len(lit_pos);
+    primitives::set_vec_len(&mut workspace.lit_buf, lit_pos);
+}
+
+fn compute_frequencies(packed: &[PackedSeq]) -> ([u32; 36], [u32; 53], [u32; 32], u64) {
+    let mut ll_freq = [0u32; 36];
+    let mut ml_freq = [0u32; 53];
+    let mut of_freq = [0u32; 32];
+    let mut total_extra_bits: u64 = 0;
+    for p in packed {
+        ll_freq[p.ll_c as usize] += 1;
+        ml_freq[p.ml_c as usize] += 1;
+        of_freq[p.of_c as usize] += 1;
+        total_extra_bits += p.extra_nbits as u64;
     }
-
-    workspace.lit_section.clear();
-    encode_raw_literals_section(&workspace.lit_buf, &mut workspace.lit_section);
-
-    encode_seq_predefined(
-        &workspace.packed_seqs,
-        &mut workspace.pred_seq,
-        &mut workspace.pred_writer_buf,
-    );
-
-    let block_len = workspace.lit_section.len() + workspace.pred_seq.len();
-    if block_len >= src.len() {
-        *rep_offsets = saved_rep;
-        encode_raw_block(src, last, output);
-        return;
-    }
-
-    let block_size = block_len as u32;
-    let header = (block_size << 3) | 0x04 | if last { 1 } else { 0 };
-    output.push(header as u8);
-    output.push((header >> 8) as u8);
-    output.push((header >> 16) as u8);
-    output.extend_from_slice(&workspace.lit_section);
-    output.extend_from_slice(&workspace.pred_seq);
+    (ll_freq, ml_freq, of_freq, total_extra_bits)
 }
 
 fn encode_literals_section(
@@ -590,7 +468,6 @@ fn encode_literals_section(
 
     let use_4_streams = lits.len() >= 1024;
 
-    // Try reusing the previous Huffman table (treeless block)
     if let Some(prev) = prev_huffman.as_ref() {
         if prev.can_encode(lits) {
             if use_4_streams {
@@ -720,7 +597,7 @@ fn encode_seq_predefined(packed: &[PackedSeq], output: &mut Vec<u8>, writer_buf:
     output.push(0x00);
 
     let tables = predefined_tables();
-    let last = unsafe { packed.get_unchecked(n - 1) };
+    let last = primitives::slice_get_ref(packed, n - 1);
 
     let max_out = n * 18 + 16;
     writer_buf.clear();
@@ -730,7 +607,6 @@ fn encode_seq_predefined(packed: &[PackedSeq], output: &mut Vec<u8>, writer_buf:
     let mut of_state = tables.of.init_state(last.of_c);
     let mut ml_state = tables.ml.init_state(last.ml_c);
 
-    let buf_ptr = writer_buf.as_mut_ptr();
     let mut pos: usize = 0;
     let mut bits: u64 = 0;
     let mut bits_used: u32 = 0;
@@ -743,9 +619,7 @@ fn encode_seq_predefined(packed: &[PackedSeq], output: &mut Vec<u8>, writer_buf:
     }
     macro_rules! flush_fast {
         () => {
-            unsafe {
-                (buf_ptr.add(pos) as *mut u64).write_unaligned(bits.to_le());
-            }
+            primitives::bitstream_flush(writer_buf, pos, bits);
             let nb = (bits_used >> 3) as usize;
             pos += nb;
             bits >>= (nb << 3) as u64;
@@ -754,18 +628,18 @@ fn encode_seq_predefined(packed: &[PackedSeq], output: &mut Vec<u8>, writer_buf:
     }
     macro_rules! encode_transition {
         ($table:expr, $symbol:expr, $state:expr) => {{
-            let tt = unsafe { $table.symbol_tt.get_unchecked($symbol as usize) };
+            let tt = primitives::slice_get_ref(&$table.symbol_tt, $symbol as usize);
             let nb = (tt.delta_nb_bits.wrapping_add($state)) >> 16;
             add_bits!($state & ((1u32 << nb) - 1), nb);
             let idx = ($state >> nb) as i32 + tt.delta_find_state;
-            $state = unsafe { *$table.state_table.get_unchecked(idx as usize) } as u32;
+            $state = primitives::slice_get(&$table.state_table, idx as usize) as u32;
         }};
     }
 
     add_bits!(last.extra_bits, last.extra_nbits);
 
     for k in (0..n - 1).rev() {
-        let p = unsafe { packed.get_unchecked(k) };
+        let p = primitives::slice_get_ref(packed, k);
 
         flush_fast!();
         encode_transition!(tables.of, p.of_c, of_state);
@@ -787,16 +661,12 @@ fn encode_seq_predefined(packed: &[PackedSeq], output: &mut Vec<u8>, writer_buf:
     add_bits!(1u32, 1u8);
     flush_fast!();
     while bits_used > 0 {
-        unsafe {
-            *buf_ptr.add(pos) = bits as u8;
-        }
+        primitives::bitstream_write_byte(writer_buf, pos, bits as u8);
         bits >>= 8;
         bits_used = bits_used.saturating_sub(8);
         pos += 1;
     }
-    unsafe {
-        writer_buf.set_len(pos);
-    }
+    primitives::set_vec_len(writer_buf, pos);
     output.extend_from_slice(writer_buf);
 }
 
@@ -919,7 +789,6 @@ fn encode_seq_custom(
     let max_out = n * 18 + 16;
     writer_buf.clear();
     writer_buf.reserve(max_out);
-    let buf_ptr = writer_buf.as_mut_ptr();
     let mut pos: usize = 0;
     let mut bits: u64 = 0;
     let mut bits_used: u32 = 0;
@@ -932,9 +801,7 @@ fn encode_seq_custom(
     }
     macro_rules! flush_fast {
         () => {
-            unsafe {
-                (buf_ptr.add(pos) as *mut u64).write_unaligned(bits.to_le());
-            }
+            primitives::bitstream_flush(writer_buf, pos, bits);
             let nb = (bits_used >> 3) as usize;
             pos += nb;
             bits >>= (nb << 3) as u64;
@@ -961,29 +828,29 @@ fn encode_seq_custom(
             let mut ml_s = ml_t.init_state(last.ml_c);
 
             for k in (0..n - 1).rev() {
-                let p = unsafe { packed.get_unchecked(k) };
+                let p = primitives::slice_get_ref(packed, k);
 
                 flush_fast!();
                 {
-                    let tt = unsafe { of_t.symbol_tt.get_unchecked(p.of_c as usize) };
+                    let tt = primitives::slice_get_ref(&of_t.symbol_tt, p.of_c as usize);
                     let nb = (tt.delta_nb_bits.wrapping_add(of_s)) >> 16;
                     add_bits!(of_s & ((1u32 << nb) - 1), nb);
                     let idx = (of_s >> nb) as i32 + tt.delta_find_state;
-                    of_s = unsafe { *of_t.state_table.get_unchecked(idx as usize) } as u32;
+                    of_s = primitives::slice_get(&of_t.state_table, idx as usize) as u32;
                 }
                 {
-                    let tt = unsafe { ml_t.symbol_tt.get_unchecked(p.ml_c as usize) };
+                    let tt = primitives::slice_get_ref(&ml_t.symbol_tt, p.ml_c as usize);
                     let nb = (tt.delta_nb_bits.wrapping_add(ml_s)) >> 16;
                     add_bits!(ml_s & ((1u32 << nb) - 1), nb);
                     let idx = (ml_s >> nb) as i32 + tt.delta_find_state;
-                    ml_s = unsafe { *ml_t.state_table.get_unchecked(idx as usize) } as u32;
+                    ml_s = primitives::slice_get(&ml_t.state_table, idx as usize) as u32;
                 }
                 {
-                    let tt = unsafe { ll_t.symbol_tt.get_unchecked(p.ll_c as usize) };
+                    let tt = primitives::slice_get_ref(&ll_t.symbol_tt, p.ll_c as usize);
                     let nb = (tt.delta_nb_bits.wrapping_add(ll_s)) >> 16;
                     add_bits!(ll_s & ((1u32 << nb) - 1), nb);
                     let idx = (ll_s >> nb) as i32 + tt.delta_find_state;
-                    ll_s = unsafe { *ll_t.state_table.get_unchecked(idx as usize) } as u32;
+                    ll_s = primitives::slice_get(&ll_t.state_table, idx as usize) as u32;
                 }
                 flush_fast!();
 
@@ -1016,11 +883,11 @@ fn encode_seq_custom(
             macro_rules! encode_transition_opt {
                 ($table:expr, $state:expr, $symbol:expr) => {
                     if let (Some(t), Some(s)) = (&$table, &mut $state) {
-                        let tt = unsafe { t.symbol_tt.get_unchecked($symbol as usize) };
+                        let tt = primitives::slice_get_ref(&t.symbol_tt, $symbol as usize);
                         let nb = (tt.delta_nb_bits.wrapping_add(*s)) >> 16;
                         add_bits!(*s & ((1u32 << nb) - 1), nb);
                         let idx = (*s >> nb) as i32 + tt.delta_find_state;
-                        *s = unsafe { *t.state_table.get_unchecked(idx as usize) } as u32;
+                        *s = primitives::slice_get(&t.state_table, idx as usize) as u32;
                     }
                 };
             }
@@ -1053,16 +920,12 @@ fn encode_seq_custom(
     add_bits!(1u32, 1u8);
     flush_fast!();
     while bits_used > 0 {
-        unsafe {
-            *buf_ptr.add(pos) = bits as u8;
-        }
+        primitives::bitstream_write_byte(writer_buf, pos, bits as u8);
         bits >>= 8;
         bits_used = bits_used.saturating_sub(8);
         pos += 1;
     }
-    unsafe {
-        writer_buf.set_len(pos);
-    }
+    primitives::set_vec_len(writer_buf, pos);
     output.extend_from_slice(writer_buf);
 
     true
@@ -1132,10 +995,6 @@ fn estimate_fse_bits(freqs: &[u32], total: usize) -> usize {
     if total == 0 {
         return 0;
     }
-    // Integer-only Shannon entropy estimate using fixed-point log2.
-    // For each symbol with frequency f: contribution = f * log2(total/f)
-    //   = f * (log2(total) - log2(f))
-    // We use 32 - leading_zeros as an integer log2 approximation.
     let log2_total = (usize::BITS).saturating_sub(total.leading_zeros());
     let mut bits: u64 = 0;
     for &f in freqs {

--- a/crates/encode/src/dfast.rs
+++ b/crates/encode/src/dfast.rs
@@ -1,8 +1,11 @@
+#![forbid(unsafe_code)]
+
 #[cfg(feature = "alloc")]
 use alloc::vec;
 #[cfg(feature = "alloc")]
 use alloc::vec::Vec;
 
+use crate::primitives;
 use crate::strategy::LevelParams;
 use zrip_core::Sequence;
 use zrip_core::hash::PRIME64_1;
@@ -103,43 +106,22 @@ fn compress_dfast_block_impl<const HASH_LOG: u32, const SHORT_LOG: u32>(
         params.chain_log
     };
 
-    let src_ptr = src.as_ptr();
-    let ht_short = hash_short.as_mut_ptr();
-    let ht_long = hash_long.as_mut_ptr();
-
     let mut rep0 = rep_offsets[0];
     let mut rep1 = rep_offsets[1];
     let mut rep2 = rep_offsets[2];
     let mut anchor = block_start;
     let mut ip0 = block_start;
 
-    unsafe {
-        core::hint::assert_unchecked(rep0 > 0);
-        core::hint::assert_unchecked(rep1 > 0);
-    }
-
-    #[inline(always)]
-    unsafe fn rdp32(p: *const u8, pos: usize) -> u32 {
-        unsafe { (p.add(pos) as *const u32).read_unaligned() }
-    }
-
-    #[inline(always)]
-    unsafe fn rdp64(p: *const u8, pos: usize) -> u64 {
-        unsafe { (p.add(pos) as *const u64).read_unaligned() }
-    }
+    primitives::assert_rep_valid(rep0, rep1);
 
     macro_rules! update_hashes_inline {
         ($pos:expr) => {{
             let pos = $pos;
             if pos + 8 <= src.len() {
-                let hs = h5(unsafe { rdp64(src_ptr, pos) }, short_log);
-                unsafe {
-                    *ht_short.add(hs) = pos as u32;
-                }
-                let hl = h8(unsafe { rdp64(src_ptr, pos) }, hash_log);
-                unsafe {
-                    *ht_long.add(hl) = pos as u32;
-                }
+                let hs = h5(primitives::rd64(src, pos), short_log);
+                primitives::hash_store(hash_short, hs, pos as u32);
+                let hl = h8(primitives::rd64(src, pos), hash_log);
+                primitives::hash_store(hash_long, hl, pos as u32);
             }
         }};
     }
@@ -153,27 +135,19 @@ fn compress_dfast_block_impl<const HASH_LOG: u32, const SHORT_LOG: u32>(
             let cap_end = safe_end.min(ms + 2 + step * 4);
             let mut pos = ms + 2;
             while pos < cap_end {
-                let hs = h5(unsafe { rdp64(src_ptr, pos) }, short_log);
-                unsafe {
-                    *ht_short.add(hs) = pos as u32;
-                }
-                let hl = h8(unsafe { rdp64(src_ptr, pos) }, hash_log);
-                unsafe {
-                    *ht_long.add(hl) = pos as u32;
-                }
+                let hs = h5(primitives::rd64(src, pos), short_log);
+                primitives::hash_store(hash_short, hs, pos as u32);
+                let hl = h8(primitives::rd64(src, pos), hash_log);
+                primitives::hash_store(hash_long, hl, pos as u32);
                 pos += step;
             }
             if me >= 2 {
                 let tail = me - 2;
                 if tail < safe_end && tail >= cap_end {
-                    let hs = h5(unsafe { rdp64(src_ptr, tail) }, short_log);
-                    unsafe {
-                        *ht_short.add(hs) = tail as u32;
-                    }
-                    let hl = h8(unsafe { rdp64(src_ptr, tail) }, hash_log);
-                    unsafe {
-                        *ht_long.add(hl) = tail as u32;
-                    }
+                    let hs = h5(primitives::rd64(src, tail), short_log);
+                    primitives::hash_store(hash_short, hs, tail as u32);
+                    let hl = h8(primitives::rd64(src, tail), hash_log);
+                    primitives::hash_store(hash_long, hl, tail as u32);
                 }
             }
         }};
@@ -181,21 +155,15 @@ fn compress_dfast_block_impl<const HASH_LOG: u32, const SHORT_LOG: u32>(
 
     macro_rules! rep_match_loop_inline {
         () => {{
-            // Only check rep1 at LL=0 positions (C zstd pattern). With LL=0,
-            // offset_value=1 encodes rep[1], so rep1 matches are rep-codable.
-            // Rep0 at LL=0 has NO rep encoding in the zstd spec; those matches
-            // would waste bits as full offsets. The alternating swap lets the
-            // loop ping-pong between rep0 and rep1 (each becomes the other's
-            // rep1 after the swap), keeping every emitted sequence rep-coded.
             loop {
                 if ip0 >= ilimit {
                     break;
                 }
                 let r1 = rep1 as usize;
                 if (r1 > 0) & (ip0 >= r1)
-                    && unsafe { rdp32(src_ptr, ip0) == rdp32(src_ptr, ip0 - r1) }
+                    && primitives::rd32(src, ip0) == primitives::rd32(src, ip0 - r1)
                 {
-                    let ml = count_match(src, ip0 + 4, ip0 - r1 + 4, block_end) + 4;
+                    let ml = primitives::count_match(src, ip0 + 4, ip0 - r1 + 4, block_end) + 4;
                     core::mem::swap(&mut rep0, &mut rep1);
                     total_match_bytes += ml;
                     sequences.push(Sequence {
@@ -222,40 +190,39 @@ fn compress_dfast_block_impl<const HASH_LOG: u32, const SHORT_LOG: u32>(
             break;
         }
 
-        let mut hs0 = h5(unsafe { rdp64(src_ptr, ip0) }, short_log);
-        let mut hl0 = h8(unsafe { rdp64(src_ptr, ip0) }, hash_log);
-        let mut hs1 = h5(unsafe { rdp64(src_ptr, ip1) }, short_log);
-        let mut hl1 = h8(unsafe { rdp64(src_ptr, ip1) }, hash_log);
+        let mut hs0 = h5(primitives::rd64(src, ip0), short_log);
+        let mut hl0 = h8(primitives::rd64(src, ip0), hash_log);
+        let mut hs1 = h5(primitives::rd64(src, ip1), short_log);
+        let mut hl1 = h8(primitives::rd64(src, ip1), hash_log);
 
-        let mut match_short = unsafe { *ht_short.add(hs0) } as usize;
-        let mut match_long = unsafe { *ht_long.add(hl0) } as usize;
+        let mut match_short = primitives::hash_load(hash_short, hs0) as usize;
+        let mut match_long = primitives::hash_load(hash_long, hl0) as usize;
 
         loop {
             // --- Store hashes for ip0 ---
-            unsafe {
-                *ht_short.add(hs0) = ip0 as u32;
-                *ht_long.add(hl0) = ip0 as u32;
-            }
+            primitives::hash_store(hash_short, hs0, ip0 as u32);
+            primitives::hash_store(hash_long, hl0, ip0 as u32);
 
             // --- Rep check at step-ahead position ip2 ---
             {
                 let r0 = rep0 as usize;
                 if ip2 >= r0 {
-                    let v = unsafe { rdp32(src_ptr, ip2) };
-                    if v == unsafe { rdp32(src_ptr, ip2 - r0) } {
+                    let v = primitives::rd32(src, ip2);
+                    if v == primitives::rd32(src, ip2 - r0) {
                         let fill_pos = ip0;
-                        unsafe {
-                            *ht_short.add(hs1) = ip1 as u32;
-                            *ht_long.add(hl1) = ip1 as u32;
-                        }
+                        primitives::hash_store(hash_short, hs1, ip1 as u32);
+                        primitives::hash_store(hash_long, hl1, ip1 as u32);
                         ip0 = ip2;
                         if ip0 > anchor
-                            && unsafe { *src_ptr.add(ip0 - 1) == *src_ptr.add(ip0 - r0 - 1) }
+                            && primitives::src_byte(src, ip0 - 1)
+                                == primitives::src_byte(src, ip0 - r0 - 1)
                         {
                             ip0 -= 1;
                         }
                         let back = ip2 - ip0;
-                        let mlen = count_match(src, ip2 + 4, ip2 - r0 + 4, block_end) + 4 + back;
+                        let mlen = primitives::count_match(src, ip2 + 4, ip2 - r0 + 4, block_end)
+                            + 4
+                            + back;
                         total_match_bytes += mlen;
                         sequences.push(Sequence {
                             literal_length: (ip0 - anchor) as u32,
@@ -277,23 +244,21 @@ fn compress_dfast_block_impl<const HASH_LOG: u32, const SHORT_LOG: u32>(
             // --- Long match check at ip0 ---
             if match_long < ip0
                 && ip0 - match_long <= max_distance
-                && unsafe { rdp64(src_ptr, ip0) == rdp64(src_ptr, match_long) }
+                && primitives::rd64(src, ip0) == primitives::rd64(src, match_long)
             {
-                unsafe {
-                    *ht_short.add(hs1) = ip1 as u32;
-                    *ht_long.add(hl1) = ip1 as u32;
-                }
+                primitives::hash_store(hash_short, hs1, ip1 as u32);
+                primitives::hash_store(hash_long, hl1, ip1 as u32);
                 let mut back = 0usize;
                 while ip0 > anchor + back
                     && match_long > back + block_start
-                    && unsafe {
-                        *src_ptr.add(ip0 - back - 1) == *src_ptr.add(match_long - back - 1)
-                    }
+                    && primitives::src_byte(src, ip0 - back - 1)
+                        == primitives::src_byte(src, match_long - back - 1)
                 {
                     back += 1;
                 }
                 let match_start = ip0 - back;
-                let mlen = count_match(src, ip0 + 8, match_long + 8, block_end) + 8 + back;
+                let mlen =
+                    primitives::count_match(src, ip0 + 8, match_long + 8, block_end) + 8 + back;
                 total_match_bytes += mlen;
                 let offset = (match_start - (match_long - back)) as u32;
                 sequences.push(Sequence {
@@ -317,30 +282,29 @@ fn compress_dfast_block_impl<const HASH_LOG: u32, const SHORT_LOG: u32>(
             // --- Short match check at ip0 ---
             if match_short < ip0
                 && ip0 - match_short <= max_distance
-                && unsafe { rdp32(src_ptr, ip0) == rdp32(src_ptr, match_short) }
+                && primitives::rd32(src, ip0) == primitives::rd32(src, match_short)
             {
                 // ip+1 lookahead: prefer long match at ip1 if significantly better
                 if ip1 < ilimit {
-                    let ml_next = unsafe { *ht_long.add(hl1) } as usize;
+                    let ml_next = primitives::hash_load(hash_long, hl1) as usize;
                     if ml_next < ip1
                         && ip1 - ml_next <= max_distance
-                        && unsafe { rdp64(src_ptr, ip1) == rdp64(src_ptr, ml_next) }
+                        && primitives::rd64(src, ip1) == primitives::rd64(src, ml_next)
                     {
-                        let long_len = count_match(src, ip1 + 8, ml_next + 8, block_end) + 8;
-                        let short_len = count_match(src, ip0 + 4, match_short + 4, block_end) + 4;
+                        let long_len =
+                            primitives::count_match(src, ip1 + 8, ml_next + 8, block_end) + 8;
+                        let short_len =
+                            primitives::count_match(src, ip0 + 4, match_short + 4, block_end) + 4;
 
                         if long_len > short_len + 1 {
-                            unsafe {
-                                *ht_short.add(hs1) = ip1 as u32;
-                                *ht_long.add(hl1) = ip1 as u32;
-                            }
+                            primitives::hash_store(hash_short, hs1, ip1 as u32);
+                            primitives::hash_store(hash_long, hl1, ip1 as u32);
                             ip0 = ip1;
                             let mut back = 0usize;
                             while ip0 > anchor + back
                                 && ml_next > back + block_start
-                                && unsafe {
-                                    *src_ptr.add(ip0 - back - 1) == *src_ptr.add(ml_next - back - 1)
-                                }
+                                && primitives::src_byte(src, ip0 - back - 1)
+                                    == primitives::src_byte(src, ml_next - back - 1)
                             {
                                 back += 1;
                             }
@@ -368,17 +332,15 @@ fn compress_dfast_block_impl<const HASH_LOG: u32, const SHORT_LOG: u32>(
                 }
 
                 // Take short match at ip0
-                unsafe {
-                    *ht_short.add(hs1) = ip1 as u32;
-                    *ht_long.add(hl1) = ip1 as u32;
-                }
-                let mut mlen = count_match(src, ip0 + 4, match_short + 4, block_end) + 4;
+                primitives::hash_store(hash_short, hs1, ip1 as u32);
+                primitives::hash_store(hash_long, hl1, ip1 as u32);
+                let mut mlen =
+                    primitives::count_match(src, ip0 + 4, match_short + 4, block_end) + 4;
                 let mut back = 0usize;
                 while ip0 > anchor + back
                     && match_short > back + block_start
-                    && unsafe {
-                        *src_ptr.add(ip0 - back - 1) == *src_ptr.add(match_short - back - 1)
-                    }
+                    && primitives::src_byte(src, ip0 - back - 1)
+                        == primitives::src_byte(src, match_short - back - 1)
                 {
                     back += 1;
                 }
@@ -405,56 +367,47 @@ fn compress_dfast_block_impl<const HASH_LOG: u32, const SHORT_LOG: u32>(
             }
 
             // === First shift ===
-            match_short = unsafe { *ht_short.add(hs1) } as usize;
-            match_long = unsafe { *ht_long.add(hl1) } as usize;
+            match_short = primitives::hash_load(hash_short, hs1) as usize;
+            match_long = primitives::hash_load(hash_long, hl1) as usize;
             hs0 = hs1;
             hl0 = hl1;
 
-            hs1 = h5(unsafe { rdp64(src_ptr, ip2) }, short_log);
-            hl1 = h8(unsafe { rdp64(src_ptr, ip2) }, hash_log);
+            hs1 = h5(primitives::rd64(src, ip2), short_log);
+            hl1 = h8(primitives::rd64(src, ip2), hash_log);
             ip0 = ip1;
             ip1 = ip2;
             ip2 = ip3;
 
-            unsafe {
-                core::arch::x86_64::_mm_prefetch(
-                    ht_short.add(hs1) as *const i8,
-                    core::arch::x86_64::_MM_HINT_T0,
-                );
-                core::arch::x86_64::_mm_prefetch(
-                    ht_long.add(hl1) as *const i8,
-                    core::arch::x86_64::_MM_HINT_T0,
-                );
+            #[cfg(target_arch = "x86_64")]
+            {
+                primitives::prefetch_ht(hash_short, hs1);
+                primitives::prefetch_ht(hash_long, hl1);
             }
 
             // --- Store hashes for shifted ip0 ---
-            unsafe {
-                *ht_short.add(hs0) = ip0 as u32;
-                *ht_long.add(hl0) = ip0 as u32;
-            }
+            primitives::hash_store(hash_short, hs0, ip0 as u32);
+            primitives::hash_store(hash_long, hl0, ip0 as u32);
 
             // --- Long match check at shifted ip0 ---
             if match_long < ip0
                 && ip0 - match_long <= max_distance
-                && unsafe { rdp64(src_ptr, ip0) == rdp64(src_ptr, match_long) }
+                && primitives::rd64(src, ip0) == primitives::rd64(src, match_long)
             {
                 if step_size + ((ip0 - anchor) >> search_strength) <= 4 {
-                    unsafe {
-                        *ht_short.add(hs1) = ip1 as u32;
-                        *ht_long.add(hl1) = ip1 as u32;
-                    }
+                    primitives::hash_store(hash_short, hs1, ip1 as u32);
+                    primitives::hash_store(hash_long, hl1, ip1 as u32);
                 }
                 let mut back = 0usize;
                 while ip0 > anchor + back
                     && match_long > back + block_start
-                    && unsafe {
-                        *src_ptr.add(ip0 - back - 1) == *src_ptr.add(match_long - back - 1)
-                    }
+                    && primitives::src_byte(src, ip0 - back - 1)
+                        == primitives::src_byte(src, match_long - back - 1)
                 {
                     back += 1;
                 }
                 let match_start = ip0 - back;
-                let mlen = count_match(src, ip0 + 8, match_long + 8, block_end) + 8 + back;
+                let mlen =
+                    primitives::count_match(src, ip0 + 8, match_long + 8, block_end) + 8 + back;
                 total_match_bytes += mlen;
                 let offset = (match_start - (match_long - back)) as u32;
                 sequences.push(Sequence {
@@ -478,32 +431,31 @@ fn compress_dfast_block_impl<const HASH_LOG: u32, const SHORT_LOG: u32>(
             // --- Short match check at shifted ip0 ---
             if match_short < ip0
                 && ip0 - match_short <= max_distance
-                && unsafe { rdp32(src_ptr, ip0) == rdp32(src_ptr, match_short) }
+                && primitives::rd32(src, ip0) == primitives::rd32(src, match_short)
             {
                 // ip+1 lookahead (hash_long[hl1] was prefetched in the shift)
                 if ip1 < ilimit {
-                    let ml_next = unsafe { *ht_long.add(hl1) } as usize;
+                    let ml_next = primitives::hash_load(hash_long, hl1) as usize;
                     if ml_next < ip1
                         && ip1 - ml_next <= max_distance
-                        && unsafe { rdp64(src_ptr, ip1) == rdp64(src_ptr, ml_next) }
+                        && primitives::rd64(src, ip1) == primitives::rd64(src, ml_next)
                     {
-                        let long_len = count_match(src, ip1 + 8, ml_next + 8, block_end) + 8;
-                        let short_len = count_match(src, ip0 + 4, match_short + 4, block_end) + 4;
+                        let long_len =
+                            primitives::count_match(src, ip1 + 8, ml_next + 8, block_end) + 8;
+                        let short_len =
+                            primitives::count_match(src, ip0 + 4, match_short + 4, block_end) + 4;
 
                         if long_len > short_len + 1 {
                             if step_size + ((ip0 - anchor) >> search_strength) <= 4 {
-                                unsafe {
-                                    *ht_short.add(hs1) = ip1 as u32;
-                                    *ht_long.add(hl1) = ip1 as u32;
-                                }
+                                primitives::hash_store(hash_short, hs1, ip1 as u32);
+                                primitives::hash_store(hash_long, hl1, ip1 as u32);
                             }
                             ip0 = ip1;
                             let mut back = 0usize;
                             while ip0 > anchor + back
                                 && ml_next > back + block_start
-                                && unsafe {
-                                    *src_ptr.add(ip0 - back - 1) == *src_ptr.add(ml_next - back - 1)
-                                }
+                                && primitives::src_byte(src, ip0 - back - 1)
+                                    == primitives::src_byte(src, ml_next - back - 1)
                             {
                                 back += 1;
                             }
@@ -532,18 +484,16 @@ fn compress_dfast_block_impl<const HASH_LOG: u32, const SHORT_LOG: u32>(
 
                 // Take short match
                 if step_size + ((ip0 - anchor) >> search_strength) <= 4 {
-                    unsafe {
-                        *ht_short.add(hs1) = ip1 as u32;
-                        *ht_long.add(hl1) = ip1 as u32;
-                    }
+                    primitives::hash_store(hash_short, hs1, ip1 as u32);
+                    primitives::hash_store(hash_long, hl1, ip1 as u32);
                 }
-                let mut mlen = count_match(src, ip0 + 4, match_short + 4, block_end) + 4;
+                let mut mlen =
+                    primitives::count_match(src, ip0 + 4, match_short + 4, block_end) + 4;
                 let mut back = 0usize;
                 while ip0 > anchor + back
                     && match_short > back + block_start
-                    && unsafe {
-                        *src_ptr.add(ip0 - back - 1) == *src_ptr.add(match_short - back - 1)
-                    }
+                    && primitives::src_byte(src, ip0 - back - 1)
+                        == primitives::src_byte(src, match_short - back - 1)
                 {
                     back += 1;
                 }
@@ -570,28 +520,23 @@ fn compress_dfast_block_impl<const HASH_LOG: u32, const SHORT_LOG: u32>(
             }
 
             // === Second shift with step gap ===
-            match_short = unsafe { *ht_short.add(hs1) } as usize;
-            match_long = unsafe { *ht_long.add(hl1) } as usize;
+            match_short = primitives::hash_load(hash_short, hs1) as usize;
+            match_long = primitives::hash_load(hash_long, hl1) as usize;
             hs0 = hs1;
             hl0 = hl1;
 
-            hs1 = h5(unsafe { rdp64(src_ptr, ip2) }, short_log);
-            hl1 = h8(unsafe { rdp64(src_ptr, ip2) }, hash_log);
+            hs1 = h5(primitives::rd64(src, ip2), short_log);
+            hl1 = h8(primitives::rd64(src, ip2), hash_log);
             ip0 = ip1;
             ip1 = ip2;
             let step = step_size + ((ip0 - anchor) >> search_strength);
             ip2 = ip0 + step;
             ip3 = ip1 + step;
 
-            unsafe {
-                core::arch::x86_64::_mm_prefetch(
-                    ht_short.add(hs1) as *const i8,
-                    core::arch::x86_64::_MM_HINT_T0,
-                );
-                core::arch::x86_64::_mm_prefetch(
-                    ht_long.add(hl1) as *const i8,
-                    core::arch::x86_64::_MM_HINT_T0,
-                );
+            #[cfg(target_arch = "x86_64")]
+            {
+                primitives::prefetch_ht(hash_short, hs1);
+                primitives::prefetch_ht(hash_long, hl1);
             }
 
             if ip0 >= probe_limit {
@@ -628,18 +573,18 @@ pub(crate) fn prefill_hash_tables(
     let step = (prefix_len / hash_size).max(1);
     let mut i = 0;
     while i + 8 <= prefix_len {
-        let hs = h5(rd64(combined, i), short_log);
-        hs32(hash_short, hs, i as u32);
-        let hl = h8(rd64(combined, i), hash_log);
-        hs32(hash_long, hl, i as u32);
+        let hs = h5(primitives::rd64(combined, i), short_log);
+        primitives::hash_store(hash_short, hs, i as u32);
+        let hl = h8(primitives::rd64(combined, i), hash_log);
+        primitives::hash_store(hash_long, hl, i as u32);
         i += step;
     }
     let tail_start = prefix_len.saturating_sub(64);
     for i in tail_start..prefix_len.saturating_sub(7) {
-        let hs = h5(rd64(combined, i), short_log);
-        hs32(hash_short, hs, i as u32);
-        let hl = h8(rd64(combined, i), hash_log);
-        hs32(hash_long, hl, i as u32);
+        let hs = h5(primitives::rd64(combined, i), short_log);
+        primitives::hash_store(hash_short, hs, i as u32);
+        let hl = h8(primitives::rd64(combined, i), hash_log);
+        primitives::hash_store(hash_long, hl, i as u32);
     }
 }
 
@@ -717,45 +662,4 @@ fn h5(val: u64, hash_log: u32) -> usize {
 #[inline(always)]
 fn h8(val: u64, hash_log: u32) -> usize {
     (val.wrapping_mul(PRIME64_1) >> (64 - hash_log)) as usize
-}
-
-#[inline(always)]
-fn rd64(src: &[u8], pos: usize) -> u64 {
-    debug_assert!(pos + 8 <= src.len());
-    unsafe { (src.as_ptr().add(pos) as *const u64).read_unaligned() }
-}
-
-#[inline(always)]
-fn hs32(table: &mut [u32], idx: usize, val: u32) {
-    debug_assert!(idx < table.len());
-    unsafe {
-        *table.get_unchecked_mut(idx) = val;
-    }
-}
-
-#[inline(always)]
-fn count_match(src: &[u8], mut p1: usize, mut p2: usize, limit: usize) -> usize {
-    debug_assert!(p1 <= limit && limit <= src.len());
-    debug_assert!(p2 <= src.len());
-    let start = p1;
-    let max_len = (limit - p1).min(src.len() - p2);
-    let end8 = start + (max_len & !7);
-    while p1 < end8 {
-        let a = rd64(src, p1);
-        let b = rd64(src, p2);
-        let xor = a ^ b;
-        if xor != 0 {
-            return p1 - start + (xor.trailing_zeros() as usize / 8);
-        }
-        p1 += 8;
-        p2 += 8;
-    }
-    while p1 < start + max_len {
-        if unsafe { *src.get_unchecked(p1) != *src.get_unchecked(p2) } {
-            break;
-        }
-        p1 += 1;
-        p2 += 1;
-    }
-    p1 - start
 }

--- a/crates/encode/src/fast.rs
+++ b/crates/encode/src/fast.rs
@@ -1,8 +1,11 @@
+#![forbid(unsafe_code)]
+
 #[cfg(feature = "alloc")]
 use alloc::vec;
 #[cfg(feature = "alloc")]
 use alloc::vec::Vec;
 
+use crate::primitives;
 use crate::strategy::LevelParams;
 use zrip_core::Sequence;
 use zrip_core::hash::{PRIME32_1, PRIME64_1};
@@ -93,24 +96,12 @@ fn compress_fast_block_impl<const HASH_LOG: u32, const MLS: usize>(
     let mut probe_limit = block_start + probe_interval;
     let mut total_match_bytes: usize = 0;
 
-    let src_ptr = src.as_ptr();
-    let src_end = unsafe { src_ptr.add(block_end) };
-    let ht_ptr = hash_table.as_mut_ptr();
-
     let mut rep1 = rep_offsets[0] as usize;
     let mut rep2 = rep_offsets[1] as usize;
     let mut anchor = block_start;
     let mut ip0 = block_start;
 
-    unsafe {
-        core::hint::assert_unchecked(rep1 > 0);
-        core::hint::assert_unchecked(rep2 > 0);
-    }
-
-    #[inline(always)]
-    unsafe fn rd32(p: *const u8, pos: usize) -> u32 {
-        unsafe { (p.add(pos) as *const u32).read_unaligned() }
-    }
+    primitives::assert_rep_valid(rep1 as u32, rep2 as u32);
 
     let hash_log = if HASH_LOG != 0 {
         HASH_LOG
@@ -126,33 +117,32 @@ fn compress_fast_block_impl<const HASH_LOG: u32, const MLS: usize>(
             break;
         }
 
-        let mut h0 = hash_pos::<HASH_LOG, MLS>(src_ptr, ip0, hash_log);
-        let mut match_idx = unsafe { *ht_ptr.add(h0) } as usize;
+        let mut h0 = hash_pos::<HASH_LOG, MLS>(src, ip0, hash_log);
+        let mut match_idx = primitives::hash_load(hash_table, h0) as usize;
 
         loop {
             // Write hash for ip0 (before any checks, matching C zstd order)
-            unsafe { *ht_ptr.add(h0) = ip0 as u32 };
+            primitives::hash_store(hash_table, h0, ip0 as u32);
 
             // Rep check at step-ahead position ip2
             if ip2 >= rep1 {
-                let ip2_val = unsafe { rd32(src_ptr, ip2) };
-                let rep_val = unsafe { rd32(src_ptr, ip2 - rep1) };
+                let ip2_val = primitives::rd32(src, ip2);
+                let rep_val = primitives::rd32(src, ip2 - rep1);
                 if ip2_val == rep_val {
                     let fill_pos = ip0;
                     ip0 = ip2;
                     // 1-byte backward extension (C zstd style)
                     if ip0 > anchor
-                        && unsafe { *src_ptr.add(ip0 - 1) == *src_ptr.add(ip0 - rep1 - 1) }
+                        && primitives::src_byte(src, ip0 - 1)
+                            == primitives::src_byte(src, ip0 - rep1 - 1)
                     {
                         ip0 -= 1;
                     }
-                    let h1 = hash_pos::<HASH_LOG, MLS>(src_ptr, ip1, hash_log);
-                    unsafe { *ht_ptr.add(h1) = ip1 as u32 };
+                    let h1 = hash_pos::<HASH_LOG, MLS>(src, ip1, hash_log);
+                    primitives::hash_store(hash_table, h1, ip1 as u32);
                     let back = ip2 - ip0;
-                    let mlen = unsafe {
-                        count_match_raw(src_ptr.add(ip2 + 4), src_ptr.add(ip2 - rep1 + 4), src_end)
-                    } + 4
-                        + back;
+                    let mlen =
+                        primitives::count_match(src, ip2 + 4, ip2 - rep1 + 4, block_end) + 4 + back;
                     total_match_bytes += mlen;
                     let lit_len = (ip0 - anchor) as u32;
                     sequences.push(Sequence {
@@ -185,28 +175,25 @@ fn compress_fast_block_impl<const HASH_LOG: u32, const MLS: usize>(
             // First match check at ip0
             if match_idx < ip0
                 && ip0 - match_idx <= max_distance
-                && unsafe { match_at::<MLS>(src_ptr, ip0, match_idx) }
+                && primitives::match_at::<MLS>(src, ip0, match_idx)
             {
-                let h1 = hash_pos::<HASH_LOG, MLS>(src_ptr, ip1, hash_log);
-                unsafe { *ht_ptr.add(h1) = ip1 as u32 };
+                let h1 = hash_pos::<HASH_LOG, MLS>(src, ip1, hash_log);
+                primitives::hash_store(hash_table, h1, ip1 as u32);
                 let fill_pos = ip0;
                 let mut back = 0usize;
                 while ip0 > anchor + back
                     && match_idx > back + block_start
-                    && unsafe { *src_ptr.add(ip0 - back - 1) == *src_ptr.add(match_idx - back - 1) }
+                    && primitives::src_byte(src, ip0 - back - 1)
+                        == primitives::src_byte(src, match_idx - back - 1)
                 {
                     back += 1;
                 }
                 let match_start = ip0 - back;
                 let offset = (match_start - (match_idx - back)) as u32;
-                let mlen = unsafe {
-                    count_match_raw(
-                        src_ptr.add(ip0 + confirm),
-                        src_ptr.add(match_idx + confirm),
-                        src_end,
-                    )
-                } + confirm
-                    + back;
+                let mlen =
+                    primitives::count_match(src, ip0 + confirm, match_idx + confirm, block_end)
+                        + confirm
+                        + back;
                 total_match_bytes += mlen;
                 let lit_len = (match_start - anchor) as u32;
                 sequences.push(Sequence {
@@ -238,50 +225,43 @@ fn compress_fast_block_impl<const HASH_LOG: u32, const MLS: usize>(
             }
 
             // First shift: compute h1 for ip1, reuse as h0
-            let h1 = hash_pos::<HASH_LOG, MLS>(src_ptr, ip1, hash_log);
-            match_idx = unsafe { *ht_ptr.add(h1) } as usize;
+            let h1 = hash_pos::<HASH_LOG, MLS>(src, ip1, hash_log);
+            match_idx = primitives::hash_load(hash_table, h1) as usize;
             h0 = h1;
-            let h_ip2 = hash_pos::<HASH_LOG, MLS>(src_ptr, ip2, hash_log);
+            let h_ip2 = hash_pos::<HASH_LOG, MLS>(src, ip2, hash_log);
             ip0 = ip1;
             ip1 = ip2;
             ip2 += 1;
 
-            unsafe {
-                core::arch::x86_64::_mm_prefetch(
-                    ht_ptr.add(h_ip2) as *const i8,
-                    core::arch::x86_64::_MM_HINT_T0,
-                );
-            }
+            #[cfg(target_arch = "x86_64")]
+            primitives::prefetch_ht(hash_table, h_ip2);
 
             // Write hash for shifted ip0
-            unsafe { *ht_ptr.add(h0) = ip0 as u32 };
+            primitives::hash_store(hash_table, h0, ip0 as u32);
 
             // Second match check at shifted ip0
             if match_idx < ip0
                 && ip0 - match_idx <= max_distance
-                && unsafe { match_at::<MLS>(src_ptr, ip0, match_idx) }
+                && primitives::match_at::<MLS>(src, ip0, match_idx)
             {
                 if step_size + ((ip0 - anchor) >> search_strength) <= 4 {
-                    unsafe { *ht_ptr.add(h_ip2) = ip1 as u32 };
+                    primitives::hash_store(hash_table, h_ip2, ip1 as u32);
                 }
                 let fill_pos = ip0;
                 let mut back = 0usize;
                 while ip0 > anchor + back
                     && match_idx > back + block_start
-                    && unsafe { *src_ptr.add(ip0 - back - 1) == *src_ptr.add(match_idx - back - 1) }
+                    && primitives::src_byte(src, ip0 - back - 1)
+                        == primitives::src_byte(src, match_idx - back - 1)
                 {
                     back += 1;
                 }
                 let match_start = ip0 - back;
                 let offset = (match_start - (match_idx - back)) as u32;
-                let mlen = unsafe {
-                    count_match_raw(
-                        src_ptr.add(ip0 + confirm),
-                        src_ptr.add(match_idx + confirm),
-                        src_end,
-                    )
-                } + confirm
-                    + back;
+                let mlen =
+                    primitives::count_match(src, ip0 + confirm, match_idx + confirm, block_end)
+                        + confirm
+                        + back;
                 total_match_bytes += mlen;
                 let lit_len = (match_start - anchor) as u32;
                 sequences.push(Sequence {
@@ -313,20 +293,16 @@ fn compress_fast_block_impl<const HASH_LOG: u32, const MLS: usize>(
             }
 
             // Second shift with step gap
-            match_idx = unsafe { *ht_ptr.add(h_ip2) } as usize;
+            match_idx = primitives::hash_load(hash_table, h_ip2) as usize;
             h0 = h_ip2;
-            let h_next = hash_pos::<HASH_LOG, MLS>(src_ptr, ip2, hash_log);
+            let h_next = hash_pos::<HASH_LOG, MLS>(src, ip2, hash_log);
             ip0 = ip1;
             ip1 = ip2;
             let step = step_size + ((ip0 - anchor) >> search_strength);
             ip2 = ip0 + step;
 
-            unsafe {
-                core::arch::x86_64::_mm_prefetch(
-                    ht_ptr.add(h_next) as *const i8,
-                    core::arch::x86_64::_MM_HINT_T0,
-                );
-            }
+            #[cfg(target_arch = "x86_64")]
+            primitives::prefetch_ht(hash_table, h_next);
 
             if ip0 >= probe_limit {
                 let scanned = ip0 - block_start;
@@ -364,17 +340,13 @@ fn rep2_match_loop<const HASH_LOG: u32, const MLS: usize>(
     if *rep2 == 0 {
         return;
     }
-    let src_ptr = src.as_ptr();
     while *ip <= ilimit && *ip >= *rep2 {
-        let val = unsafe { (src_ptr.add(*ip) as *const u32).read_unaligned() };
-        let rval = unsafe { (src_ptr.add(*ip - *rep2) as *const u32).read_unaligned() };
+        let val = primitives::rd32(src, *ip);
+        let rval = primitives::rd32(src, *ip - *rep2);
         if val != rval {
             break;
         }
-        let src_end = unsafe { src_ptr.add(block_end) };
-        let rlen =
-            unsafe { count_match_raw(src_ptr.add(*ip + 4), src_ptr.add(*ip - *rep2 + 4), src_end) }
-                + 4;
+        let rlen = primitives::count_match(src, *ip + 4, *ip - *rep2 + 4, block_end) + 4;
         core::mem::swap(rep1, rep2);
         insert_hash_mls::<HASH_LOG, MLS>(src, *ip, hash_log, hash_table);
         sequences.push(Sequence {
@@ -401,14 +373,14 @@ pub(crate) fn prefill_hash_table(
     let step = (prefix_len / hash_size).max(1);
     let mut i = 0;
     while i + 4 <= prefix_len {
-        let h = hash4_const::<0>(read_u32(combined, i), hash_log);
-        hash_store(hash_table, h, i as u32);
+        let h = hash4_const::<0>(primitives::rd32(combined, i), hash_log);
+        primitives::hash_store(hash_table, h, i as u32);
         i += step;
     }
     let tail_start = prefix_len.saturating_sub(64);
     for i in tail_start..prefix_len.saturating_sub(3) {
-        let h = hash4_const::<0>(read_u32(combined, i), hash_log);
-        hash_store(hash_table, h, i as u32);
+        let h = hash4_const::<0>(primitives::rd32(combined, i), hash_log);
+        primitives::hash_store(hash_table, h, i as u32);
     }
 }
 
@@ -470,9 +442,11 @@ pub(crate) fn compress_fast_with_prefix_reuse(
 
     while ip < limit {
         let rep0 = rep[0] as usize;
-        if (rep0 > 0) & (ip >= rep0) && read_u32(combined, ip) == read_u32(combined, ip - rep0) {
+        if (rep0 > 0) & (ip >= rep0)
+            && primitives::rd32(combined, ip) == primitives::rd32(combined, ip - rep0)
+        {
             let clen = combined.len();
-            let mut match_len = count_match(combined, ip + 4, ip - rep0 + 4, clen) + 4;
+            let mut match_len = primitives::count_match(combined, ip + 4, ip - rep0 + 4, clen) + 4;
             let mut back = 0usize;
             while ip - back > anchor
                 && ip - back > rep0
@@ -508,17 +482,18 @@ pub(crate) fn compress_fast_with_prefix_reuse(
         let search_start = ip;
 
         loop {
-            let val = read_u32(combined, ip);
+            let val = primitives::rd32(combined, ip);
             let h = hash4_const::<0>(val, params.hash_log);
-            let match_pos = hash_load(hash_table, h) as usize;
-            hash_store(hash_table, h, ip as u32);
+            let match_pos = primitives::hash_load(hash_table, h) as usize;
+            primitives::hash_store(hash_table, h, ip as u32);
 
             if match_pos < ip
                 && ip - match_pos <= (1usize << params.window_log)
-                && val == read_u32(combined, match_pos)
+                && val == primitives::rd32(combined, match_pos)
             {
                 let clen = combined.len();
-                let mut match_len = count_match(combined, ip + 4, match_pos + 4, clen) + 4;
+                let mut match_len =
+                    primitives::count_match(combined, ip + 4, match_pos + 4, clen) + 4;
                 let mut back = 0usize;
                 while ip - back > anchor
                     && match_pos > back
@@ -602,46 +577,21 @@ fn hash7_const<const HASH_LOG: u32>(value: u64, hash_log: u32) -> usize {
 }
 
 #[inline(always)]
-unsafe fn rd64(p: *const u8, pos: usize) -> u64 {
-    unsafe { (p.add(pos) as *const u64).read_unaligned() }
-}
-
-#[inline(always)]
-fn hash_pos<const HASH_LOG: u32, const MLS: usize>(
-    src_ptr: *const u8,
-    pos: usize,
-    hash_log: u32,
-) -> usize {
+fn hash_pos<const HASH_LOG: u32, const MLS: usize>(src: &[u8], pos: usize, hash_log: u32) -> usize {
     if MLS >= 7 {
-        hash7_const::<HASH_LOG>(unsafe { rd64(src_ptr, pos) }, hash_log)
+        hash7_const::<HASH_LOG>(primitives::rd64(src, pos), hash_log)
     } else if MLS >= 5 {
-        hash5_const::<HASH_LOG>(unsafe { rd64(src_ptr, pos) }, hash_log)
+        hash5_const::<HASH_LOG>(primitives::rd64(src, pos), hash_log)
     } else {
-        hash4_const::<HASH_LOG>(unsafe { rd32_static(src_ptr, pos) }, hash_log)
-    }
-}
-
-#[inline(always)]
-unsafe fn rd32_static(p: *const u8, pos: usize) -> u32 {
-    unsafe { (p.add(pos) as *const u32).read_unaligned() }
-}
-
-#[inline(always)]
-unsafe fn match_at<const MLS: usize>(p: *const u8, a: usize, b: usize) -> bool {
-    if MLS >= 5 {
-        let va = unsafe { rd64(p, a) };
-        let vb = unsafe { rd64(p, b) };
-        (va ^ vb) & 0xFF_FFFF_FFFF == 0
-    } else {
-        unsafe { rd32_static(p, a) == rd32_static(p, b) }
+        hash4_const::<HASH_LOG>(primitives::rd32(src, pos), hash_log)
     }
 }
 
 #[inline]
 fn insert_hash<const HASH_LOG: u32>(src: &[u8], ip: usize, hash_log: u32, hash_table: &mut [u32]) {
     if ip + 4 <= src.len() {
-        let h = hash4_const::<HASH_LOG>(read_u32(src, ip), hash_log);
-        hash_store(hash_table, h, ip as u32);
+        let h = hash4_const::<HASH_LOG>(primitives::rd32(src, ip), hash_log);
+        primitives::hash_store(hash_table, h, ip as u32);
     }
 }
 
@@ -653,8 +603,8 @@ fn insert_hash_mls<const HASH_LOG: u32, const MLS: usize>(
     hash_table: &mut [u32],
 ) {
     if ip + MLS <= src.len() {
-        let h = hash_pos::<HASH_LOG, MLS>(src.as_ptr(), ip, hash_log);
-        hash_store(hash_table, h, ip as u32);
+        let h = hash_pos::<HASH_LOG, MLS>(src, ip, hash_log);
+        primitives::hash_store(hash_table, h, ip as u32);
     }
 }
 
@@ -667,14 +617,14 @@ fn insert_complementary_fast<const HASH_LOG: u32>(
 ) {
     let pos1 = match_start + 2;
     if pos1 + 4 <= src.len() && pos1 < match_end {
-        let h = hash4_const::<HASH_LOG>(read_u32(src, pos1), hash_log);
-        hash_store(hash_table, h, pos1 as u32);
+        let h = hash4_const::<HASH_LOG>(primitives::rd32(src, pos1), hash_log);
+        primitives::hash_store(hash_table, h, pos1 as u32);
     }
     if match_end >= 2 {
         let pos2 = match_end - 2;
         if pos2 + 4 <= src.len() && pos2 > match_start + 2 {
-            let h = hash4_const::<HASH_LOG>(read_u32(src, pos2), hash_log);
-            hash_store(hash_table, h, pos2 as u32);
+            let h = hash4_const::<HASH_LOG>(primitives::rd32(src, pos2), hash_log);
+            primitives::hash_store(hash_table, h, pos2 as u32);
         }
     }
 }
@@ -697,8 +647,8 @@ fn rep_match_loop_fast<const HASH_LOG: u32>(
             break;
         }
         let r0 = rep[0] as usize;
-        if (r0 > 0) & (*ip >= r0) && read_u32(src, *ip) == read_u32(src, *ip - r0) {
-            let ml = count_match(src, *ip + 4, *ip - r0 + 4, block_end) + 4;
+        if (r0 > 0) & (*ip >= r0) && primitives::rd32(src, *ip) == primitives::rd32(src, *ip - r0) {
+            let ml = primitives::count_match(src, *ip + 4, *ip - r0 + 4, block_end) + 4;
             sequences.push(Sequence {
                 literal_length: 0,
                 offset: r0 as u32,
@@ -710,9 +660,9 @@ fn rep_match_loop_fast<const HASH_LOG: u32>(
             continue;
         }
         let r1 = rep[1] as usize;
-        if (r1 > 0) & (*ip >= r1) && read_u32(src, *ip) == read_u32(src, *ip - r1) {
+        if (r1 > 0) & (*ip >= r1) && primitives::rd32(src, *ip) == primitives::rd32(src, *ip - r1) {
             rep.swap(0, 1);
-            let ml = count_match(src, *ip + 4, *ip - r1 + 4, block_end) + 4;
+            let ml = primitives::count_match(src, *ip + 4, *ip - r1 + 4, block_end) + 4;
             sequences.push(Sequence {
                 literal_length: 0,
                 offset: r1 as u32,
@@ -724,62 +674,5 @@ fn rep_match_loop_fast<const HASH_LOG: u32>(
             continue;
         }
         break;
-    }
-}
-
-#[inline(always)]
-fn read_u32(src: &[u8], pos: usize) -> u32 {
-    debug_assert!(pos + 4 <= src.len());
-    unsafe { (src.as_ptr().add(pos) as *const u32).read_unaligned() }
-}
-
-#[inline(always)]
-unsafe fn count_match_raw(
-    mut p_in: *const u8,
-    mut p_match: *const u8,
-    p_in_limit: *const u8,
-) -> usize {
-    let p_start = p_in;
-    let p_in_loop_limit = unsafe { p_in_limit.sub(7) };
-    while p_in < p_in_loop_limit {
-        let diff = unsafe {
-            (p_in as *const u64).read_unaligned() ^ (p_match as *const u64).read_unaligned()
-        };
-        if diff != 0 {
-            return (unsafe { p_in.offset_from(p_start) }) as usize
-                + (diff.trailing_zeros() as usize / 8);
-        }
-        p_in = unsafe { p_in.add(8) };
-        p_match = unsafe { p_match.add(8) };
-    }
-    while p_in < p_in_limit && unsafe { *p_in == *p_match } {
-        p_in = unsafe { p_in.add(1) };
-        p_match = unsafe { p_match.add(1) };
-    }
-    (unsafe { p_in.offset_from(p_start) }) as usize
-}
-
-#[inline(always)]
-fn count_match(src: &[u8], p1: usize, p2: usize, limit: usize) -> usize {
-    debug_assert!(p1 <= limit && limit <= src.len());
-    debug_assert!(p2 <= src.len());
-    let max_len = (limit - p1).min(src.len() - p2);
-    unsafe {
-        let base = src.as_ptr();
-        count_match_raw(base.add(p1), base.add(p2), base.add(p1 + max_len))
-    }
-}
-
-#[inline(always)]
-fn hash_load(table: &[u32], idx: usize) -> u32 {
-    debug_assert!(idx < table.len());
-    unsafe { *table.get_unchecked(idx) }
-}
-
-#[inline(always)]
-fn hash_store(table: &mut [u32], idx: usize, val: u32) {
-    debug_assert!(idx < table.len());
-    unsafe {
-        *table.get_unchecked_mut(idx) = val;
     }
 }

--- a/crates/encode/src/lib.rs
+++ b/crates/encode/src/lib.rs
@@ -9,6 +9,7 @@ pub(crate) mod block_encoder;
 pub mod context;
 pub(crate) mod dfast;
 pub(crate) mod fast;
+pub(crate) mod primitives;
 pub(crate) mod sequences;
 pub mod strategy;
 #[cfg(feature = "std")]

--- a/crates/encode/src/primitives.rs
+++ b/crates/encode/src/primitives.rs
@@ -1,0 +1,155 @@
+#[cfg(feature = "alloc")]
+use alloc::vec::Vec;
+
+#[inline(always)]
+pub(crate) fn rd32(src: &[u8], pos: usize) -> u32 {
+    debug_assert!(pos + 4 <= src.len());
+    unsafe { (src.as_ptr().add(pos) as *const u32).read_unaligned() }
+}
+
+#[inline(always)]
+pub(crate) fn rd64(src: &[u8], pos: usize) -> u64 {
+    debug_assert!(pos + 8 <= src.len());
+    unsafe { (src.as_ptr().add(pos) as *const u64).read_unaligned() }
+}
+
+#[inline(always)]
+pub(crate) fn src_byte(src: &[u8], pos: usize) -> u8 {
+    debug_assert!(pos < src.len());
+    unsafe { *src.get_unchecked(pos) }
+}
+
+#[inline(always)]
+pub(crate) fn hash_load(table: &[u32], idx: usize) -> u32 {
+    debug_assert!(idx < table.len());
+    unsafe { *table.get_unchecked(idx) }
+}
+
+#[inline(always)]
+pub(crate) fn hash_store(table: &mut [u32], idx: usize, val: u32) {
+    debug_assert!(idx < table.len());
+    unsafe { *table.get_unchecked_mut(idx) = val }
+}
+
+#[inline(always)]
+pub(crate) fn match_at<const MLS: usize>(src: &[u8], a: usize, b: usize) -> bool {
+    if MLS >= 7 {
+        rd64(src, a) == rd64(src, b)
+    } else if MLS >= 5 {
+        let va = rd64(src, a);
+        let vb = rd64(src, b);
+        ((va ^ vb) << (64 - 8 * MLS)) == 0
+    } else {
+        rd32(src, a) == rd32(src, b)
+    }
+}
+
+pub(crate) fn count_match(src: &[u8], p1: usize, p2: usize, limit: usize) -> usize {
+    debug_assert!(p1 <= limit && limit <= src.len());
+    debug_assert!(p2 < src.len());
+    let src_ptr = src.as_ptr();
+    unsafe { count_match_raw(src_ptr.add(p1), src_ptr.add(p2), src_ptr.add(limit)) }
+}
+
+#[inline(always)]
+unsafe fn count_match_raw(
+    mut p_in: *const u8,
+    mut p_match: *const u8,
+    p_in_limit: *const u8,
+) -> usize {
+    unsafe {
+        let p_start = p_in;
+        let safe_limit = p_in_limit.sub(7);
+
+        while p_in < safe_limit {
+            let diff =
+                (p_in as *const u64).read_unaligned() ^ (p_match as *const u64).read_unaligned();
+            if diff != 0 {
+                return p_in.offset_from(p_start) as usize + (diff.trailing_zeros() >> 3) as usize;
+            }
+            p_in = p_in.add(8);
+            p_match = p_match.add(8);
+        }
+        while p_in < p_in_limit {
+            if *p_in != *p_match {
+                break;
+            }
+            p_in = p_in.add(1);
+            p_match = p_match.add(1);
+        }
+        p_in.offset_from(p_start) as usize
+    }
+}
+
+#[inline(always)]
+pub(crate) fn assert_rep_valid(r0: u32, r1: u32) {
+    unsafe {
+        core::hint::assert_unchecked(r0 > 0);
+        core::hint::assert_unchecked(r1 > 0);
+    }
+}
+
+#[cfg(target_arch = "x86_64")]
+#[inline(always)]
+pub(crate) fn prefetch_ht(table: &[u32], idx: usize) {
+    unsafe {
+        core::arch::x86_64::_mm_prefetch(
+            table.as_ptr().add(idx) as *const i8,
+            core::arch::x86_64::_MM_HINT_T0,
+        );
+    }
+}
+
+#[inline(always)]
+pub(crate) fn slice_get<T: Copy>(slice: &[T], idx: usize) -> T {
+    debug_assert!(idx < slice.len());
+    unsafe { *slice.get_unchecked(idx) }
+}
+
+#[inline(always)]
+pub(crate) fn slice_get_ref<T>(slice: &[T], idx: usize) -> &T {
+    debug_assert!(idx < slice.len());
+    unsafe { slice.get_unchecked(idx) }
+}
+
+#[inline(always)]
+pub(crate) fn copy_literals_fast(
+    src: &[u8],
+    src_off: usize,
+    dst: &mut Vec<u8>,
+    dst_off: usize,
+    len: usize,
+) {
+    debug_assert!(src_off + len <= src.len());
+    debug_assert!(dst_off + len <= dst.capacity());
+    unsafe {
+        let s = src.as_ptr().add(src_off);
+        let d = dst.as_mut_ptr().add(dst_off);
+        if len <= 16 && src_off + 16 <= src.len() {
+            (d as *mut u64).write_unaligned((s as *const u64).read_unaligned());
+            (d.add(8) as *mut u64).write_unaligned((s.add(8) as *const u64).read_unaligned());
+        } else {
+            core::ptr::copy_nonoverlapping(s, d, len);
+        }
+    }
+}
+
+#[inline(always)]
+pub(crate) fn bitstream_flush(buf: &mut Vec<u8>, pos: usize, bits: u64) {
+    debug_assert!(pos + 8 <= buf.capacity());
+    unsafe {
+        (buf.as_mut_ptr().add(pos) as *mut u64).write_unaligned(bits.to_le());
+    }
+}
+
+#[inline(always)]
+pub(crate) fn bitstream_write_byte(buf: &mut Vec<u8>, pos: usize, val: u8) {
+    debug_assert!(pos < buf.capacity());
+    unsafe { *buf.as_mut_ptr().add(pos) = val }
+}
+
+#[inline(always)]
+pub(crate) fn set_vec_len<T>(vec: &mut Vec<T>, len: usize) {
+    debug_assert!(len <= vec.capacity());
+    unsafe { vec.set_len(len) }
+}

--- a/doc/charts/x86_64/matrix.svg
+++ b/doc/charts/x86_64/matrix.svg
@@ -16,9 +16,9 @@
   <rect x="95.3" y="230.8" width="50.0" height="39.2" fill="#60a5fa" rx="1"/>
   <rect x="95.3" y="195.6" width="50.0" height="35.2" fill="#4680c4" rx="1"/>
   <rect x="95.3" y="182.4" width="50.0" height="13.2" fill="#60a5fa" rx="1"/>
-  <rect x="147.8" y="217.8" width="50.0" height="52.2" fill="#f87171" rx="1"/>
-  <rect x="147.8" y="180.6" width="50.0" height="37.2" fill="#c45050" rx="1"/>
-  <rect x="147.8" y="151.7" width="50.0" height="29.0" fill="#f87171" rx="1"/>
+  <rect x="147.8" y="216.2" width="50.0" height="53.8" fill="#f87171" rx="1"/>
+  <rect x="147.8" y="179.1" width="50.0" height="37.2" fill="#c45050" rx="1"/>
+  <rect x="147.8" y="149.9" width="50.0" height="29.2" fill="#f87171" rx="1"/>
   <rect x="200.3" y="196.0" width="50.0" height="74.0" fill="#f59e0b" rx="1"/>
   <rect x="200.3" y="165.7" width="50.0" height="30.2" fill="#c47d08" rx="1"/>
   <rect x="200.3" y="136.6" width="50.0" height="29.1" fill="#f59e0b" rx="1"/>
@@ -26,9 +26,9 @@
   <rect x="348.7" y="227.6" width="50.0" height="42.4" fill="#60a5fa" rx="1"/>
   <rect x="348.7" y="198.0" width="50.0" height="29.6" fill="#4680c4" rx="1"/>
   <rect x="348.7" y="184.0" width="50.0" height="14.0" fill="#60a5fa" rx="1"/>
-  <rect x="401.2" y="213.3" width="50.0" height="56.7" fill="#f87171" rx="1"/>
-  <rect x="401.2" y="179.4" width="50.0" height="33.9" fill="#c45050" rx="1"/>
-  <rect x="401.2" y="146.7" width="50.0" height="32.7" fill="#f87171" rx="1"/>
+  <rect x="401.2" y="211.1" width="50.0" height="58.9" fill="#f87171" rx="1"/>
+  <rect x="401.2" y="177.1" width="50.0" height="33.9" fill="#c45050" rx="1"/>
+  <rect x="401.2" y="144.2" width="50.0" height="32.9" fill="#f87171" rx="1"/>
   <rect x="453.7" y="194.0" width="50.0" height="76.0" fill="#f59e0b" rx="1"/>
   <rect x="453.7" y="164.4" width="50.0" height="29.6" fill="#c47d08" rx="1"/>
   <rect x="453.7" y="135.2" width="50.0" height="29.2" fill="#f59e0b" rx="1"/>
@@ -36,9 +36,9 @@
   <rect x="602.0" y="213.5" width="50.0" height="56.5" fill="#60a5fa" rx="1"/>
   <rect x="602.0" y="185.8" width="50.0" height="27.7" fill="#4680c4" rx="1"/>
   <rect x="602.0" y="171.1" width="50.0" height="14.6" fill="#60a5fa" rx="1"/>
-  <rect x="654.5" y="200.4" width="50.0" height="69.6" fill="#f87171" rx="1"/>
-  <rect x="654.5" y="168.7" width="50.0" height="31.6" fill="#c45050" rx="1"/>
-  <rect x="654.5" y="140.3" width="50.0" height="28.4" fill="#f87171" rx="1"/>
+  <rect x="654.5" y="200.2" width="50.0" height="69.8" fill="#f87171" rx="1"/>
+  <rect x="654.5" y="168.6" width="50.0" height="31.6" fill="#c45050" rx="1"/>
+  <rect x="654.5" y="140.0" width="50.0" height="28.5" fill="#f87171" rx="1"/>
   <rect x="707.0" y="154.0" width="50.0" height="116.0" fill="#f59e0b" rx="1"/>
   <rect x="707.0" y="125.2" width="50.0" height="28.9" fill="#c47d08" rx="1"/>
   <rect x="707.0" y="96.1" width="50.0" height="29.1" fill="#f59e0b" rx="1"/>
@@ -56,9 +56,9 @@
   <rect x="95.3" y="511.2" width="50.0" height="33.8" fill="#60a5fa" rx="1"/>
   <rect x="95.3" y="468.7" width="50.0" height="42.5" fill="#4680c4" rx="1"/>
   <rect x="95.3" y="460.1" width="50.0" height="8.6" fill="#60a5fa" rx="1"/>
-  <rect x="147.8" y="499.2" width="50.0" height="45.8" fill="#f87171" rx="1"/>
-  <rect x="147.8" y="456.8" width="50.0" height="42.4" fill="#c45050" rx="1"/>
-  <rect x="147.8" y="440.5" width="50.0" height="16.3" fill="#f87171" rx="1"/>
+  <rect x="147.8" y="497.9" width="50.0" height="47.1" fill="#f87171" rx="1"/>
+  <rect x="147.8" y="455.5" width="50.0" height="42.4" fill="#c45050" rx="1"/>
+  <rect x="147.8" y="439.1" width="50.0" height="16.3" fill="#f87171" rx="1"/>
   <rect x="200.3" y="485.1" width="50.0" height="59.9" fill="#f59e0b" rx="1"/>
   <rect x="200.3" y="448.2" width="50.0" height="36.8" fill="#c47d08" rx="1"/>
   <rect x="200.3" y="427.8" width="50.0" height="20.5" fill="#f59e0b" rx="1"/>
@@ -66,9 +66,9 @@
   <rect x="348.7" y="508.4" width="50.0" height="36.6" fill="#60a5fa" rx="1"/>
   <rect x="348.7" y="473.0" width="50.0" height="35.4" fill="#4680c4" rx="1"/>
   <rect x="348.7" y="463.0" width="50.0" height="10.0" fill="#60a5fa" rx="1"/>
-  <rect x="401.2" y="493.3" width="50.0" height="51.7" fill="#f87171" rx="1"/>
-  <rect x="401.2" y="455.3" width="50.0" height="38.0" fill="#c45050" rx="1"/>
-  <rect x="401.2" y="434.6" width="50.0" height="20.6" fill="#f87171" rx="1"/>
+  <rect x="401.2" y="490.4" width="50.0" height="54.6" fill="#f87171" rx="1"/>
+  <rect x="401.2" y="452.4" width="50.0" height="38.0" fill="#c45050" rx="1"/>
+  <rect x="401.2" y="431.6" width="50.0" height="20.7" fill="#f87171" rx="1"/>
   <rect x="453.7" y="483.6" width="50.0" height="61.4" fill="#f59e0b" rx="1"/>
   <rect x="453.7" y="448.1" width="50.0" height="35.6" fill="#c47d08" rx="1"/>
   <rect x="453.7" y="427.4" width="50.0" height="20.7" fill="#f59e0b" rx="1"/>
@@ -76,9 +76,9 @@
   <rect x="602.0" y="484.0" width="50.0" height="61.0" fill="#60a5fa" rx="1"/>
   <rect x="602.0" y="452.0" width="50.0" height="32.0" fill="#4680c4" rx="1"/>
   <rect x="602.0" y="440.4" width="50.0" height="11.6" fill="#60a5fa" rx="1"/>
-  <rect x="654.5" y="474.0" width="50.0" height="71.0" fill="#f87171" rx="1"/>
-  <rect x="654.5" y="437.8" width="50.0" height="36.2" fill="#c45050" rx="1"/>
-  <rect x="654.5" y="420.9" width="50.0" height="16.9" fill="#f87171" rx="1"/>
+  <rect x="654.5" y="474.5" width="50.0" height="70.5" fill="#f87171" rx="1"/>
+  <rect x="654.5" y="438.3" width="50.0" height="36.2" fill="#c45050" rx="1"/>
+  <rect x="654.5" y="421.4" width="50.0" height="16.9" fill="#f87171" rx="1"/>
   <rect x="707.0" y="427.4" width="50.0" height="117.6" fill="#f59e0b" rx="1"/>
   <rect x="707.0" y="394.8" width="50.0" height="32.5" fill="#c47d08" rx="1"/>
   <rect x="707.0" y="371.1" width="50.0" height="23.7" fill="#f59e0b" rx="1"/>
@@ -94,9 +94,9 @@
   <rect x="95.3" y="808.5" width="50.0" height="11.5" fill="#60a5fa" rx="1"/>
   <rect x="95.3" y="745.3" width="50.0" height="63.2" fill="#4680c4" rx="1"/>
   <rect x="95.3" y="743.6" width="50.0" height="1.7" fill="#60a5fa" rx="1"/>
-  <rect x="147.8" y="808.3" width="50.0" height="11.7" fill="#f87171" rx="1"/>
-  <rect x="147.8" y="744.8" width="50.0" height="63.5" fill="#c45050" rx="1"/>
-  <rect x="147.8" y="741.8" width="50.0" height="2.9" fill="#f87171" rx="1"/>
+  <rect x="147.8" y="808.2" width="50.0" height="11.8" fill="#f87171" rx="1"/>
+  <rect x="147.8" y="744.6" width="50.0" height="63.5" fill="#c45050" rx="1"/>
+  <rect x="147.8" y="741.7" width="50.0" height="2.9" fill="#f87171" rx="1"/>
   <rect x="200.3" y="784.3" width="50.0" height="35.7" fill="#f59e0b" rx="1"/>
   <rect x="200.3" y="728.8" width="50.0" height="55.5" fill="#c47d08" rx="1"/>
   <rect x="200.3" y="720.0" width="50.0" height="8.8" fill="#f59e0b" rx="1"/>
@@ -104,9 +104,9 @@
   <rect x="348.7" y="801.4" width="50.0" height="18.6" fill="#60a5fa" rx="1"/>
   <rect x="348.7" y="746.5" width="50.0" height="54.8" fill="#4680c4" rx="1"/>
   <rect x="348.7" y="739.8" width="50.0" height="6.7" fill="#60a5fa" rx="1"/>
-  <rect x="401.2" y="791.6" width="50.0" height="28.4" fill="#f87171" rx="1"/>
-  <rect x="401.2" y="733.2" width="50.0" height="58.4" fill="#c45050" rx="1"/>
-  <rect x="401.2" y="726.7" width="50.0" height="6.5" fill="#f87171" rx="1"/>
+  <rect x="401.2" y="789.0" width="50.0" height="31.0" fill="#f87171" rx="1"/>
+  <rect x="401.2" y="730.6" width="50.0" height="58.4" fill="#c45050" rx="1"/>
+  <rect x="401.2" y="724.1" width="50.0" height="6.5" fill="#f87171" rx="1"/>
   <rect x="453.7" y="782.4" width="50.0" height="37.6" fill="#f59e0b" rx="1"/>
   <rect x="453.7" y="727.5" width="50.0" height="54.8" fill="#c47d08" rx="1"/>
   <rect x="453.7" y="718.4" width="50.0" height="9.1" fill="#f59e0b" rx="1"/>
@@ -114,9 +114,9 @@
   <rect x="602.0" y="751.7" width="50.0" height="68.3" fill="#60a5fa" rx="1"/>
   <rect x="602.0" y="702.8" width="50.0" height="48.9" fill="#4680c4" rx="1"/>
   <rect x="602.0" y="692.9" width="50.0" height="9.9" fill="#60a5fa" rx="1"/>
-  <rect x="654.5" y="765.9" width="50.0" height="54.1" fill="#f87171" rx="1"/>
-  <rect x="654.5" y="710.6" width="50.0" height="55.3" fill="#c45050" rx="1"/>
-  <rect x="654.5" y="703.5" width="50.0" height="7.1" fill="#f87171" rx="1"/>
+  <rect x="654.5" y="765.5" width="50.0" height="54.5" fill="#f87171" rx="1"/>
+  <rect x="654.5" y="710.2" width="50.0" height="55.3" fill="#c45050" rx="1"/>
+  <rect x="654.5" y="703.0" width="50.0" height="7.1" fill="#f87171" rx="1"/>
   <rect x="707.0" y="710.1" width="50.0" height="109.9" fill="#f59e0b" rx="1"/>
   <rect x="707.0" y="660.1" width="50.0" height="50.0" fill="#c47d08" rx="1"/>
   <rect x="707.0" y="646.1" width="50.0" height="14.0" fill="#f59e0b" rx="1"/>
@@ -124,11 +124,11 @@
   <rect x="250" y="850" width="12" height="12" fill="#60a5fa" rx="2"/>
   <text x="268" y="860" fill="#e6edf3" font-size="10" font-weight="500">C zstd 1.5.7 (libzstd)</text>
   <rect x="250" y="868" width="12" height="12" fill="#f87171" rx="2"/>
-  <text x="268" y="878" fill="#e6edf3" font-size="10" font-weight="500">zrip (safe Rust)</text>
+  <text x="268" y="878" fill="#e6edf3" font-size="10" font-weight="500">zrip (safe API, Rust)</text>
   <rect x="460" y="850" width="12" height="12" fill="#f59e0b" rx="2"/>
   <text x="478" y="860" fill="#e6edf3" font-size="10" font-weight="500">structured-zstd 0.0.40 (unsafe Rust)</text>
   <rect x="460" y="868" width="12" height="12" fill="#c084fc" rx="2"/>
-  <text x="478" y="878" fill="#e6edf3" font-size="10" font-weight="500">lz4rip 0.3.1 (safe Rust, LZ4)</text>
+  <text x="478" y="878" fill="#e6edf3" font-size="10" font-weight="500">lz4rip 0.3.1 (safe API, Rust, LZ4)</text>
   <text x="240" y="903" fill="#e6edf3" font-size="9">bright = compress + decompress</text>
   <text x="480" y="903" fill="#7d8590" font-size="9">dim = transfer @100 MB/s</text>
 </svg>

--- a/doc/charts/x86_64/scatter.svg
+++ b/doc/charts/x86_64/scatter.svg
@@ -40,23 +40,23 @@
   <text x="488.7" y="93.7" text-anchor="start" fill="#60a5fa" font-size="8" font-weight="600">3</text>
   <circle cx="479.9" cy="93.7" r="3.5" fill="#60a5fa" stroke="#0d1117" stroke-width="1"/>
   <text x="473.9" y="93.7" text-anchor="end" fill="#60a5fa" font-size="8" font-weight="600">4</text>
-  <path d="M541.6,256.7L510.7,233.7L503.2,223.3L500.2,212.7L496.0,199.3L493.0,179.6L489.8,160.5L475.0,140.9L471.4,138.6L441.5,124.9L441.7,124.1" fill="none" stroke="#f87171" stroke-width="1.5" stroke-opacity="0.6"/>
-  <circle cx="541.6" cy="256.7" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
-  <text x="547.6" y="256.7" text-anchor="start" fill="#f87171" font-size="8" font-weight="600">-7</text>
-  <circle cx="510.7" cy="233.7" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
-  <circle cx="503.2" cy="223.3" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
-  <circle cx="500.2" cy="212.7" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
-  <text x="506.2" y="212.7" text-anchor="start" fill="#f87171" font-size="8" font-weight="600">-4</text>
-  <circle cx="496.0" cy="199.3" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
-  <circle cx="493.0" cy="179.6" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
-  <circle cx="489.8" cy="160.5" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
-  <text x="495.8" y="160.5" text-anchor="start" fill="#f87171" font-size="8" font-weight="600">-1</text>
-  <circle cx="475.0" cy="140.9" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
-  <circle cx="471.4" cy="138.6" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
-  <circle cx="441.5" cy="124.9" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
-  <text x="447.5" y="124.9" text-anchor="start" fill="#f87171" font-size="8" font-weight="600">3</text>
-  <circle cx="441.7" cy="124.1" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
-  <text x="435.7" y="124.1" text-anchor="end" fill="#f87171" font-size="8" font-weight="600">4</text>
+  <path d="M540.7,256.7L508.8,233.7L501.1,223.3L497.9,212.7L494.0,199.3L490.8,179.6L487.5,160.5L472.0,140.9L468.7,138.6L441.3,124.9L441.2,124.1" fill="none" stroke="#f87171" stroke-width="1.5" stroke-opacity="0.6"/>
+  <circle cx="540.7" cy="256.7" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
+  <text x="546.7" y="256.7" text-anchor="start" fill="#f87171" font-size="8" font-weight="600">-7</text>
+  <circle cx="508.8" cy="233.7" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
+  <circle cx="501.1" cy="223.3" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
+  <circle cx="497.9" cy="212.7" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
+  <text x="503.9" y="212.7" text-anchor="start" fill="#f87171" font-size="8" font-weight="600">-4</text>
+  <circle cx="494.0" cy="199.3" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
+  <circle cx="490.8" cy="179.6" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
+  <circle cx="487.5" cy="160.5" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
+  <text x="493.5" y="160.5" text-anchor="start" fill="#f87171" font-size="8" font-weight="600">-1</text>
+  <circle cx="472.0" cy="140.9" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
+  <circle cx="468.7" cy="138.6" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
+  <circle cx="441.3" cy="124.9" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
+  <text x="447.3" y="124.9" text-anchor="start" fill="#f87171" font-size="8" font-weight="600">3</text>
+  <circle cx="441.2" cy="124.1" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
+  <text x="435.2" y="124.1" text-anchor="end" fill="#f87171" font-size="8" font-weight="600">4</text>
   <path d="M441.8,175.3L438.8,166.2L438.4,155.4L436.4,142.2L433.5,127.5L430.5,114.3L424.0,107.6L421.8,104.1L412.3,99.8L358.6,105.8L358.3,105.1" fill="none" stroke="#f59e0b" stroke-width="1.5" stroke-opacity="0.6"/>
   <circle cx="441.8" cy="175.3" r="3.5" fill="#f59e0b" stroke="#0d1117" stroke-width="1"/>
   <text x="447.8" y="175.3" text-anchor="start" fill="#f59e0b" font-size="8" font-weight="600">-7</text>
@@ -118,23 +118,23 @@
   <text x="330.3" y="410.9" text-anchor="start" fill="#60a5fa" font-size="8" font-weight="600">3</text>
   <circle cx="318.8" cy="407.3" r="3.5" fill="#60a5fa" stroke="#0d1117" stroke-width="1"/>
   <text x="312.8" y="407.3" text-anchor="end" fill="#60a5fa" font-size="8" font-weight="600">4</text>
-  <path d="M413.9,580.5L390.6,556.0L386.2,550.6L382.0,542.7L375.3,530.1L370.0,519.2L363.3,507.3L346.7,474.7L333.2,463.7L296.3,464.7L295.6,460.9" fill="none" stroke="#f87171" stroke-width="1.5" stroke-opacity="0.6"/>
-  <circle cx="413.9" cy="580.5" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
-  <text x="419.9" y="580.5" text-anchor="start" fill="#f87171" font-size="8" font-weight="600">-7</text>
-  <circle cx="390.6" cy="556.0" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
-  <circle cx="386.2" cy="550.6" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
-  <circle cx="382.0" cy="542.7" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
-  <text x="388.0" y="542.7" text-anchor="start" fill="#f87171" font-size="8" font-weight="600">-4</text>
-  <circle cx="375.3" cy="530.1" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
-  <circle cx="370.0" cy="519.2" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
-  <circle cx="363.3" cy="507.3" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
-  <text x="369.3" y="507.3" text-anchor="start" fill="#f87171" font-size="8" font-weight="600">-1</text>
-  <circle cx="346.7" cy="474.7" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
-  <circle cx="333.2" cy="463.7" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
-  <circle cx="296.3" cy="464.7" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
-  <text x="302.3" y="464.7" text-anchor="start" fill="#f87171" font-size="8" font-weight="600">3</text>
-  <circle cx="295.6" cy="460.9" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
-  <text x="289.6" y="460.9" text-anchor="end" fill="#f87171" font-size="8" font-weight="600">4</text>
+  <path d="M412.5,580.5L387.2,556.0L383.1,550.6L378.9,542.7L372.5,530.1L366.9,519.2L360.5,507.3L340.5,474.7L327.5,463.7L296.4,464.7L294.7,460.9" fill="none" stroke="#f87171" stroke-width="1.5" stroke-opacity="0.6"/>
+  <circle cx="412.5" cy="580.5" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
+  <text x="418.5" y="580.5" text-anchor="start" fill="#f87171" font-size="8" font-weight="600">-7</text>
+  <circle cx="387.2" cy="556.0" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
+  <circle cx="383.1" cy="550.6" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
+  <circle cx="378.9" cy="542.7" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
+  <text x="384.9" y="542.7" text-anchor="start" fill="#f87171" font-size="8" font-weight="600">-4</text>
+  <circle cx="372.5" cy="530.1" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
+  <circle cx="366.9" cy="519.2" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
+  <circle cx="360.5" cy="507.3" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
+  <text x="366.5" y="507.3" text-anchor="start" fill="#f87171" font-size="8" font-weight="600">-1</text>
+  <circle cx="340.5" cy="474.7" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
+  <circle cx="327.5" cy="463.7" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
+  <circle cx="296.4" cy="464.7" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
+  <text x="302.4" y="464.7" text-anchor="start" fill="#f87171" font-size="8" font-weight="600">3</text>
+  <circle cx="294.7" cy="460.9" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
+  <text x="288.7" y="460.9" text-anchor="end" fill="#f87171" font-size="8" font-weight="600">4</text>
   <path d="M347.5,503.4L344.7,498.1L339.3,492.1L335.3,484.9L329.6,476.3L323.9,467.3L315.7,459.2L310.7,446.1L288.3,425.9L215.0,412.8L213.7,408.2" fill="none" stroke="#f59e0b" stroke-width="1.5" stroke-opacity="0.6"/>
   <circle cx="347.5" cy="503.4" r="3.5" fill="#f59e0b" stroke="#0d1117" stroke-width="1"/>
   <text x="353.5" y="503.4" text-anchor="start" fill="#f59e0b" font-size="8" font-weight="600">-7</text>
@@ -198,23 +198,23 @@
   <text x="258.4" y="734.2" text-anchor="start" fill="#60a5fa" font-size="8" font-weight="600">3</text>
   <circle cx="239.3" cy="703.9" r="3.5" fill="#60a5fa" stroke="#0d1117" stroke-width="1"/>
   <text x="245.3" y="703.9" text-anchor="start" fill="#60a5fa" font-size="8" font-weight="600">4</text>
-  <path d="M710.0,907.4L716.3,908.2L668.3,903.7L624.7,896.6L604.4,893.4L597.6,894.8L541.0,887.0L390.6,842.3L326.0,808.8L294.1,812.8L281.7,792.6" fill="none" stroke="#f87171" stroke-width="1.5" stroke-opacity="0.6"/>
-  <circle cx="710.0" cy="907.4" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
-  <text x="716.0" y="907.4" text-anchor="start" fill="#f87171" font-size="8" font-weight="600">-7</text>
-  <circle cx="716.3" cy="908.2" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
-  <circle cx="668.3" cy="903.7" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
-  <circle cx="624.7" cy="896.6" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
-  <text x="630.7" y="896.6" text-anchor="start" fill="#f87171" font-size="8" font-weight="600">-4</text>
-  <circle cx="604.4" cy="893.4" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
-  <circle cx="597.6" cy="894.8" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
-  <circle cx="541.0" cy="887.0" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
-  <text x="547.0" y="887.0" text-anchor="start" fill="#f87171" font-size="8" font-weight="600">-1</text>
-  <circle cx="390.6" cy="842.3" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
-  <circle cx="326.0" cy="808.8" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
-  <circle cx="294.1" cy="812.8" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
-  <text x="300.1" y="812.8" text-anchor="start" fill="#f87171" font-size="8" font-weight="600">3</text>
-  <circle cx="281.7" cy="792.6" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
-  <text x="287.7" y="792.6" text-anchor="start" fill="#f87171" font-size="8" font-weight="600">4</text>
+  <path d="M714.0,907.4L718.1,908.2L669.0,903.7L624.9,896.6L604.5,893.4L597.7,894.8L540.2,887.0L377.1,842.3L315.7,808.8L294.0,812.8L281.5,792.6" fill="none" stroke="#f87171" stroke-width="1.5" stroke-opacity="0.6"/>
+  <circle cx="714.0" cy="907.4" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
+  <text x="720.0" y="907.4" text-anchor="start" fill="#f87171" font-size="8" font-weight="600">-7</text>
+  <circle cx="718.1" cy="908.2" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
+  <circle cx="669.0" cy="903.7" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
+  <circle cx="624.9" cy="896.6" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
+  <text x="630.9" y="896.6" text-anchor="start" fill="#f87171" font-size="8" font-weight="600">-4</text>
+  <circle cx="604.5" cy="893.4" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
+  <circle cx="597.7" cy="894.8" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
+  <circle cx="540.2" cy="887.0" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
+  <text x="546.2" y="887.0" text-anchor="start" fill="#f87171" font-size="8" font-weight="600">-1</text>
+  <circle cx="377.1" cy="842.3" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
+  <circle cx="315.7" cy="808.8" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
+  <circle cx="294.0" cy="812.8" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
+  <text x="300.0" y="812.8" text-anchor="start" fill="#f87171" font-size="8" font-weight="600">3</text>
+  <circle cx="281.5" cy="792.6" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
+  <text x="287.5" y="792.6" text-anchor="start" fill="#f87171" font-size="8" font-weight="600">4</text>
   <path d="M381.8,824.5L380.9,825.4L377.6,823.1L374.4,821.3L368.1,817.3L364.4,817.7L353.4,814.5L345.7,807.6L292.5,780.6L179.0,748.4L143.9,716.5" fill="none" stroke="#f59e0b" stroke-width="1.5" stroke-opacity="0.6"/>
   <circle cx="381.8" cy="824.5" r="3.5" fill="#f59e0b" stroke="#0d1117" stroke-width="1"/>
   <text x="387.8" y="824.5" text-anchor="start" fill="#f59e0b" font-size="8" font-weight="600">-7</text>
@@ -237,14 +237,14 @@
   <circle cx="733.8" cy="902.2" r="3.5" fill="#c084fc" stroke="#0d1117" stroke-width="1"/>
   <text x="739.8" y="902.2" text-anchor="start" fill="#c084fc" font-size="8" font-weight="600">LZ4</text>
   <text x="16" y="495.0" text-anchor="middle" fill="#e6edf3" font-size="11" font-weight="600" transform="rotate(-90,16,495.0)">compression ratio</text>
-  <circle cx="153" cy="975" r="4" fill="#60a5fa"/>
-  <text x="161" y="978.5" fill="#e6edf3" font-size="10" font-weight="500">C zstd 1.5.7 (libzstd)</text>
-  <circle cx="325" cy="975" r="4" fill="#f87171"/>
-  <text x="333" y="978.5" fill="#e6edf3" font-size="10" font-weight="500">zrip (safe Rust)</text>
-  <circle cx="460" cy="975" r="4" fill="#f59e0b"/>
-  <text x="468" y="978.5" fill="#e6edf3" font-size="10" font-weight="500">structured-zstd 0.0.40 (unsafe Rust)</text>
-  <circle cx="236" cy="993" r="4" fill="#4ade80"/>
-  <text x="244" y="996.5" fill="#e6edf3" font-size="10" font-weight="500">ruzstd 0.8.2 (safe Rust)</text>
-  <circle cx="420" cy="993" r="4" fill="#c084fc"/>
-  <text x="428" y="996.5" fill="#e6edf3" font-size="10" font-weight="500">lz4rip 0.3.1 (safe Rust, LZ4)</text>
+  <circle cx="137" cy="975" r="4" fill="#60a5fa"/>
+  <text x="145" y="978.5" fill="#e6edf3" font-size="10" font-weight="500">C zstd 1.5.7 (libzstd)</text>
+  <circle cx="310" cy="975" r="4" fill="#f87171"/>
+  <text x="318" y="978.5" fill="#e6edf3" font-size="10" font-weight="500">zrip (safe API, Rust)</text>
+  <circle cx="476" cy="975" r="4" fill="#f59e0b"/>
+  <text x="484" y="978.5" fill="#e6edf3" font-size="10" font-weight="500">structured-zstd 0.0.40 (unsafe Rust)</text>
+  <circle cx="220" cy="993" r="4" fill="#4ade80"/>
+  <text x="228" y="996.5" fill="#e6edf3" font-size="10" font-weight="500">ruzstd 0.8.2 (safe Rust)</text>
+  <circle cx="405" cy="993" r="4" fill="#c084fc"/>
+  <text x="413" y="996.5" fill="#e6edf3" font-size="10" font-weight="500">lz4rip 0.3.1 (safe API, Rust, LZ4)</text>
 </svg>

--- a/doc/charts/x86_64/summary.svg
+++ b/doc/charts/x86_64/summary.svg
@@ -14,9 +14,9 @@
   <rect x="167.0" y="259.0" width="80.0" height="22.8" fill="#4680c4" rx="1"/>
   <rect x="167.0" y="252.0" width="80.0" height="7.0" fill="#60a5fa" rx="1"/>
   <text x="207.0" y="321" text-anchor="middle" fill="#e6edf3" font-size="10" font-weight="600">C zstd</text>
-  <rect x="279.0" y="272.0" width="80.0" height="33.0" fill="#f87171" rx="1"/>
-  <rect x="279.0" y="246.9" width="80.0" height="25.1" fill="#c45050" rx="1"/>
-  <rect x="279.0" y="235.0" width="80.0" height="11.9" fill="#f87171" rx="1"/>
+  <rect x="279.0" y="270.7" width="80.0" height="34.3" fill="#f87171" rx="1"/>
+  <rect x="279.0" y="245.6" width="80.0" height="25.1" fill="#c45050" rx="1"/>
+  <rect x="279.0" y="233.6" width="80.0" height="12.0" fill="#f87171" rx="1"/>
   <text x="319.0" y="321" text-anchor="middle" fill="#e6edf3" font-size="10" font-weight="600">zrip</text>
   <rect x="391.0" y="261.5" width="80.0" height="43.5" fill="#f59e0b" rx="1"/>
   <rect x="391.0" y="238.7" width="80.0" height="22.8" fill="#c47d08" rx="1"/>
@@ -29,7 +29,7 @@
   <rect x="150" y="335" width="12" height="12" fill="#60a5fa" rx="2"/>
   <text x="168" y="345" fill="#e6edf3" font-size="10" font-weight="500">C zstd 1.5.7 (libzstd)</text>
   <rect x="150" y="353" width="12" height="12" fill="#f87171" rx="2"/>
-  <text x="168" y="363" fill="#e6edf3" font-size="10" font-weight="500">zrip (safe Rust)</text>
+  <text x="168" y="363" fill="#e6edf3" font-size="10" font-weight="500">zrip (safe API, Rust)</text>
   <rect x="360" y="335" width="12" height="12" fill="#f59e0b" rx="2"/>
   <text x="378" y="345" fill="#e6edf3" font-size="10" font-weight="500">structured-zstd 0.0.40 (unsafe Rust)</text>
   <rect x="360" y="353" width="12" height="12" fill="#4ade80" rx="2"/>

--- a/scripts/plot_matrix.py
+++ b/scripts/plot_matrix.py
@@ -28,9 +28,9 @@ COLORS = {
 
 LABELS = {
     "C zstd":          "C zstd 1.5.7 (libzstd)",
-    "zrip":            "zrip (safe Rust)",
+    "zrip":            "zrip (safe API, Rust)",
     "structured-zstd": "structured-zstd 0.0.40 (unsafe Rust)",
-    "lz4rip":          "lz4rip 0.3.1 (safe Rust, LZ4)",
+    "lz4rip":          "lz4rip 0.3.1 (safe API, Rust, LZ4)",
 }
 
 LEVELS = [3, 1, -1]

--- a/scripts/plot_scatter.py
+++ b/scripts/plot_scatter.py
@@ -28,10 +28,10 @@ COLORS = {
 
 LABELS = {
     "C zstd":          "C zstd 1.5.7 (libzstd)",
-    "zrip":            "zrip (safe Rust)",
+    "zrip":            "zrip (safe API, Rust)",
     "structured-zstd": "structured-zstd 0.0.40 (unsafe Rust)",
     "ruzstd":          "ruzstd 0.8.2 (safe Rust)",
-    "lz4rip":          "lz4rip 0.3.1 (safe Rust, LZ4)",
+    "lz4rip":          "lz4rip 0.3.1 (safe API, Rust, LZ4)",
 }
 
 # ruzstd only compresses at L1; other levels output raw (1.00x ratio).

--- a/scripts/plot_summary.py
+++ b/scripts/plot_summary.py
@@ -27,7 +27,7 @@ COLORS = {
 
 LABELS = {
     "C zstd":          "C zstd 1.5.7 (libzstd)",
-    "zrip":            "zrip (safe Rust)",
+    "zrip":            "zrip (safe API, Rust)",
     "structured-zstd": "structured-zstd 0.0.40 (unsafe Rust)",
     "ruzstd":          "ruzstd 0.8.2 (safe Rust)",
 }


### PR DESCRIPTION
- Move all unsafe out of algorithm modules into dedicated `primitives.rs` files with safe `pub(crate)` signatures and `#[inline(always)]`
- Every algorithm module now enforces `#![forbid(unsafe_code)]`
- Unsafe confined to: `primitives.rs` modules, `core/simd/`, `decode/simd_decode/`, `core/huffman/decode_4stream.rs`
- 166 unsafe blocks in 14 files (down from ~334 in ~15 algorithm files), all behind safe APIs
- Decode throughput regression: <2%
- Encode L1 regression: <4%; negative levels (L-7..L-1): 5-6% on some files from `&[u8]` fat pointer overhead replacing cached `*const u8`
- Fix chart labels from "safe Rust" to "safe API, Rust" to avoid overstating safety guarantees vs genuinely zero-unsafe crates like ruzstd
- Update README Safety section to reflect encapsulated-unsafe reality