### PR TITLE
Release 0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 ## [Unreleased]
 
+## [0.3.0]
+
+### Added
+
+- Streaming dictionary compression: `FrameEncoder::with_dict()`,
+  `FrameDecoder::with_dict()`, and `reset_with_dict()` for buffer-reusing
+  streaming with trained dictionaries.
+- `CompressContext::with_dict()` and `DecompressContext::with_dict()` for
+  reusable one-shot dictionary compression.
+
+### Changed
+
+- Encapsulated all unsafe behind `primitives.rs` modules with safe
+  `pub(crate)` signatures. Every algorithm module now enforces
+  `#![forbid(unsafe_code)]`. Unsafe confined to primitives, SIMD intrinsics,
+  and the 4-stream Huffman decoder.
+
 ## [0.2.1]
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ exclude = ["fuzz", "bench"]
 
 [package]
 name = "zrip"
-version = "0.2.1"
+version = "0.3.0"
 edition = "2024"
 rust-version = "1.85"
 description = "Pure Rust zstd codec: Fast/DFast strategies (levels -7..4), COVER/FastCOVER dict builder"
@@ -22,9 +22,9 @@ dict_builder = ["std", "zrip-core/dict_builder"]
 nightly = ["zrip-core/nightly", "zrip-encode/nightly", "zrip-decode/nightly"]
 
 [dependencies]
-zrip-core = { version = "0.2.0", path = "crates/core", default-features = false }
-zrip-encode = { version = "0.2.1", path = "crates/encode", default-features = false }
-zrip-decode = { version = "0.2.1", path = "crates/decode", default-features = false }
+zrip-core = { version = "0.3.0", path = "crates/core", default-features = false }
+zrip-encode = { version = "0.3.0", path = "crates/encode", default-features = false }
+zrip-decode = { version = "0.3.0", path = "crates/decode", default-features = false }
 
 [dev-dependencies]
 zstd = "0.13"

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zrip-core"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2024"
 rust-version = "1.85"
 description = "Shared types and codecs for zrip (internal crate)"

--- a/crates/decode/Cargo.toml
+++ b/crates/decode/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zrip-decode"
-version = "0.2.1"
+version = "0.3.0"
 edition = "2024"
 rust-version = "1.85"
 description = "zstd decoder for zrip (internal crate)"
@@ -15,4 +15,4 @@ frame = ["std"]
 nightly = ["zrip-core/nightly"]
 
 [dependencies]
-zrip-core = { version = "0.2.0", path = "../core", default-features = false }
+zrip-core = { version = "0.3.0", path = "../core", default-features = false }

--- a/crates/encode/Cargo.toml
+++ b/crates/encode/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zrip-encode"
-version = "0.2.1"
+version = "0.3.0"
 edition = "2024"
 rust-version = "1.85"
 description = "zstd encoder for zrip (internal crate)"
@@ -15,4 +15,4 @@ frame = ["std"]
 nightly = ["zrip-core/nightly"]
 
 [dependencies]
-zrip-core = { version = "0.2.0", path = "../core", default-features = false }
+zrip-core = { version = "0.3.0", path = "../core", default-features = false }


### PR DESCRIPTION
- Bump all workspace crates to 0.3.0
- Add CHANGELOG entry for streaming dictionary support and unsafe encapsulation