### PR TITLE
Release 0.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 ## [Unreleased]
 
+## [0.3.1]
+
+### Fixed
+
+- UB in SIMD decode: `wildcopy_neon_write32` computed an out-of-bounds pointer
+  before checking if the fast path applies, triggering UB even when `len < 32`.
+- Removed dead `decode_sequences_neon` that referenced undefined variables and
+  would fail to compile on aarch64.
+- Fixed `eprintln!("")` clippy warning in decode_compare example.
+
+### Changed
+
+- Split monolithic 3k-line test file into focused modules (`roundtrip`,
+  `interop`, `streaming`, `dict`, `adversarial`, `proptest_tests`).
+- Made tests Miri-compatible: avoid C zstd FFI and SIMD paths under Miri,
+  use pure-Rust scalar fallbacks.
+- Removed stale version badge from README.
+
 ## [0.3.0]
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ exclude = ["fuzz", "bench"]
 
 [package]
 name = "zrip"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2024"
 rust-version = "1.85"
 description = "Pure Rust zstd codec: Fast/DFast strategies (levels -7..4), COVER/FastCOVER dict builder"
@@ -22,9 +22,9 @@ dict_builder = ["std", "zrip-core/dict_builder"]
 nightly = ["zrip-core/nightly", "zrip-encode/nightly", "zrip-decode/nightly"]
 
 [dependencies]
-zrip-core = { version = "0.3.0", path = "crates/core", default-features = false }
-zrip-encode = { version = "0.3.0", path = "crates/encode", default-features = false }
-zrip-decode = { version = "0.3.0", path = "crates/decode", default-features = false }
+zrip-core = { version = "0.3.1", path = "crates/core", default-features = false }
+zrip-encode = { version = "0.3.1", path = "crates/encode", default-features = false }
+zrip-decode = { version = "0.3.1", path = "crates/decode", default-features = false }
 
 [dev-dependencies]
 zstd = "0.13"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -80,6 +80,7 @@ redundant_closure_for_method_calls = "allow"
 # u128 -> f64 is fine for display purposes.
 enum_glob_use = "allow"
 module_name_repetitions = "allow"
+needless_pass_by_value = "allow"
 
 [profile.release]
 lto = "thin"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,9 @@ zrip-core = { version = "0.3.1", path = "crates/core", default-features = false 
 zrip-encode = { version = "0.3.1", path = "crates/encode", default-features = false }
 zrip-decode = { version = "0.3.1", path = "crates/decode", default-features = false }
 
+[lints]
+workspace = true
+
 [dev-dependencies]
 zstd = "0.13"
 zstd-safe = "7"
@@ -34,6 +37,49 @@ libc = "0.2"
 
 [[example]]
 name = "quickstart"
+
+[workspace.lints.clippy]
+pedantic = { level = "warn", priority = -1 }
+# Casts are pervasive and intentional in a codec operating on fixed-width fields.
+cast_possible_truncation = "allow"
+cast_possible_wrap = "allow"
+cast_sign_loss = "allow"
+cast_lossless = "allow"
+cast_precision_loss = "allow"
+# Raw pointer casts in unsafe primitives and SIMD intrinsics.
+ptr_as_ptr = "allow"
+ptr_cast_constness = "allow"
+cast_ptr_alignment = "allow"
+# Hot-path primitives need guaranteed inlining.
+inline_always = "allow"
+# Codec functions are inherently long.
+too_many_lines = "allow"
+# Internal crate: doc and must_use noise not worth it.
+must_use_candidate = "allow"
+missing_errors_doc = "allow"
+missing_panics_doc = "allow"
+doc_markdown = "allow"
+# Acceptable in codec code.
+similar_names = "allow"
+items_after_statements = "allow"
+wildcard_imports = "allow"
+# Bitwise bool is intentional for branchless hot paths.
+needless_bitwise_bool = "allow"
+# match on tuple with catch-all is clearer than if-let for FSE table dispatch.
+single_match_else = "allow"
+# manual_ilog2 suggestion changes behavior on zero.
+manual_ilog2 = "allow"
+bool_to_int_with_if = "allow"
+if_not_else = "allow"
+# Iterating with .iter() is explicit about intent.
+explicit_iter_loop = "allow"
+# let-else doesn't help when the else is a complex expression.
+option_if_let_else = "allow"
+match_same_arms = "allow"
+redundant_closure_for_method_calls = "allow"
+# u128 -> f64 is fine for display purposes.
+enum_glob_use = "allow"
+module_name_repetitions = "allow"
 
 [profile.release]
 lto = "thin"

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -7,6 +7,9 @@ description = "Shared types and codecs for zrip (internal crate)"
 license = "MIT"
 repository = "https://github.com/paddor/zrip"
 
+[lints]
+workspace = true
+
 [features]
 default = ["std"]
 std = ["alloc"]

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zrip-core"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2024"
 rust-version = "1.85"
 description = "Shared types and codecs for zrip (internal crate)"

--- a/crates/core/src/bitstream/reader.rs
+++ b/crates/core/src/bitstream/reader.rs
@@ -109,7 +109,7 @@ mod tests {
 
     #[test]
     fn read_single_bits() {
-        let data = [0b10110100u8];
+        let data = [0b1011_0100_u8];
         let mut r = BitReader::new(&data);
         assert_eq!(r.read_bits(1).unwrap(), 0);
         assert_eq!(r.read_bits(1).unwrap(), 0);
@@ -132,10 +132,10 @@ mod tests {
 
     #[test]
     fn read_cross_byte() {
-        let data = [0b11010110, 0b10110001];
+        let data = [0b1101_0110, 0b1011_0001];
         let mut r = BitReader::new(&data);
         assert_eq!(r.read_bits(4).unwrap(), 0b0110);
-        assert_eq!(r.read_bits(8).unwrap(), 0b00011101);
+        assert_eq!(r.read_bits(8).unwrap(), 0b0001_1101);
         assert_eq!(r.read_bits(4).unwrap(), 0b1011);
     }
 

--- a/crates/core/src/bitstream/reader_reverse.rs
+++ b/crates/core/src/bitstream/reader_reverse.rs
@@ -181,7 +181,7 @@ mod tests {
 
     #[test]
     fn sentinel_only_no_data() {
-        let data = [0b00000001];
+        let data = [0b0000_0001];
         let r = ReverseBitReader::new(&data).unwrap();
         assert_eq!(r.bits_remaining(), 0);
     }
@@ -192,21 +192,21 @@ mod tests {
 
         let mut w = BitWriter::new();
         w.write_bits(0b101, 3);
-        w.write_bits(0b11001010, 8);
+        w.write_bits(0b1100_1010, 8);
         w.write_bits(0b1, 1);
         w.close_reverse_stream();
         let bytes = w.into_bytes();
 
         let mut r = ReverseBitReader::new(&bytes).unwrap();
         assert_eq!(r.read_bits(1).unwrap(), 0b1);
-        assert_eq!(r.read_bits(8).unwrap(), 0b11001010);
+        assert_eq!(r.read_bits(8).unwrap(), 0b1100_1010);
         assert_eq!(r.read_bits(3).unwrap(), 0b101);
         assert_eq!(r.bits_remaining(), 0);
     }
 
     #[test]
     fn single_byte_with_data() {
-        let data = [0b00001101];
+        let data = [0b0000_1101];
         let mut r = ReverseBitReader::new(&data).unwrap();
         assert_eq!(r.read_bits(3).unwrap(), 0b101);
         assert_eq!(r.bits_remaining(), 0);

--- a/crates/core/src/bitstream/writer.rs
+++ b/crates/core/src/bitstream/writer.rs
@@ -134,7 +134,7 @@ mod tests {
         w.write_bits(0b11, 2);
         w.write_bits(0b000, 3);
         let bytes = w.into_bytes();
-        assert_eq!(bytes, [0b00011101]);
+        assert_eq!(bytes, [0b0001_1101]);
     }
 
     #[test]
@@ -151,7 +151,7 @@ mod tests {
         let mut w = BitWriter::new();
         w.write_bits(0b1, 1);
         let bytes = w.into_bytes();
-        assert_eq!(bytes, [0b00000001]);
+        assert_eq!(bytes, [0b0000_0001]);
     }
 
     #[test]

--- a/crates/core/src/block/mod.rs
+++ b/crates/core/src/block/mod.rs
@@ -51,7 +51,7 @@ mod tests {
         let hdr = parse_block_header(&data).unwrap();
         assert!(!hdr.last_block);
         assert_eq!(hdr.block_type, BlockType::Raw);
-        assert_eq!(hdr.block_size, 0x010000 >> 3);
+        assert_eq!(hdr.block_size, 0x0001_0000 >> 3);
     }
 
     #[test]

--- a/crates/core/src/dict/fastcover.rs
+++ b/crates/core/src/dict/fastcover.rs
@@ -135,16 +135,17 @@ fn hash_dmer(dmer: &[u8]) -> usize {
     let len = dmer.len();
     if len <= 8 {
         let v = read_le_partial(dmer);
-        v.wrapping_mul(0x9E3779B97F4A7C15) as usize
+        v.wrapping_mul(0x9E37_79B9_7F4A_7C15) as usize
     } else {
-        let mut h = read_le_u64(dmer).wrapping_mul(0x9E3779B97F4A7C15);
+        let mut h = read_le_u64(dmer).wrapping_mul(0x9E37_79B9_7F4A_7C15);
         let mut off = 8;
         while off + 8 <= len {
-            h = h.rotate_left(11) ^ read_le_u64(&dmer[off..]).wrapping_mul(0x9E3779B97F4A7C15);
+            h = h.rotate_left(11) ^ read_le_u64(&dmer[off..]).wrapping_mul(0x9E37_79B9_7F4A_7C15);
             off += 8;
         }
         if off < len {
-            h = h.rotate_left(11) ^ read_le_partial(&dmer[off..]).wrapping_mul(0x9E3779B97F4A7C15);
+            h = h.rotate_left(11)
+                ^ read_le_partial(&dmer[off..]).wrapping_mul(0x9E37_79B9_7F4A_7C15);
         }
         h as usize
     }

--- a/crates/core/src/dict/finalize.rs
+++ b/crates/core/src/dict/finalize.rs
@@ -104,15 +104,15 @@ fn compute_rep_offsets(content: &[u8], samples: &[&[u8]]) -> [u32; 3] {
 }
 
 fn compute_dict_id(content: &[u8], samples: &[&[u8]]) -> u32 {
-    let mut h = 0x811c9dc5u32;
+    let mut h = 0x811c_9dc5_u32;
     for &b in content {
         h ^= b as u32;
-        h = h.wrapping_mul(0x01000193);
+        h = h.wrapping_mul(0x0100_0193);
     }
     for &sample in samples.iter().take(10) {
         for &b in sample {
             h ^= b as u32;
-            h = h.wrapping_mul(0x01000193);
+            h = h.wrapping_mul(0x0100_0193);
         }
     }
     if h == 0 {

--- a/crates/core/src/dict/mod.rs
+++ b/crates/core/src/dict/mod.rs
@@ -17,7 +17,7 @@ use crate::fse::{FseDecodeEntry, LL_MAX_SYMBOL, ML_MAX_SYMBOL, OF_MAX_SYMBOL};
 use crate::huffman::HuffmanDecodeEntry;
 use crate::huffman::weights::{build_huffman_decode_table, parse_huffman_weights};
 
-pub const DICT_MAGIC: u32 = 0xEC30A437;
+pub const DICT_MAGIC: u32 = 0xEC30_A437;
 
 /// A pre-trained zstd dictionary for improved compression of small data.
 ///

--- a/crates/core/src/error.rs
+++ b/crates/core/src/error.rs
@@ -23,7 +23,7 @@ pub enum CompressError {
 /// Error returned by decompression functions.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum DecompressError {
-    /// Frame magic number is not `0xFD2FB528`.
+    /// Frame magic number is not `0xFD2F_B528`.
     BadMagic,
     /// Frame descriptor or field sizes are invalid.
     BadFrameHeader,

--- a/crates/core/src/frame/header.rs
+++ b/crates/core/src/frame/header.rs
@@ -45,7 +45,9 @@ pub fn parse_frame_header(data: &[u8]) -> Result<FrameHeader, DecompressError> {
 
     let mut offset = 5;
 
-    let window_size = if !single_segment {
+    let window_size = if single_segment {
+        0
+    } else {
         if data.len() <= offset {
             return Err(DecompressError::BadFrameHeader);
         }
@@ -56,8 +58,6 @@ pub fn parse_frame_header(data: &[u8]) -> Result<FrameHeader, DecompressError> {
         let window_base = 1u64 << (10 + exponent);
         let window_add = (window_base >> 3) * mantissa;
         window_base + window_add
-    } else {
-        0
     };
 
     let dict_id_size = match dict_id_flag {

--- a/crates/core/src/frame/mod.rs
+++ b/crates/core/src/frame/mod.rs
@@ -4,8 +4,8 @@
 
 pub mod header;
 
-/// Zstd frame magic number (`0xFD2FB528`).
-pub const ZSTD_MAGIC: u32 = 0xFD2FB528;
+/// Zstd frame magic number (`0xFD2F_B528`).
+pub const ZSTD_MAGIC: u32 = 0xFD2F_B528;
 
 /// Minimum frame header size in bytes.
 pub const MIN_FRAME_HEADER_SIZE: usize = 2;

--- a/crates/core/src/hash.rs
+++ b/crates/core/src/hash.rs
@@ -1,8 +1,8 @@
 #![forbid(unsafe_code)]
 
-pub const PRIME32_1: u32 = 0x9E3779B1;
-pub const PRIME32_2: u32 = 0x85EBCA77;
-pub const PRIME64_1: u64 = 0x9E3779B185EBCA87;
+pub const PRIME32_1: u32 = 0x9E37_79B1;
+pub const PRIME32_2: u32 = 0x85EB_CA77;
+pub const PRIME64_1: u64 = 0x9E37_79B1_85EB_CA87;
 
 #[inline]
 pub fn hash4(value: u32, hash_log: u32) -> u32 {

--- a/crates/core/src/huffman/weights.rs
+++ b/crates/core/src/huffman/weights.rs
@@ -53,7 +53,7 @@ fn parse_fse_compressed_weights(data: &[u8]) -> Result<(Vec<u8>, usize), Decompr
         return Err(DecompressError::BadHuffmanWeights);
     }
 
-    let compressed = &data[1..1 + compressed_size];
+    let compressed = &data[1..=compressed_size];
 
     let mut bit_reader = BitReader::new(compressed);
     let (distribution, accuracy_log) =

--- a/crates/core/src/xxhash/mod.rs
+++ b/crates/core/src/xxhash/mod.rs
@@ -1,10 +1,10 @@
 mod primitives;
 
-const PRIME64_1: u64 = 0x9E3779B185EBCA87;
-const PRIME64_2: u64 = 0xC2B2AE3D27D4EB4F;
-const PRIME64_3: u64 = 0x165667B19E3779F9;
-const PRIME64_4: u64 = 0x85EBCA77C2B2AE63;
-const PRIME64_5: u64 = 0x27D4EB2F165667C5;
+const PRIME64_1: u64 = 0x9E37_79B1_85EB_CA87;
+const PRIME64_2: u64 = 0xC2B2_AE3D_27D4_EB4F;
+const PRIME64_3: u64 = 0x1656_67B1_9E37_79F9;
+const PRIME64_4: u64 = 0x85EB_CA77_C2B2_AE63;
+const PRIME64_5: u64 = 0x27D4_EB2F_1656_67C5;
 
 #[inline]
 fn xxh64_round(mut acc: u64, input: u64) -> u64 {
@@ -255,7 +255,7 @@ mod tests {
     #[test]
     fn content_checksum() {
         let hash = xxh64(b"test data for zstd", 0);
-        let checksum = (hash & 0xFFFFFFFF) as u32;
+        let checksum = (hash & 0xFFFF_FFFF) as u32;
         assert_eq!(checksum, hash as u32);
     }
 }

--- a/crates/core/src/xxhash/mod.rs
+++ b/crates/core/src/xxhash/mod.rs
@@ -214,9 +214,9 @@ mod tests {
 
     #[test]
     fn known_vectors() {
-        assert_eq!(xxh64(b"", 0), 0xEF46DB3751D8E999);
-        assert_eq!(xxh64(b"a", 0), 0xD24EC4F1A98C6E5B);
-        assert_eq!(xxh64(b"abc", 0), 0x44BC2CF5AD770999);
+        assert_eq!(xxh64(b"", 0), 0xEF46_DB37_51D8_E999);
+        assert_eq!(xxh64(b"a", 0), 0xD24E_C4F1_A98C_6E5B);
+        assert_eq!(xxh64(b"abc", 0), 0x44BC_2CF5_AD77_0999);
     }
 
     #[test]

--- a/crates/decode/Cargo.toml
+++ b/crates/decode/Cargo.toml
@@ -7,6 +7,9 @@ description = "zstd decoder for zrip (internal crate)"
 license = "MIT"
 repository = "https://github.com/paddor/zrip"
 
+[lints]
+workspace = true
+
 [features]
 default = ["std"]
 std = ["alloc", "zrip-core/std"]

--- a/crates/decode/Cargo.toml
+++ b/crates/decode/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zrip-decode"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2024"
 rust-version = "1.85"
 description = "zstd decoder for zrip (internal crate)"
@@ -15,4 +15,4 @@ frame = ["std"]
 nightly = ["zrip-core/nightly"]
 
 [dependencies]
-zrip-core = { version = "0.3.0", path = "../core", default-features = false }
+zrip-core = { version = "0.3.1", path = "../core", default-features = false }

--- a/crates/decode/src/lib.rs
+++ b/crates/decode/src/lib.rs
@@ -70,7 +70,7 @@ pub(crate) fn skip_skippable_frame(data: &[u8]) -> Option<usize> {
         return None;
     }
     let magic = u32::from_le_bytes([data[0], data[1], data[2], data[3]]);
-    if (magic & 0xFFFFFFF0) != 0x184D2A50 {
+    if (magic & 0xFFFF_FFF0) != 0x184D_2A50 {
         return None;
     }
     let frame_size = u32::from_le_bytes([data[4], data[5], data[6], data[7]]) as usize;
@@ -272,7 +272,7 @@ pub(crate) fn decompress_frame(
     if let Some(ref mut hasher) = hasher {
         hasher.update(&output[output_start..]);
         let hash = hasher.finish();
-        let expected_checksum = (hash & 0xFFFFFFFF) as u32;
+        let expected_checksum = (hash & 0xFFFF_FFFF) as u32;
 
         if offset + 4 > input.len() {
             return Err(DecompressError::InputExhausted);

--- a/crates/decode/src/streaming.rs
+++ b/crates/decode/src/streaming.rs
@@ -162,7 +162,7 @@ impl<R: Read> FrameDecoder<R> {
             self.read_buf[3],
         ]);
 
-        if (magic & 0xFFFFFFF0) == 0x184D2A50 {
+        if (magic & 0xFFFF_FFF0) == 0x184D_2A50 {
             self.inner.read_exact(&mut self.read_buf[5..9])?;
             let skip_size = u32::from_le_bytes([
                 self.read_buf[5],
@@ -462,7 +462,7 @@ impl<R: Read> FrameDecoder<R> {
 
         if let Some(ref hasher) = self.hasher {
             let hash = hasher.finish();
-            let expected = (hash & 0xFFFFFFFF) as u32;
+            let expected = (hash & 0xFFFF_FFFF) as u32;
             if expected != stored {
                 return Err(io::Error::new(
                     io::ErrorKind::InvalidData,

--- a/crates/encode/Cargo.toml
+++ b/crates/encode/Cargo.toml
@@ -7,6 +7,9 @@ description = "zstd encoder for zrip (internal crate)"
 license = "MIT"
 repository = "https://github.com/paddor/zrip"
 
+[lints]
+workspace = true
+
 [features]
 default = ["std"]
 std = ["alloc", "zrip-core/std"]

--- a/crates/encode/Cargo.toml
+++ b/crates/encode/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zrip-encode"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2024"
 rust-version = "1.85"
 description = "zstd encoder for zrip (internal crate)"
@@ -15,4 +15,4 @@ frame = ["std"]
 nightly = ["zrip-core/nightly"]
 
 [dependencies]
-zrip-core = { version = "0.3.0", path = "../core", default-features = false }
+zrip-core = { version = "0.3.1", path = "../core", default-features = false }

--- a/crates/encode/src/block_encoder.rs
+++ b/crates/encode/src/block_encoder.rs
@@ -728,17 +728,14 @@ fn encode_seq_custom(
         return false;
     }
 
-    let ll_enc = match build_table_enc(ll_freq, ll_max, 9, n) {
-        Some(e) => e,
-        None => return false,
+    let Some(ll_enc) = build_table_enc(ll_freq, ll_max, 9, n) else {
+        return false;
     };
-    let of_enc = match build_table_enc(of_freq, of_max, 8, n) {
-        Some(e) => e,
-        None => return false,
+    let Some(of_enc) = build_table_enc(of_freq, of_max, 8, n) else {
+        return false;
     };
-    let ml_enc = match build_table_enc(ml_freq, ml_max, 9, n) {
-        Some(e) => e,
-        None => return false,
+    let Some(ml_enc) = build_table_enc(ml_freq, ml_max, 9, n) else {
+        return false;
     };
 
     let ll_mode: u8 = match &ll_enc {

--- a/crates/encode/src/context.rs
+++ b/crates/encode/src/context.rs
@@ -122,7 +122,7 @@ impl CompressContext {
     }
 }
 
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::unnecessary_wraps)]
 fn compress_core(
     input: &[u8],
     params: LevelParams,
@@ -154,7 +154,7 @@ fn compress_core(
         1
     } else if input.len() <= 0xFFFF + 256 {
         2
-    } else if input.len() <= 0xFFFFFFFF {
+    } else if input.len() <= 0xFFFF_FFFF {
         4
     } else {
         8
@@ -432,7 +432,7 @@ fn compress_core(
     }
 
     let hash = xxh64(input, 0);
-    let checksum = (hash & 0xFFFFFFFF) as u32;
+    let checksum = (hash & 0xFFFF_FFFF) as u32;
     output.extend_from_slice(&checksum.to_le_bytes());
 
     Ok(())

--- a/crates/encode/src/dfast.rs
+++ b/crates/encode/src/dfast.rs
@@ -58,7 +58,7 @@ pub(crate) fn compress_dfast_block(
             )
         };
     }
-    dispatch!(0, 0)
+    dispatch!(0, 0);
 }
 
 /// 4-cursor DFast match finder with prefetch pipeline.

--- a/crates/encode/src/fast.rs
+++ b/crates/encode/src/fast.rs
@@ -568,7 +568,7 @@ fn hash5_const<const HASH_LOG: u32>(value: u64, hash_log: u32) -> usize {
     (((value << 24).wrapping_mul(PRIME64_1)) >> (64 - hl)) as usize
 }
 
-const PRIME7: u64 = 58295818150454627;
+const PRIME7: u64 = 58_295_818_150_454_627;
 
 #[inline(always)]
 fn hash7_const<const HASH_LOG: u32>(value: u64, hash_log: u32) -> usize {

--- a/crates/encode/src/lib.rs
+++ b/crates/encode/src/lib.rs
@@ -69,6 +69,7 @@ pub fn compress(input: &[u8], level: i32) -> Result<Vec<u8>, CompressError> {
     compress_inner(input, &params)
 }
 
+#[allow(clippy::unnecessary_wraps)]
 fn compress_inner(input: &[u8], params: &strategy::LevelParams) -> Result<Vec<u8>, CompressError> {
     let mut output = Vec::with_capacity(input.len() + 32);
     compress_frame(input, params, &mut output);
@@ -82,7 +83,7 @@ fn compress_frame(input: &[u8], params: &strategy::LevelParams, output: &mut Vec
         1
     } else if input.len() <= 0xFFFF + 256 {
         2
-    } else if input.len() <= 0xFFFFFFFF {
+    } else if input.len() <= 0xFFFF_FFFF {
         4
     } else {
         8
@@ -201,7 +202,7 @@ fn compress_frame(input: &[u8], params: &strategy::LevelParams, output: &mut Vec
     }
 
     let hash = xxh64(input, 0);
-    let checksum = (hash & 0xFFFFFFFF) as u32;
+    let checksum = (hash & 0xFFFF_FFFF) as u32;
     output.extend_from_slice(&checksum.to_le_bytes());
 }
 
@@ -221,7 +222,7 @@ pub fn compress_with_dict(
         1
     } else if input.len() <= 0xFFFF + 256 {
         2
-    } else if input.len() <= 0xFFFFFFFF {
+    } else if input.len() <= 0xFFFF_FFFF {
         4
     } else {
         8
@@ -390,7 +391,7 @@ pub fn compress_with_dict(
     }
 
     let hash = xxh64(input, 0);
-    let checksum = (hash & 0xFFFFFFFF) as u32;
+    let checksum = (hash & 0xFFFF_FFFF) as u32;
     output.extend_from_slice(&checksum.to_le_bytes());
 
     Ok(output)

--- a/crates/encode/src/sequences.rs
+++ b/crates/encode/src/sequences.rs
@@ -65,13 +65,13 @@ pub fn encode_sequences_section(
         }
 
         let ml_extra_bits = (ml_packed >> 24) as u8;
-        let ml_extra = ml_packed & 0xFFFFFF;
+        let ml_extra = ml_packed & 0x00FF_FFFF;
         if ml_extra_bits > 0 {
             writer.write_bits(ml_extra, ml_extra_bits);
         }
 
         let ll_extra_bits = (ll_packed >> 24) as u8;
-        let ll_extra = ll_packed & 0xFFFFFF;
+        let ll_extra = ll_packed & 0x00FF_FFFF;
         if ll_extra_bits > 0 {
             writer.write_bits(ll_extra, ll_extra_bits);
         }

--- a/crates/encode/src/streaming.rs
+++ b/crates/encode/src/streaming.rs
@@ -137,7 +137,7 @@ impl<W: Write> FrameEncoder<W> {
         self.flush_block(true)?;
 
         let hash = self.hasher.finish();
-        let checksum = (hash & 0xFFFFFFFF) as u32;
+        let checksum = (hash & 0xFFFF_FFFF) as u32;
         self.inner.write_all(&checksum.to_le_bytes())?;
         Ok(())
     }
@@ -260,7 +260,7 @@ impl<W: Write> FrameEncoder<W> {
                         );
                     }
                 }
-            };
+            }
             if self.params.force_raw_literals {
                 block_encoder::encode_compressed_block_raw(
                     &chunk,

--- a/examples/decode_compare.rs
+++ b/examples/decode_compare.rs
@@ -39,7 +39,7 @@ fn main() {
             t.elapsed().as_nanos()
         })
         .collect();
-    times.sort();
+    times.sort_unstable();
     let zrip_c_ns = times[iters / 2];
 
     // zrip decoding zrip data
@@ -56,7 +56,7 @@ fn main() {
             t.elapsed().as_nanos()
         })
         .collect();
-    times.sort();
+    times.sort_unstable();
     let zrip_z_ns = times[iters / 2];
 
     // C zstd decoding C-zstd data
@@ -77,7 +77,7 @@ fn main() {
             t.elapsed().as_nanos()
         })
         .collect();
-    times.sort();
+    times.sort_unstable();
     let c_c_ns = times[iters / 2];
 
     let mb = data.len() as f64 / 1e6;

--- a/examples/mem_profile.rs
+++ b/examples/mem_profile.rs
@@ -53,8 +53,7 @@ fn main() {
     let args: Vec<String> = std::env::args().collect();
     let path = args
         .get(1)
-        .map(|s| s.as_str())
-        .unwrap_or("corpus/dickens.txt");
+        .map_or("corpus/dickens.txt", std::string::String::as_str);
     let level: i32 = args.get(2).and_then(|s| s.parse().ok()).unwrap_or(1);
 
     let data = std::fs::read(path).unwrap();

--- a/examples/profile_czstd.rs
+++ b/examples/profile_czstd.rs
@@ -14,6 +14,6 @@ fn main() {
         let _ = black_box(ctx.compress(black_box(&data)).unwrap());
     }
     let elapsed = start.elapsed();
-    let mbs = (data.len() as f64 * iters as f64) / elapsed.as_secs_f64() / 1e6;
-    eprintln!("{:.0} MB/s C zstd encode L1 ({})", mbs, path);
+    let mbs = (data.len() as f64 * f64::from(iters)) / elapsed.as_secs_f64() / 1e6;
+    eprintln!("{mbs:.0} MB/s C zstd encode L1 ({path})");
 }

--- a/examples/profile_czstd_decode.rs
+++ b/examples/profile_czstd_decode.rs
@@ -21,5 +21,5 @@ fn main() {
     }
     let elapsed = start.elapsed();
     let mbs = (data.len() as f64 * 20.0) / elapsed.as_secs_f64() / 1e6;
-    eprintln!("{:.0} MB/s decode", mbs);
+    eprintln!("{mbs:.0} MB/s decode");
 }

--- a/examples/profile_decode.rs
+++ b/examples/profile_decode.rs
@@ -17,6 +17,6 @@ fn main() {
         let _ = black_box(ctx.decompress(black_box(&compressed)).unwrap());
     }
     let elapsed = start.elapsed();
-    let mbs = (data.len() as f64 * iters as f64) / elapsed.as_secs_f64() / 1e6;
-    eprintln!("{:.0} MB/s decode L1 ({})", mbs, path);
+    let mbs = (data.len() as f64 * f64::from(iters)) / elapsed.as_secs_f64() / 1e6;
+    eprintln!("{mbs:.0} MB/s decode L1 ({path})");
 }

--- a/examples/profile_encode.rs
+++ b/examples/profile_encode.rs
@@ -15,6 +15,6 @@ fn main() {
         let _ = black_box(zrip::compress(black_box(&data), 1).unwrap());
     }
     let elapsed = start.elapsed();
-    let mbs = (data.len() as f64 * iters as f64) / elapsed.as_secs_f64() / 1e6;
-    eprintln!("{:.0} MB/s encode L1 ({})", mbs, path);
+    let mbs = (data.len() as f64 * f64::from(iters)) / elapsed.as_secs_f64() / 1e6;
+    eprintln!("{mbs:.0} MB/s encode L1 ({path})");
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,6 @@
 //! Fast, pure-Rust zstd compression.
 //!
-//! zrip implements zstd compression levels -7 through 4 (Fast and DFast strategies),
+//! zrip implements zstd compression levels -7 through 4 (Fast and `DFast` strategies),
 //! targeting high-speed compression for data transfers. It produces standard zstd
 //! frames decompressible by any compliant decoder.
 //!
@@ -24,7 +24,7 @@
 //! | -7..=-1 | Fast | Fastest encode, lowest ratio |
 //! | 0 | | Library default (currently level 1) |
 //! | 1..=2 | Fast | Good balance for network transfers |
-//! | 3..=4 | DFast | Better ratio, still fast |
+//! | 3..=4 | `DFast` | Better ratio, still fast |
 //!
 //! # Streaming
 //!
@@ -127,6 +127,7 @@ pub fn compress_into(input: &[u8], output: &mut [u8], level: i32) -> Result<usiz
     zrip_encode::compress_into(input, output, level)
 }
 
+#[must_use]
 pub fn compress_bound(input_len: usize) -> usize {
     let num_blocks = input_len / zrip_core::frame::MAX_BLOCK_SIZE + 1;
     input_len + num_blocks * 3 + 18

--- a/tests/adversarial.rs
+++ b/tests/adversarial.rs
@@ -7,7 +7,7 @@ fn decompress_garbage_bytes_never_panics() {
         let data: Vec<u8> = (0..len)
             .map(|i| {
                 let x = seed
-                    .wrapping_mul(6364136223846793005)
+                    .wrapping_mul(6_364_136_223_846_793_005)
                     .wrapping_add(i as u64);
                 (x >> 33) as u8
             })
@@ -24,8 +24,8 @@ fn decompress_valid_frame_with_corrupt_blocks_never_panics() {
         let garbage: Vec<u8> = (0..garbage_len)
             .map(|i| {
                 let x = seed
-                    .wrapping_mul(2654435761)
-                    .wrapping_add(i as u64 * 1103515245);
+                    .wrapping_mul(2_654_435_761)
+                    .wrapping_add(i as u64 * 1_103_515_245);
                 (x >> 24) as u8
             })
             .collect();
@@ -72,7 +72,7 @@ fn decompress_truncated_at_every_byte_never_panics() {
 #[test]
 fn decompress_two_byte_flips_never_panic() {
     let original: Vec<u8> = (0..2000u32)
-        .map(|i| ((i.wrapping_mul(2654435761)) >> 24) as u8)
+        .map(|i| ((i.wrapping_mul(2_654_435_761)) >> 24) as u8)
         .collect();
     let compressed = zrip::compress(&original, 1).unwrap();
     let len = compressed.len();
@@ -145,7 +145,7 @@ fn decompress_block_header_claiming_huge_size() {
         0x00, // FHD: no checksum, no dict, fcs=0, single=0
         0x00, // window descriptor
     ];
-    let block_hdr = (131071u32 << 3) | 0b001; // last=1, raw=00
+    let block_hdr = (131_071_u32 << 3) | 0b001; // last=1, raw=00
     frame.push((block_hdr & 0xFF) as u8);
     frame.push(((block_hdr >> 8) & 0xFF) as u8);
     frame.push(((block_hdr >> 16) & 0xFF) as u8);
@@ -223,7 +223,7 @@ fn decompress_corrupt_sequence_section_never_panics() {
 #[test]
 fn decompress_corrupt_literals_section_never_panics() {
     let original: Vec<u8> = (0..8000u32)
-        .map(|i| ((i.wrapping_mul(2654435761)) >> 24) as u8)
+        .map(|i| ((i.wrapping_mul(2_654_435_761)) >> 24) as u8)
         .collect();
     let compressed = zrip::compress(&original, 1).unwrap();
 

--- a/tests/dict.rs
+++ b/tests/dict.rs
@@ -60,7 +60,7 @@ fn fastcover_improves_compression() {
 fn fastcover_various_params() {
     let samples: Vec<Vec<u8>> = (0..100)
         .map(|i| {
-            format!(r#"{{"id":{i},"name":"user_{i}","email":"user{i}@example.com"}}"#,).into_bytes()
+            format!(r#"{{"id":{i},"name":"user_{i}","email":"user{i}@example.com"}}"#).into_bytes()
         })
         .collect();
     let sample_refs: Vec<&[u8]> = samples.iter().map(|s| s.as_slice()).collect();

--- a/tests/dict.rs
+++ b/tests/dict.rs
@@ -5,11 +5,8 @@
 fn zrip_trained_dict_roundtrip() {
     let samples: Vec<Vec<u8>> = (0..100)
         .map(|i| {
-            format!(
-                r#"{{"id":{},"name":"user_{}","email":"user{}@example.com","active":true}}"#,
-                i, i, i
-            )
-            .into_bytes()
+            format!(r#"{{"id":{i},"name":"user_{i}","email":"user{i}@example.com","active":true}}"#)
+                .into_bytes()
         })
         .collect();
 
@@ -35,11 +32,8 @@ fn zrip_trained_dict_roundtrip() {
 fn fastcover_improves_compression() {
     let samples: Vec<Vec<u8>> = (0..100)
         .map(|i| {
-            format!(
-                r#"{{"id":{},"name":"user_{}","email":"user{}@example.com","active":true}}"#,
-                i, i, i
-            )
-            .into_bytes()
+            format!(r#"{{"id":{i},"name":"user_{i}","email":"user{i}@example.com","active":true}}"#)
+                .into_bytes()
         })
         .collect();
 
@@ -66,11 +60,7 @@ fn fastcover_improves_compression() {
 fn fastcover_various_params() {
     let samples: Vec<Vec<u8>> = (0..100)
         .map(|i| {
-            format!(
-                r#"{{"id":{},"name":"user_{}","email":"user{}@example.com"}}"#,
-                i, i, i,
-            )
-            .into_bytes()
+            format!(r#"{{"id":{i},"name":"user_{i}","email":"user{i}@example.com"}}"#,).into_bytes()
         })
         .collect();
     let sample_refs: Vec<&[u8]> = samples.iter().map(|s| s.as_slice()).collect();
@@ -114,7 +104,7 @@ fn fastcover_various_params() {
 fn fastcover_diverse_data_types() {
     // JSON-like
     let json_samples: Vec<Vec<u8>> = (0..100)
-        .map(|i| format!(r#"{{"key{}":"val{}"}}"#, i, i).into_bytes())
+        .map(|i| format!(r#"{{"key{i}":"val{i}"}}"#).into_bytes())
         .collect();
     let json_refs: Vec<&[u8]> = json_samples.iter().map(|s| s.as_slice()).collect();
     let dict = zrip::dict::train_dict_fastcover(
@@ -150,7 +140,7 @@ fn fastcover_diverse_data_types() {
             let mut v = vec![0x08]; // field 1, varint
             v.push((i & 0x7F) as u8);
             v.push(0x12); // field 2, length-delimited
-            let s = format!("user_{}", i);
+            let s = format!("user_{i}");
             v.push(s.len() as u8);
             v.extend_from_slice(s.as_bytes());
             v
@@ -225,11 +215,8 @@ fn fastcover_large_dict() {
 fn fastcover_all_levels() {
     let samples: Vec<Vec<u8>> = (0..100)
         .map(|i| {
-            format!(
-                r#"{{"id":{},"name":"user_{}","email":"user{}@example.com","active":true}}"#,
-                i, i, i
-            )
-            .into_bytes()
+            format!(r#"{{"id":{i},"name":"user_{i}","email":"user{i}@example.com","active":true}}"#)
+                .into_bytes()
         })
         .collect();
     let sample_refs: Vec<&[u8]> = samples.iter().map(|s| s.as_slice()).collect();
@@ -256,11 +243,8 @@ fn streaming_dict_zrip_trained_roundtrip() {
 
     let samples: Vec<Vec<u8>> = (0..100)
         .map(|i| {
-            format!(
-                r#"{{"id":{},"name":"user_{}","email":"user{}@example.com","active":true}}"#,
-                i, i, i
-            )
-            .into_bytes()
+            format!(r#"{{"id":{i},"name":"user_{i}","email":"user{i}@example.com","active":true}}"#)
+                .into_bytes()
         })
         .collect();
     let sample_refs: Vec<&[u8]> = samples.iter().map(|s| s.as_slice()).collect();
@@ -323,11 +307,8 @@ fn streaming_dict_single_byte_writes() {
 
     let samples: Vec<Vec<u8>> = (0..100)
         .map(|i| {
-            format!(
-                r#"{{"id":{},"name":"user_{}","email":"user{}@example.com","active":true}}"#,
-                i, i, i
-            )
-            .into_bytes()
+            format!(r#"{{"id":{i},"name":"user_{i}","email":"user{i}@example.com","active":true}}"#)
+                .into_bytes()
         })
         .collect();
     let sample_refs: Vec<&[u8]> = samples.iter().map(|s| s.as_slice()).collect();
@@ -364,11 +345,8 @@ fn streaming_dict_roundtrip() {
 
     let samples: Vec<Vec<u8>> = (0..100)
         .map(|i| {
-            format!(
-                r#"{{"id":{},"name":"user_{}","email":"user{}@example.com","active":true}}"#,
-                i, i, i
-            )
-            .into_bytes()
+            format!(r#"{{"id":{i},"name":"user_{i}","email":"user{i}@example.com","active":true}}"#)
+                .into_bytes()
         })
         .collect();
     let sample_refs: Vec<&[u8]> = samples.iter().map(|s| s.as_slice()).collect();
@@ -403,11 +381,8 @@ fn streaming_dict_multiblock() {
 
     let samples: Vec<Vec<u8>> = (0..100)
         .map(|i| {
-            format!(
-                r#"{{"id":{},"name":"user_{}","email":"user{}@example.com","active":true}}"#,
-                i, i, i
-            )
-            .into_bytes()
+            format!(r#"{{"id":{i},"name":"user_{i}","email":"user{i}@example.com","active":true}}"#)
+                .into_bytes()
         })
         .collect();
     let sample_refs: Vec<&[u8]> = samples.iter().map(|s| s.as_slice()).collect();
@@ -446,11 +421,8 @@ fn streaming_encoder_reset_with_dict() {
 
     let samples: Vec<Vec<u8>> = (0..100)
         .map(|i| {
-            format!(
-                r#"{{"id":{},"name":"user_{}","email":"user{}@example.com","active":true}}"#,
-                i, i, i
-            )
-            .into_bytes()
+            format!(r#"{{"id":{i},"name":"user_{i}","email":"user{i}@example.com","active":true}}"#)
+                .into_bytes()
         })
         .collect();
     let sample_refs: Vec<&[u8]> = samples.iter().map(|s| s.as_slice()).collect();
@@ -484,11 +456,8 @@ fn streaming_decoder_reset_with_dict() {
 
     let samples: Vec<Vec<u8>> = (0..100)
         .map(|i| {
-            format!(
-                r#"{{"id":{},"name":"user_{}","email":"user{}@example.com","active":true}}"#,
-                i, i, i
-            )
-            .into_bytes()
+            format!(r#"{{"id":{i},"name":"user_{i}","email":"user{i}@example.com","active":true}}"#)
+                .into_bytes()
         })
         .collect();
     let sample_refs: Vec<&[u8]> = samples.iter().map(|s| s.as_slice()).collect();
@@ -522,11 +491,8 @@ fn streaming_dict_multiblock_reset() {
 
     let samples: Vec<Vec<u8>> = (0..100)
         .map(|i| {
-            format!(
-                r#"{{"id":{},"name":"user_{}","email":"user{}@example.com","active":true}}"#,
-                i, i, i
-            )
-            .into_bytes()
+            format!(r#"{{"id":{i},"name":"user_{i}","email":"user{i}@example.com","active":true}}"#)
+                .into_bytes()
         })
         .collect();
     let sample_refs: Vec<&[u8]> = samples.iter().map(|s| s.as_slice()).collect();
@@ -561,11 +527,8 @@ fn streaming_decoder_dict_mismatch() {
 
     let samples: Vec<Vec<u8>> = (0..100)
         .map(|i| {
-            format!(
-                r#"{{"id":{},"name":"user_{}","email":"user{}@example.com","active":true}}"#,
-                i, i, i
-            )
-            .into_bytes()
+            format!(r#"{{"id":{i},"name":"user_{i}","email":"user{i}@example.com","active":true}}"#)
+                .into_bytes()
         })
         .collect();
     let sample_refs: Vec<&[u8]> = samples.iter().map(|s| s.as_slice()).collect();

--- a/tests/interop.rs
+++ b/tests/interop.rs
@@ -25,7 +25,7 @@ fn roundtrip_all_levels_c_cross_validate() {
 #[test]
 fn roundtrip_all_levels_random_c_cross_validate() {
     let original: Vec<u8> = (0..100_000u32)
-        .map(|i| ((i.wrapping_mul(2654435761)) >> 24) as u8)
+        .map(|i| ((i.wrapping_mul(2_654_435_761)) >> 24) as u8)
         .collect();
     for level in [-7, -6, -5, -4, -3, -2, -1, 1, 2, 3, 4] {
         let compressed = zrip::compress(&original, level).unwrap();
@@ -82,9 +82,9 @@ fn roundtrip_all_levels_all_patterns_c_cross_validate() {
             "random_ish",
             (0..10000u32)
                 .map(|i| {
-                    ((i as u64)
-                        .wrapping_mul(6364136223846793005u64)
-                        .wrapping_add(1442695040888963407u64)
+                    (u64::from(i)
+                        .wrapping_mul(6_364_136_223_846_793_005_u64)
+                        .wrapping_add(1_442_695_040_888_963_407_u64)
                         >> 56) as u8
                 })
                 .collect(),
@@ -110,7 +110,7 @@ fn roundtrip_exact_block_fill_c_cross_validate() {
         }
         let size = size as usize;
         let data: Vec<u8> = (0..size as u32)
-            .map(|i| ((i.wrapping_mul(2654435761)) >> 24) as u8)
+            .map(|i| ((i.wrapping_mul(2_654_435_761)) >> 24) as u8)
             .collect();
         let compressed = zrip::compress(&data, 1).unwrap();
         let c_dec = zstd::decode_all(&compressed[..]).unwrap();
@@ -123,8 +123,8 @@ fn roundtrip_incompressible_random_c_cross_validate() {
     let data: Vec<u8> = (0..50_000u64)
         .map(|i| {
             let x = i
-                .wrapping_mul(6364136223846793005)
-                .wrapping_add(1442695040888963407);
+                .wrapping_mul(6_364_136_223_846_793_005)
+                .wrapping_add(1_442_695_040_888_963_407);
             (x >> 33) as u8
         })
         .collect();
@@ -142,8 +142,8 @@ fn roundtrip_zero_literal_lengths_c_cross_validate() {
     for level in [1, 2, 3, 4] {
         let compressed = zrip::compress(&data, level).unwrap();
         let decoded = zstd::decode_all(&compressed[..])
-            .unwrap_or_else(|e| panic!("C zstd decode failed at L{}: {}", level, e));
-        assert_eq!(decoded, data, "zero-ll round-trip mismatch at L{}", level);
+            .unwrap_or_else(|e| panic!("C zstd decode failed at L{level}: {e}"));
+        assert_eq!(decoded, data, "zero-ll round-trip mismatch at L{level}");
     }
 }
 
@@ -162,11 +162,10 @@ fn roundtrip_alternating_rep_offsets_ll0_c_cross_validate() {
     for level in [1, 3] {
         let compressed = zrip::compress(&data, level).unwrap();
         let decoded = zstd::decode_all(&compressed[..])
-            .unwrap_or_else(|e| panic!("C zstd decode failed at L{}: {}", level, e));
+            .unwrap_or_else(|e| panic!("C zstd decode failed at L{level}: {e}"));
         assert_eq!(
             decoded, data,
-            "alternating rep offsets mismatch at L{}",
-            level
+            "alternating rep offsets mismatch at L{level}"
         );
     }
 }
@@ -190,8 +189,8 @@ fn roundtrip_match_length_boundaries_c_cross_validate() {
     for level in [1, 3] {
         let compressed = zrip::compress(&data, level).unwrap();
         let decoded = zstd::decode_all(&compressed[..])
-            .unwrap_or_else(|e| panic!("C zstd decode failed at L{}: {}", level, e));
-        assert_eq!(decoded, data, "ML boundary mismatch at L{}", level);
+            .unwrap_or_else(|e| panic!("C zstd decode failed at L{level}: {e}"));
+        assert_eq!(decoded, data, "ML boundary mismatch at L{level}");
     }
 }
 
@@ -206,18 +205,18 @@ fn roundtrip_single_symbol_distribution_c_cross_validate() {
     for level in [1, 3] {
         let compressed = zrip::compress(&data, level).unwrap();
         let decoded = zstd::decode_all(&compressed[..])
-            .unwrap_or_else(|e| panic!("C zstd decode failed at L{}: {}", level, e));
-        assert_eq!(decoded, data, "single-symbol FSE mismatch at L{}", level);
+            .unwrap_or_else(|e| panic!("C zstd decode failed at L{level}: {e}"));
+        assert_eq!(decoded, data, "single-symbol FSE mismatch at L{level}");
     }
 }
 
 #[test]
 fn roundtrip_large_literal_runs_c_cross_validate() {
     let mut data = Vec::with_capacity(200_000);
-    let mut rng = 0xDEADBEEFu32;
+    let mut rng = 0xDEAD_BEEF_u32;
     for _ in 0..100 {
         for _ in 0..1024 {
-            rng = rng.wrapping_mul(1664525).wrapping_add(1013904223);
+            rng = rng.wrapping_mul(1_664_525).wrapping_add(1_013_904_223);
             data.push((rng >> 16) as u8);
         }
         for j in 0..32u8 {
@@ -230,8 +229,8 @@ fn roundtrip_large_literal_runs_c_cross_validate() {
     for level in [1, 3] {
         let compressed = zrip::compress(&data, level).unwrap();
         let decoded = zstd::decode_all(&compressed[..])
-            .unwrap_or_else(|e| panic!("C zstd decode failed at L{}: {}", level, e));
-        assert_eq!(decoded, data, "large LL run mismatch at L{}", level);
+            .unwrap_or_else(|e| panic!("C zstd decode failed at L{level}: {e}"));
+        assert_eq!(decoded, data, "large LL run mismatch at L{level}");
     }
 }
 
@@ -321,9 +320,9 @@ fn compress_into_c_cross_validate() {
 #[test]
 fn rep_offset2_rotation_cross_validate() {
     let mut data = vec![0u8; 64 * 1024];
-    let mut rng = 0x12345678u32;
-    for b in data.iter_mut() {
-        rng = rng.wrapping_mul(1103515245).wrapping_add(12345);
+    let mut rng = 0x1234_5678_u32;
+    for b in &mut data {
+        rng = rng.wrapping_mul(1_103_515_245).wrapping_add(12345);
         *b = (rng >> 16) as u8 & 0x1F;
     }
     for chunk in data.chunks_mut(512) {
@@ -339,21 +338,21 @@ fn rep_offset2_rotation_cross_validate() {
     for level in [3, 4] {
         let compressed = zrip::compress(&data, level).unwrap();
         let decoded = zstd::decode_all(&compressed[..])
-            .unwrap_or_else(|e| panic!("C zstd decode failed at L{}: {}", level, e));
-        assert_eq!(decoded, data, "rep offset rotation mismatch at L{}", level);
+            .unwrap_or_else(|e| panic!("C zstd decode failed at L{level}: {e}"));
+        assert_eq!(decoded, data, "rep offset rotation mismatch at L{level}");
     }
 }
 
 #[test]
 fn roundtrip_negative_levels_cross_validate() {
     let data: Vec<u8> = (0..100_000u32)
-        .map(|i| ((i.wrapping_mul(2654435761)) >> 24) as u8)
+        .map(|i| ((i.wrapping_mul(2_654_435_761)) >> 24) as u8)
         .collect();
     for level in [-7, -6, -5, -4, -3, -2, -1] {
         let compressed = zrip::compress(&data, level).unwrap();
         let decoded = zstd::decode_all(&compressed[..])
-            .unwrap_or_else(|e| panic!("C zstd decode failed at L{}: {}", level, e));
-        assert_eq!(decoded, data, "C zstd round-trip mismatch at L{}", level);
+            .unwrap_or_else(|e| panic!("C zstd decode failed at L{level}: {e}"));
+        assert_eq!(decoded, data, "C zstd round-trip mismatch at L{level}");
     }
 }
 
@@ -370,15 +369,14 @@ fn roundtrip_corpus_l3_cross_validate() {
         "webster",
         "x-ray",
     ] {
-        let path = format!("corpus/{}", name);
-        let data = match std::fs::read(&path) {
-            Ok(d) => d,
-            Err(_) => continue,
+        let path = format!("corpus/{name}");
+        let Ok(data) = std::fs::read(&path) else {
+            continue;
         };
         let compressed = zrip::compress(&data, 3).unwrap();
         let decoded = zstd::decode_all(&compressed[..])
-            .unwrap_or_else(|e| panic!("C zstd decode failed for {} L3: {}", name, e));
-        assert_eq!(decoded, data, "C zstd round-trip mismatch for {} L3", name);
+            .unwrap_or_else(|e| panic!("C zstd decode failed for {name} L3: {e}"));
+        assert_eq!(decoded, data, "C zstd round-trip mismatch for {name} L3");
     }
 }
 
@@ -395,15 +393,14 @@ fn roundtrip_corpus_l4_cross_validate() {
         "webster",
         "x-ray",
     ] {
-        let path = format!("corpus/{}", name);
-        let data = match std::fs::read(&path) {
-            Ok(d) => d,
-            Err(_) => continue,
+        let path = format!("corpus/{name}");
+        let Ok(data) = std::fs::read(&path) else {
+            continue;
         };
         let compressed = zrip::compress(&data, 4).unwrap();
         let decoded = zstd::decode_all(&compressed[..])
-            .unwrap_or_else(|e| panic!("C zstd decode failed for {} L4: {}", name, e));
-        assert_eq!(decoded, data, "C zstd round-trip mismatch for {} L4", name);
+            .unwrap_or_else(|e| panic!("C zstd decode failed for {name} L4: {e}"));
+        assert_eq!(decoded, data, "C zstd round-trip mismatch for {name} L4");
     }
 }
 
@@ -457,7 +454,7 @@ fn decompress_c_zstd_negative_levels() {
 #[test]
 fn decompress_c_zstd_random() {
     let original: Vec<u8> = (0..100_000u32)
-        .map(|i| ((i.wrapping_mul(2654435761)) >> 24) as u8)
+        .map(|i| ((i.wrapping_mul(2_654_435_761)) >> 24) as u8)
         .collect();
     for level in [1, 3, 5, 9] {
         let compressed = zstd::encode_all(&original[..], level).unwrap();
@@ -531,9 +528,9 @@ fn decompress_c_all_levels_all_patterns() {
             "random_ish",
             (0..10000u32)
                 .map(|i| {
-                    ((i as u64)
-                        .wrapping_mul(6364136223846793005u64)
-                        .wrapping_add(1442695040888963407u64)
+                    (u64::from(i)
+                        .wrapping_mul(6_364_136_223_846_793_005_u64)
+                        .wrapping_add(1_442_695_040_888_963_407_u64)
                         >> 56) as u8
                 })
                 .collect(),
@@ -554,7 +551,7 @@ fn decompress_c_all_levels_all_patterns() {
 fn decompress_c_block_boundary_sizes() {
     for size in [128 * 1024 - 1, 128 * 1024, 128 * 1024 + 1, 200_000] {
         let original: Vec<u8> = (0..size as u32)
-            .map(|i| ((i.wrapping_mul(2654435761)) >> 24) as u8)
+            .map(|i| ((i.wrapping_mul(2_654_435_761)) >> 24) as u8)
             .collect();
         let compressed = zstd::encode_all(&original[..], 1).unwrap();
         let decompressed =
@@ -568,8 +565,8 @@ fn decompress_c_high_entropy() {
     let original: Vec<u8> = (0..50_000u32)
         .map(|i| {
             let x = i
-                .wrapping_mul(2654435761)
-                .wrapping_add(i.wrapping_mul(1103515245));
+                .wrapping_mul(2_654_435_761)
+                .wrapping_add(i.wrapping_mul(1_103_515_245));
             (x >> 16) as u8
         })
         .collect();
@@ -611,7 +608,7 @@ fn decompress_c_alternating_compressible_incompressible() {
         if i % 2 == 0 {
             original.extend(std::iter::repeat_n(0x42u8, 250));
         } else {
-            original.extend((0..250u32).map(|j| ((j + i).wrapping_mul(2654435761) >> 24) as u8));
+            original.extend((0..250u32).map(|j| ((j + i).wrapping_mul(2_654_435_761) >> 24) as u8));
         }
     }
     for level in [1, 3, 9] {
@@ -632,7 +629,7 @@ fn decompress_c_size_sweep() {
                 continue;
             }
             let original: Vec<u8> = (0..s as u32)
-                .map(|i| ((i.wrapping_mul(2654435761)) >> 24) as u8)
+                .map(|i| ((i.wrapping_mul(2_654_435_761)) >> 24) as u8)
                 .collect();
             let compressed = zstd::encode_all(&original[..], 1).unwrap();
             let decompressed =
@@ -645,7 +642,7 @@ fn decompress_c_size_sweep() {
 #[test]
 fn decompress_c_multiblock_frame() {
     let original: Vec<u8> = (0..200_000u32)
-        .map(|i| ((i.wrapping_mul(2654435761)) >> 24) as u8)
+        .map(|i| ((i.wrapping_mul(2_654_435_761)) >> 24) as u8)
         .collect();
     for level in [1, 3, 9, 19] {
         let compressed = zstd::encode_all(&original[..], level).unwrap();
@@ -673,7 +670,8 @@ fn decompress_c_long_literal_lengths() {
     let mut data = Vec::with_capacity(50_000);
     for i in 0..50 {
         data.extend(
-            (0..500u32).map(|j| ((j.wrapping_add(i * 500).wrapping_mul(2654435761)) >> 16) as u8),
+            (0..500u32)
+                .map(|j| ((j.wrapping_add(i * 500).wrapping_mul(2_654_435_761)) >> 16) as u8),
         );
         data.extend(std::iter::repeat_n(0x42u8, 500));
     }
@@ -832,7 +830,7 @@ fn decompress_c_4stream_segment_boundary_sizes() {
         997, 998, 999, 1000, 1001, 1002, 1003, 4093, 4094, 4095, 4096, 4097, 255, 256, 257,
     ] {
         let data: Vec<u8> = (0..output_size)
-            .map(|i| ((i as u32).wrapping_mul(2654435761) >> 24) as u8)
+            .map(|i| ((i as u32).wrapping_mul(2_654_435_761) >> 24) as u8)
             .collect();
         let compressed = zstd::encode_all(&data[..], 1).unwrap();
         let decompressed =
@@ -856,7 +854,7 @@ fn decompress_c_predefined_fse_tables() {
 fn decompress_c_high_accuracy_fse_tables() {
     let data: Vec<u8> = (0..50_000u32)
         .map(|i| {
-            let x = i.wrapping_mul(1103515245).wrapping_add(12345);
+            let x = i.wrapping_mul(1_103_515_245).wrapping_add(12345);
             ((x >> 16) & 0xFF) as u8
         })
         .collect();
@@ -889,12 +887,8 @@ fn decompress_c_rle_fse_tables() {
     for level in [1, 3, 6, 9] {
         let compressed = zstd::encode_all(&data[..], level).unwrap();
         let decoded = zrip::decompress(&compressed)
-            .unwrap_or_else(|e| panic!("zrip decode of C L{} failed: {}", level, e));
-        assert_eq!(
-            decoded, data,
-            "C zstd RLE FSE decode mismatch at L{}",
-            level
-        );
+            .unwrap_or_else(|e| panic!("zrip decode of C L{level} failed: {e}"));
+        assert_eq!(decoded, data, "C zstd RLE FSE decode mismatch at L{level}");
     }
 }
 
@@ -1008,7 +1002,7 @@ fn streaming_decoder_multiframe_seq_tables_reset() {
     let mut output = Vec::new();
     decoder.read_to_end(&mut output).unwrap();
 
-    let mut expected = data1.to_vec();
+    let mut expected = data1.clone();
     expected.extend_from_slice(&data2);
     assert_eq!(output, expected);
 }
@@ -1037,11 +1031,8 @@ fn streaming_encoder_reset_c_zstd_interop() {
 fn make_dict_samples() -> (Vec<Vec<u8>>, Vec<u8>) {
     let samples: Vec<Vec<u8>> = (0..100)
         .map(|i| {
-            format!(
-                r#"{{"id":{},"name":"user_{}","email":"user{}@example.com","active":true}}"#,
-                i, i, i
-            )
-            .into_bytes()
+            format!(r#"{{"id":{i},"name":"user_{i}","email":"user{i}@example.com","active":true}}"#)
+                .into_bytes()
         })
         .collect();
 
@@ -1081,7 +1072,7 @@ fn decompress_c_with_dictionary() {
         std::io::Write::write_all(&mut encoder, sample).unwrap();
         let compressed = encoder.finish().unwrap();
         let decompressed = zrip::decompress_with_dict(&compressed, &dict)
-            .unwrap_or_else(|e| panic!("dict decompress failed: {}", e));
+            .unwrap_or_else(|e| panic!("dict decompress failed: {e}"));
         assert_eq!(&decompressed, sample);
     }
 }
@@ -1323,7 +1314,7 @@ fn decompress_skippable_frame_before_c_data() {
     let compressed = zstd::encode_all(&payload[..], 1).unwrap();
 
     let mut stream = Vec::new();
-    stream.extend_from_slice(&0x184D2A50u32.to_le_bytes());
+    stream.extend_from_slice(&0x184D_2A50_u32.to_le_bytes());
     stream.extend_from_slice(&(b"skip me".len() as u32).to_le_bytes());
     stream.extend_from_slice(b"skip me");
     stream.extend_from_slice(&compressed);
@@ -1341,7 +1332,7 @@ fn decompress_skippable_frame_between_c_data_frames() {
 
     let mut stream = Vec::new();
     stream.extend_from_slice(&c1);
-    stream.extend_from_slice(&0x184D2A5Fu32.to_le_bytes());
+    stream.extend_from_slice(&0x184D_2A5F_u32.to_le_bytes());
     stream.extend_from_slice(&4u32.to_le_bytes());
     stream.extend_from_slice(b"skip");
     stream.extend_from_slice(&c2);

--- a/tests/interop.rs
+++ b/tests/interop.rs
@@ -1132,7 +1132,7 @@ fn fastcover_c_zstd_cross_validates() {
         .map(|i| {
             format!(
                 r#"{{"ts":{},"level":"info","msg":"request processed","user_id":{},"latency_ms":{}}}"#,
-                1700000000 + i,
+                1_700_000_000 + i,
                 i % 50,
                 i * 3 + 10,
             )

--- a/tests/roundtrip.rs
+++ b/tests/roundtrip.rs
@@ -22,7 +22,7 @@ fn roundtrip_all_levels_repetitive() {
 #[test]
 fn roundtrip_all_levels_random() {
     let original: Vec<u8> = (0..100_000u32)
-        .map(|i| ((i.wrapping_mul(2654435761)) >> 24) as u8)
+        .map(|i| ((i.wrapping_mul(2_654_435_761)) >> 24) as u8)
         .collect();
     for level in [-7, -6, -5, -4, -3, -2, -1, 1, 2, 3, 4] {
         let compressed = zrip::compress(&original, level).unwrap();
@@ -138,9 +138,9 @@ fn roundtrip_all_levels_all_patterns() {
             "random_ish",
             (0..10000u32)
                 .map(|i| {
-                    ((i as u64)
-                        .wrapping_mul(6364136223846793005u64)
-                        .wrapping_add(1442695040888963407u64)
+                    (u64::from(i)
+                        .wrapping_mul(6_364_136_223_846_793_005_u64)
+                        .wrapping_add(1_442_695_040_888_963_407_u64)
                         >> 56) as u8
                 })
                 .collect(),
@@ -166,7 +166,7 @@ fn roundtrip_exact_block_fill() {
         }
         let size = size as usize;
         let data: Vec<u8> = (0..size as u32)
-            .map(|i| ((i.wrapping_mul(2654435761)) >> 24) as u8)
+            .map(|i| ((i.wrapping_mul(2_654_435_761)) >> 24) as u8)
             .collect();
         let compressed = zrip::compress(&data, 1).unwrap();
         let decompressed = zrip::decompress(&compressed).unwrap();
@@ -179,8 +179,8 @@ fn roundtrip_incompressible_random() {
     let data: Vec<u8> = (0..50_000u64)
         .map(|i| {
             let x = i
-                .wrapping_mul(6364136223846793005)
-                .wrapping_add(1442695040888963407);
+                .wrapping_mul(6_364_136_223_846_793_005)
+                .wrapping_add(1_442_695_040_888_963_407);
             (x >> 33) as u8
         })
         .collect();
@@ -201,8 +201,8 @@ fn roundtrip_mixed_compressible_incompressible() {
         } else {
             data.extend((0..250u64).map(|j| {
                 let x = (i * 1000 + j)
-                    .wrapping_mul(6364136223846793005)
-                    .wrapping_add(1442695040888963407);
+                    .wrapping_mul(6_364_136_223_846_793_005)
+                    .wrapping_add(1_442_695_040_888_963_407);
                 (x >> 33) as u8
             }));
         }
@@ -223,8 +223,8 @@ fn roundtrip_zero_literal_lengths() {
     for level in [1, 2, 3, 4] {
         let compressed = zrip::compress(&data, level).unwrap();
         let decoded = zrip::decompress(&compressed)
-            .unwrap_or_else(|e| panic!("decode failed at L{}: {}", level, e));
-        assert_eq!(decoded, data, "zero-ll round-trip mismatch at L{}", level);
+            .unwrap_or_else(|e| panic!("decode failed at L{level}: {e}"));
+        assert_eq!(decoded, data, "zero-ll round-trip mismatch at L{level}");
     }
 }
 
@@ -243,11 +243,10 @@ fn roundtrip_alternating_rep_offsets_ll0() {
     for level in [1, 3] {
         let compressed = zrip::compress(&data, level).unwrap();
         let decoded = zrip::decompress(&compressed)
-            .unwrap_or_else(|e| panic!("decode failed at L{}: {}", level, e));
+            .unwrap_or_else(|e| panic!("decode failed at L{level}: {e}"));
         assert_eq!(
             decoded, data,
-            "alternating rep offsets mismatch at L{}",
-            level
+            "alternating rep offsets mismatch at L{level}"
         );
     }
 }
@@ -273,8 +272,8 @@ fn roundtrip_match_length_boundaries() {
     for level in [1, 3] {
         let compressed = zrip::compress(&data, level).unwrap();
         let decoded = zrip::decompress(&compressed)
-            .unwrap_or_else(|e| panic!("decode failed at L{}: {}", level, e));
-        assert_eq!(decoded, data, "ML boundary mismatch at L{}", level);
+            .unwrap_or_else(|e| panic!("decode failed at L{level}: {e}"));
+        assert_eq!(decoded, data, "ML boundary mismatch at L{level}");
     }
 }
 
@@ -291,8 +290,8 @@ fn roundtrip_single_symbol_distribution() {
     for level in [1, 3] {
         let compressed = zrip::compress(&data, level).unwrap();
         let decoded = zrip::decompress(&compressed)
-            .unwrap_or_else(|e| panic!("decode failed at L{}: {}", level, e));
-        assert_eq!(decoded, data, "single-symbol FSE mismatch at L{}", level);
+            .unwrap_or_else(|e| panic!("decode failed at L{level}: {e}"));
+        assert_eq!(decoded, data, "single-symbol FSE mismatch at L{level}");
     }
 }
 
@@ -301,10 +300,10 @@ fn roundtrip_single_symbol_distribution() {
 #[test]
 fn roundtrip_large_literal_runs() {
     let mut data = Vec::with_capacity(200_000);
-    let mut rng = 0xDEADBEEFu32;
+    let mut rng = 0xDEAD_BEEF_u32;
     for _ in 0..100 {
         for _ in 0..1024 {
-            rng = rng.wrapping_mul(1664525).wrapping_add(1013904223);
+            rng = rng.wrapping_mul(1_664_525).wrapping_add(1_013_904_223);
             data.push((rng >> 16) as u8);
         }
         for j in 0..32u8 {
@@ -317,8 +316,8 @@ fn roundtrip_large_literal_runs() {
     for level in [1, 3] {
         let compressed = zrip::compress(&data, level).unwrap();
         let decoded = zrip::decompress(&compressed)
-            .unwrap_or_else(|e| panic!("decode failed at L{}: {}", level, e));
-        assert_eq!(decoded, data, "large LL run mismatch at L{}", level);
+            .unwrap_or_else(|e| panic!("decode failed at L{level}: {e}"));
+        assert_eq!(decoded, data, "large LL run mismatch at L{level}");
     }
 }
 
@@ -384,7 +383,7 @@ fn checksum_mismatch_detected() {
 fn checksum_various_sizes() {
     for size in [0, 1, 100, 1000, 10000, 100_000] {
         let original: Vec<u8> = (0..size as u32)
-            .map(|i| ((i.wrapping_mul(2654435761)) >> 24) as u8)
+            .map(|i| ((i.wrapping_mul(2_654_435_761)) >> 24) as u8)
             .collect();
         let compressed = zrip::compress(&original, 1).unwrap();
         let decompressed = zrip::decompress(&compressed).unwrap();
@@ -584,7 +583,7 @@ fn decompress_skippable_frame_before_data() {
     let compressed = zrip::compress(payload, 1).unwrap();
 
     let mut stream = Vec::new();
-    stream.extend_from_slice(&0x184D2A50u32.to_le_bytes());
+    stream.extend_from_slice(&0x184D_2A50_u32.to_le_bytes());
     stream.extend_from_slice(&(b"skip me".len() as u32).to_le_bytes());
     stream.extend_from_slice(b"skip me");
     stream.extend_from_slice(&compressed);
@@ -602,7 +601,7 @@ fn decompress_skippable_frame_between_data_frames() {
 
     let mut stream = Vec::new();
     stream.extend_from_slice(&c1);
-    stream.extend_from_slice(&0x184D2A5Fu32.to_le_bytes());
+    stream.extend_from_slice(&0x184D_2A5F_u32.to_le_bytes());
     stream.extend_from_slice(&4u32.to_le_bytes());
     stream.extend_from_slice(b"skip");
     stream.extend_from_slice(&c2);


### PR DESCRIPTION
- Fix UB in SIMD decode: out-of-bounds pointer arithmetic in `wildcopy_neon_write32`
- Remove dead `decode_sequences_neon` (undefined variables, would fail on aarch64)
- Fix `eprintln!("")` clippy warning
- Split monolithic test file into focused modules, make tests Miri-compatible
- Remove stale version badge from README
- Bump all crate versions to 0.3.1