### PR TITLE
Harden unsafe boundaries and recover throughput

### DIFF
--- a/crates/core/src/bitstream/reader_reverse.rs
+++ b/crates/core/src/bitstream/reader_reverse.rs
@@ -137,8 +137,10 @@ impl<'a> ReverseBitReader<'a> {
 
     #[inline(always)]
     pub fn refill_fast(&mut self) {
-        debug_assert!(self.ptr >= self.limit_ptr);
         let byte_shift = (self.bits_consumed >> 3) as usize;
+        debug_assert!(self.ptr >= self.limit_ptr);
+        debug_assert!(byte_shift <= self.ptr);
+        debug_assert!(self.ptr - byte_shift + 8 <= self.data.len());
         self.ptr -= byte_shift;
         self.bits_consumed -= (byte_shift as u32) * 8;
         self.container = primitives::read_u64_le_unaligned(self.data, self.ptr);

--- a/crates/core/src/huffman/decode.rs
+++ b/crates/core/src/huffman/decode.rs
@@ -72,15 +72,24 @@ pub fn decode_single_stream_vec(
     output.clear();
     output.reserve(output_size);
     primitives::set_vec_len(output, output_size);
+    let result;
     #[cfg(target_arch = "x86_64")]
     {
         if crate::simd::cpu_tier() >= crate::simd::CpuTier::Bmi2 {
-            return super::decode_4stream::decode_single_stream_bmi2_safe(
+            result = super::decode_4stream::decode_single_stream_bmi2_safe(
                 table, table_log, data, output,
             );
+            if result.is_err() {
+                output.clear();
+            }
+            return result;
         }
     }
-    decode_single_stream_into(table, table_log, data, output)
+    result = decode_single_stream_into(table, table_log, data, output);
+    if result.is_err() {
+        output.clear();
+    }
+    result
 }
 
 pub fn decode_4_streams(
@@ -104,19 +113,29 @@ pub fn decode_4_streams_into(
     output.clear();
     output.reserve(output_size);
     primitives::set_vec_len(output, output_size);
+    let result;
     #[cfg(target_arch = "x86_64")]
     {
         if crate::simd::cpu_tier() >= crate::simd::CpuTier::Bmi2 {
-            return super::decode_4stream::decode_4_streams_core_bmi2_safe(
+            result = super::decode_4stream::decode_4_streams_core_bmi2_safe(
                 table,
                 table_log,
                 data,
                 output_size,
                 output,
             );
+            if result.is_err() {
+                output.clear();
+            }
+            return result;
         }
     }
-    super::decode_4stream::decode_4_streams_core(table, table_log, data, output_size, output)
+    result =
+        super::decode_4stream::decode_4_streams_core(table, table_log, data, output_size, output);
+    if result.is_err() {
+        output.clear();
+    }
+    result
 }
 
 pub(super) fn decode_stream_tail(

--- a/crates/core/src/simd/scalar.rs
+++ b/crates/core/src/simd/scalar.rs
@@ -8,7 +8,7 @@ use core::ptr;
 /// - `src` must be valid for reads of `len` bytes.
 /// - `dst` must be valid for writes of `len` bytes.
 /// - Regions may NOT overlap.
-#[inline]
+#[inline(always)]
 pub unsafe fn wildcopy_nonoverlap(src: *const u8, dst: *mut u8, len: usize) {
     debug_assert!(len > 0);
     unsafe {
@@ -29,7 +29,7 @@ pub unsafe fn wildcopy_nonoverlap(src: *const u8, dst: *mut u8, len: usize) {
 /// # Safety
 /// - `dst` must point to a buffer with at least `len + 7` bytes of writable space.
 /// - `dst - offset` must be a valid readable position within the same allocation.
-#[inline]
+#[inline(always)]
 pub unsafe fn copy_match(dst: *mut u8, offset: usize, len: usize) {
     debug_assert!(offset > 0);
     debug_assert!(len > 0);
@@ -43,7 +43,7 @@ pub unsafe fn copy_match(dst: *mut u8, offset: usize, len: usize) {
     }
 }
 
-#[inline]
+#[inline(always)]
 unsafe fn copy_match_overlapping(mut dst: *mut u8, offset: usize, len: usize) {
     unsafe {
         let end = dst.add(len);

--- a/crates/decode/src/exec.rs
+++ b/crates/decode/src/exec.rs
@@ -18,6 +18,9 @@ pub fn decode_execute_sequences(
     output: &mut Vec<u8>,
     history: &[u8],
 ) -> Result<(), DecompressError> {
+    if num_sequences == 0 {
+        return Ok(());
+    }
     if data.is_empty() {
         return Err(DecompressError::CorruptSequences);
     }

--- a/crates/decode/src/primitives.rs
+++ b/crates/decode/src/primitives.rs
@@ -26,6 +26,7 @@ pub(crate) fn ptr_gt(a: *const u8, b: *const u8) -> bool {
 
 #[inline(always)]
 pub(crate) fn ptr_offset_from_mut(a: *mut u8, b: *mut u8) -> usize {
+    debug_assert!(a >= b);
     unsafe { a.offset_from(b) as usize }
 }
 

--- a/crates/decode/src/simd_decode/x86_64/decode.rs
+++ b/crates/decode/src/simd_decode/x86_64/decode.rs
@@ -318,7 +318,7 @@ pub unsafe fn decode_execute_avx2(
         }
     } else {
         unsafe {
-            decode_execute_avx2_inner::<true>(
+            decode_execute_avx2_with_history(
                 seq_data,
                 num_sequences,
                 tables,
@@ -328,6 +328,30 @@ pub unsafe fn decode_execute_avx2(
                 history,
             )
         }
+    }
+}
+
+#[target_feature(enable = "avx2,bmi2")]
+#[inline(never)]
+unsafe fn decode_execute_avx2_with_history(
+    seq_data: &[u8],
+    num_sequences: u32,
+    tables: &SequenceDecodeTables,
+    rep_offsets: &mut [u32; 3],
+    literals: &[u8],
+    output: &mut Vec<u8>,
+    history: &[u8],
+) -> Result<(), DecompressError> {
+    unsafe {
+        decode_execute_avx2_inner::<true>(
+            seq_data,
+            num_sequences,
+            tables,
+            rep_offsets,
+            literals,
+            output,
+            history,
+        )
     }
 }
 

--- a/crates/decode/src/simd_decode/x86_64/decode.rs
+++ b/crates/decode/src/simd_decode/x86_64/decode.rs
@@ -22,6 +22,9 @@ unsafe fn decode_execute_avx2_inner<const HAS_HISTORY: bool>(
     output: &mut Vec<u8>,
     history: &[u8],
 ) -> Result<(), DecompressError> {
+    if num_sequences == 0 {
+        return Ok(());
+    }
     if seq_data.is_empty() {
         return Err(DecompressError::CorruptSequences);
     }
@@ -380,7 +383,7 @@ unsafe fn copy_match_from_history(
 
 /// Safe wrapper around `decode_execute_avx2`.
 /// Caller must have verified AVX2+BMI2 availability via `CpuTier::Avx2`.
-pub fn decode_execute_avx2_safe(
+pub(crate) fn decode_execute_avx2_safe(
     seq_data: &[u8],
     num_sequences: u32,
     tables: &SequenceDecodeTables,

--- a/crates/encode/src/block_encoder.rs
+++ b/crates/encode/src/block_encoder.rs
@@ -141,6 +141,7 @@ impl FseEncodeTable {
         let nb_bits_out = tt.delta_nb_bits.wrapping_add(1 << 15) >> 16;
         let base_state = (nb_bits_out << 16).wrapping_sub(tt.delta_nb_bits);
         let idx = (base_state >> nb_bits_out) as i32 + tt.delta_find_state;
+        debug_assert!(idx >= 0);
         primitives::slice_get(&self.state_table, idx as usize) as u32
     }
 }
@@ -637,6 +638,7 @@ fn encode_seq_predefined(packed: &[PackedSeq], output: &mut Vec<u8>, writer_buf:
             let nb = (tt.delta_nb_bits.wrapping_add($state)) >> 16;
             add_bits!($state & ((1u32 << nb) - 1), nb);
             let idx = ($state >> nb) as i32 + tt.delta_find_state;
+            debug_assert!(idx >= 0);
             $state = primitives::slice_get(&$table.state_table, idx as usize) as u32;
         }};
     }

--- a/crates/encode/src/block_encoder.rs
+++ b/crates/encode/src/block_encoder.rs
@@ -361,7 +361,7 @@ fn pack_sequences_and_literals(
     let mut rep1 = rep_offsets[1];
     let mut rep2 = rep_offsets[2];
 
-    for seq in &sequences[..n] {
+    for (i, seq) in sequences[..n].iter().enumerate() {
         let ll = seq.literal_length as usize;
         if lit_offset + ll <= src_len {
             primitives::copy_literals_fast(src, lit_offset, &mut workspace.lit_buf, lit_pos, ll);
@@ -423,14 +423,19 @@ fn pack_sequences_and_literals(
             | ((of_extra as u64) << (ll_nb + ml_nb));
         let extra_nbits = ll_nb + ml_nb + of_c;
 
-        workspace.packed_seqs.push(PackedSeq {
-            extra_bits,
-            ll_c,
-            ml_c,
-            of_c,
-            extra_nbits,
-        });
+        primitives::vec_write_at(
+            &mut workspace.packed_seqs,
+            i,
+            PackedSeq {
+                extra_bits,
+                ll_c,
+                ml_c,
+                of_c,
+                extra_nbits,
+            },
+        );
     }
+    primitives::set_vec_len(&mut workspace.packed_seqs, n);
     rep_offsets[0] = rep0;
     rep_offsets[1] = rep1;
     rep_offsets[2] = rep2;

--- a/crates/encode/src/primitives.rs
+++ b/crates/encode/src/primitives.rs
@@ -84,6 +84,8 @@ unsafe fn count_match_raw(
 
 #[inline(always)]
 pub(crate) fn assert_rep_valid(r0: u32, r1: u32) {
+    debug_assert!(r0 > 0);
+    debug_assert!(r1 > 0);
     unsafe {
         core::hint::assert_unchecked(r0 > 0);
         core::hint::assert_unchecked(r1 > 0);
@@ -127,6 +129,7 @@ pub(crate) fn copy_literals_fast(
         let s = src.as_ptr().add(src_off);
         let d = dst.as_mut_ptr().add(dst_off);
         if len <= 16 && src_off + 16 <= src.len() {
+            debug_assert!(dst_off + 16 <= dst.capacity());
             (d as *mut u64).write_unaligned((s as *const u64).read_unaligned());
             (d.add(8) as *mut u64).write_unaligned((s.add(8) as *const u64).read_unaligned());
         } else {

--- a/crates/encode/src/primitives.rs
+++ b/crates/encode/src/primitives.rs
@@ -44,6 +44,7 @@ pub(crate) fn match_at<const MLS: usize>(src: &[u8], a: usize, b: usize) -> bool
     }
 }
 
+#[inline(always)]
 pub(crate) fn count_match(src: &[u8], p1: usize, p2: usize, limit: usize) -> usize {
     debug_assert!(p1 <= limit && limit <= src.len());
     debug_assert!(p2 < src.len());
@@ -146,6 +147,12 @@ pub(crate) fn bitstream_flush(buf: &mut Vec<u8>, pos: usize, bits: u64) {
 pub(crate) fn bitstream_write_byte(buf: &mut Vec<u8>, pos: usize, val: u8) {
     debug_assert!(pos < buf.capacity());
     unsafe { *buf.as_mut_ptr().add(pos) = val }
+}
+
+#[inline(always)]
+pub(crate) fn vec_write_at<T>(vec: &mut Vec<T>, idx: usize, val: T) {
+    debug_assert!(idx < vec.capacity());
+    unsafe { vec.as_mut_ptr().add(idx).write(val) }
 }
 
 #[inline(always)]

--- a/doc/charts/x86_64/matrix.svg
+++ b/doc/charts/x86_64/matrix.svg
@@ -18,9 +18,9 @@
   <rect x="95.3" y="233.2" width="50.0" height="36.8" fill="#60a5fa" rx="1"/>
   <rect x="95.3" y="200.0" width="50.0" height="33.1" fill="#4680c4" rx="1"/>
   <rect x="95.3" y="187.6" width="50.0" height="12.4" fill="#60a5fa" rx="1"/>
-  <rect x="147.8" y="219.7" width="50.0" height="50.3" fill="#f87171" rx="1"/>
-  <rect x="147.8" y="184.7" width="50.0" height="35.0" fill="#c45050" rx="1"/>
-  <rect x="147.8" y="157.4" width="50.0" height="27.3" fill="#f87171" rx="1"/>
+  <rect x="147.8" y="220.3" width="50.0" height="49.7" fill="#f87171" rx="1"/>
+  <rect x="147.8" y="185.4" width="50.0" height="35.0" fill="#c45050" rx="1"/>
+  <rect x="147.8" y="158.1" width="50.0" height="27.3" fill="#f87171" rx="1"/>
   <rect x="200.3" y="196.5" width="50.0" height="73.5" fill="#f59e0b" rx="1"/>
   <rect x="200.3" y="165.7" width="50.0" height="30.8" fill="#c47d08" rx="1"/>
   <rect x="200.3" y="137.4" width="50.0" height="28.3" fill="#f59e0b" rx="1"/>
@@ -28,9 +28,9 @@
   <rect x="348.7" y="230.3" width="50.0" height="39.7" fill="#60a5fa" rx="1"/>
   <rect x="348.7" y="202.4" width="50.0" height="27.8" fill="#4680c4" rx="1"/>
   <rect x="348.7" y="189.3" width="50.0" height="13.2" fill="#60a5fa" rx="1"/>
-  <rect x="401.2" y="214.7" width="50.0" height="55.3" fill="#f87171" rx="1"/>
-  <rect x="401.2" y="182.8" width="50.0" height="31.9" fill="#c45050" rx="1"/>
-  <rect x="401.2" y="151.8" width="50.0" height="31.0" fill="#f87171" rx="1"/>
+  <rect x="401.2" y="215.6" width="50.0" height="54.4" fill="#f87171" rx="1"/>
+  <rect x="401.2" y="183.7" width="50.0" height="31.9" fill="#c45050" rx="1"/>
+  <rect x="401.2" y="153.0" width="50.0" height="30.7" fill="#f87171" rx="1"/>
   <rect x="453.7" y="194.9" width="50.0" height="75.1" fill="#f59e0b" rx="1"/>
   <rect x="453.7" y="164.7" width="50.0" height="30.1" fill="#c47d08" rx="1"/>
   <rect x="453.7" y="136.4" width="50.0" height="28.4" fill="#f59e0b" rx="1"/>
@@ -38,9 +38,9 @@
   <rect x="602.0" y="216.8" width="50.0" height="53.2" fill="#60a5fa" rx="1"/>
   <rect x="602.0" y="190.8" width="50.0" height="26.1" fill="#4680c4" rx="1"/>
   <rect x="602.0" y="177.0" width="50.0" height="13.8" fill="#60a5fa" rx="1"/>
-  <rect x="654.5" y="204.2" width="50.0" height="65.8" fill="#f87171" rx="1"/>
-  <rect x="654.5" y="174.5" width="50.0" height="29.7" fill="#c45050" rx="1"/>
-  <rect x="654.5" y="147.6" width="50.0" height="26.9" fill="#f87171" rx="1"/>
+  <rect x="654.5" y="205.1" width="50.0" height="64.9" fill="#f87171" rx="1"/>
+  <rect x="654.5" y="175.3" width="50.0" height="29.7" fill="#c45050" rx="1"/>
+  <rect x="654.5" y="148.7" width="50.0" height="26.7" fill="#f87171" rx="1"/>
   <rect x="707.0" y="153.4" width="50.0" height="116.6" fill="#f59e0b" rx="1"/>
   <rect x="707.0" y="124.2" width="50.0" height="29.3" fill="#c47d08" rx="1"/>
   <rect x="707.0" y="96.1" width="50.0" height="28.1" fill="#f59e0b" rx="1"/>
@@ -58,9 +58,9 @@
   <rect x="95.3" y="511.6" width="50.0" height="33.4" fill="#60a5fa" rx="1"/>
   <rect x="95.3" y="469.6" width="50.0" height="42.0" fill="#4680c4" rx="1"/>
   <rect x="95.3" y="461.2" width="50.0" height="8.5" fill="#60a5fa" rx="1"/>
-  <rect x="147.8" y="498.7" width="50.0" height="46.3" fill="#f87171" rx="1"/>
-  <rect x="147.8" y="456.8" width="50.0" height="41.9" fill="#c45050" rx="1"/>
-  <rect x="147.8" y="440.7" width="50.0" height="16.1" fill="#f87171" rx="1"/>
+  <rect x="147.8" y="499.9" width="50.0" height="45.1" fill="#f87171" rx="1"/>
+  <rect x="147.8" y="458.0" width="50.0" height="41.9" fill="#c45050" rx="1"/>
+  <rect x="147.8" y="441.7" width="50.0" height="16.2" fill="#f87171" rx="1"/>
   <rect x="200.3" y="485.6" width="50.0" height="59.4" fill="#f59e0b" rx="1"/>
   <rect x="200.3" y="449.0" width="50.0" height="36.6" fill="#c47d08" rx="1"/>
   <rect x="200.3" y="429.9" width="50.0" height="19.1" fill="#f59e0b" rx="1"/>
@@ -68,9 +68,9 @@
   <rect x="348.7" y="508.9" width="50.0" height="36.1" fill="#60a5fa" rx="1"/>
   <rect x="348.7" y="473.9" width="50.0" height="35.0" fill="#4680c4" rx="1"/>
   <rect x="348.7" y="464.0" width="50.0" height="9.9" fill="#60a5fa" rx="1"/>
-  <rect x="401.2" y="491.2" width="50.0" height="53.8" fill="#f87171" rx="1"/>
-  <rect x="401.2" y="453.7" width="50.0" height="37.5" fill="#c45050" rx="1"/>
-  <rect x="401.2" y="433.1" width="50.0" height="20.6" fill="#f87171" rx="1"/>
+  <rect x="401.2" y="492.3" width="50.0" height="52.7" fill="#f87171" rx="1"/>
+  <rect x="401.2" y="454.8" width="50.0" height="37.5" fill="#c45050" rx="1"/>
+  <rect x="401.2" y="434.1" width="50.0" height="20.6" fill="#f87171" rx="1"/>
   <rect x="453.7" y="484.3" width="50.0" height="60.7" fill="#f59e0b" rx="1"/>
   <rect x="453.7" y="449.0" width="50.0" height="35.3" fill="#c47d08" rx="1"/>
   <rect x="453.7" y="429.7" width="50.0" height="19.3" fill="#f59e0b" rx="1"/>
@@ -78,9 +78,9 @@
   <rect x="602.0" y="484.6" width="50.0" height="60.4" fill="#60a5fa" rx="1"/>
   <rect x="602.0" y="453.0" width="50.0" height="31.6" fill="#4680c4" rx="1"/>
   <rect x="602.0" y="441.5" width="50.0" height="11.5" fill="#60a5fa" rx="1"/>
-  <rect x="654.5" y="475.4" width="50.0" height="69.6" fill="#f87171" rx="1"/>
-  <rect x="654.5" y="439.6" width="50.0" height="35.7" fill="#c45050" rx="1"/>
-  <rect x="654.5" y="423.0" width="50.0" height="16.7" fill="#f87171" rx="1"/>
+  <rect x="654.5" y="475.7" width="50.0" height="69.3" fill="#f87171" rx="1"/>
+  <rect x="654.5" y="440.0" width="50.0" height="35.7" fill="#c45050" rx="1"/>
+  <rect x="654.5" y="423.3" width="50.0" height="16.6" fill="#f87171" rx="1"/>
   <rect x="707.0" y="425.9" width="50.0" height="119.1" fill="#f59e0b" rx="1"/>
   <rect x="707.0" y="393.6" width="50.0" height="32.3" fill="#c47d08" rx="1"/>
   <rect x="707.0" y="371.1" width="50.0" height="22.5" fill="#f59e0b" rx="1"/>
@@ -96,9 +96,9 @@
   <rect x="95.3" y="808.5" width="50.0" height="11.5" fill="#60a5fa" rx="1"/>
   <rect x="95.3" y="745.3" width="50.0" height="63.2" fill="#4680c4" rx="1"/>
   <rect x="95.3" y="743.6" width="50.0" height="1.7" fill="#60a5fa" rx="1"/>
-  <rect x="147.8" y="808.3" width="50.0" height="11.7" fill="#f87171" rx="1"/>
-  <rect x="147.8" y="744.8" width="50.0" height="63.5" fill="#c45050" rx="1"/>
-  <rect x="147.8" y="741.9" width="50.0" height="2.8" fill="#f87171" rx="1"/>
+  <rect x="147.8" y="808.5" width="50.0" height="11.5" fill="#f87171" rx="1"/>
+  <rect x="147.8" y="745.0" width="50.0" height="63.5" fill="#c45050" rx="1"/>
+  <rect x="147.8" y="742.1" width="50.0" height="2.9" fill="#f87171" rx="1"/>
   <rect x="200.3" y="782.9" width="50.0" height="37.1" fill="#f59e0b" rx="1"/>
   <rect x="200.3" y="727.4" width="50.0" height="55.5" fill="#c47d08" rx="1"/>
   <rect x="200.3" y="719.1" width="50.0" height="8.4" fill="#f59e0b" rx="1"/>
@@ -106,8 +106,8 @@
   <rect x="348.7" y="801.4" width="50.0" height="18.6" fill="#60a5fa" rx="1"/>
   <rect x="348.7" y="746.5" width="50.0" height="54.8" fill="#4680c4" rx="1"/>
   <rect x="348.7" y="739.8" width="50.0" height="6.7" fill="#60a5fa" rx="1"/>
-  <rect x="401.2" y="789.1" width="50.0" height="30.9" fill="#f87171" rx="1"/>
-  <rect x="401.2" y="730.7" width="50.0" height="58.4" fill="#c45050" rx="1"/>
+  <rect x="401.2" y="789.2" width="50.0" height="30.8" fill="#f87171" rx="1"/>
+  <rect x="401.2" y="730.8" width="50.0" height="58.4" fill="#c45050" rx="1"/>
   <rect x="401.2" y="724.3" width="50.0" height="6.5" fill="#f87171" rx="1"/>
   <rect x="453.7" y="781.1" width="50.0" height="38.9" fill="#f59e0b" rx="1"/>
   <rect x="453.7" y="726.2" width="50.0" height="54.8" fill="#c47d08" rx="1"/>
@@ -116,9 +116,9 @@
   <rect x="602.0" y="751.7" width="50.0" height="68.3" fill="#60a5fa" rx="1"/>
   <rect x="602.0" y="702.8" width="50.0" height="48.9" fill="#4680c4" rx="1"/>
   <rect x="602.0" y="693.0" width="50.0" height="9.9" fill="#60a5fa" rx="1"/>
-  <rect x="654.5" y="765.2" width="50.0" height="54.8" fill="#f87171" rx="1"/>
-  <rect x="654.5" y="709.9" width="50.0" height="55.3" fill="#c45050" rx="1"/>
-  <rect x="654.5" y="702.8" width="50.0" height="7.1" fill="#f87171" rx="1"/>
+  <rect x="654.5" y="764.8" width="50.0" height="55.2" fill="#f87171" rx="1"/>
+  <rect x="654.5" y="709.5" width="50.0" height="55.3" fill="#c45050" rx="1"/>
+  <rect x="654.5" y="702.3" width="50.0" height="7.1" fill="#f87171" rx="1"/>
   <rect x="707.0" y="709.2" width="50.0" height="110.8" fill="#f59e0b" rx="1"/>
   <rect x="707.0" y="659.2" width="50.0" height="50.0" fill="#c47d08" rx="1"/>
   <rect x="707.0" y="646.1" width="50.0" height="13.1" fill="#f59e0b" rx="1"/>

--- a/doc/charts/x86_64/scatter.svg
+++ b/doc/charts/x86_64/scatter.svg
@@ -40,23 +40,23 @@
   <text x="488.6" y="93.7" text-anchor="start" fill="#60a5fa" font-size="8" font-weight="600">3</text>
   <circle cx="479.9" cy="93.7" r="3.5" fill="#60a5fa" stroke="#0d1117" stroke-width="1"/>
   <text x="473.9" y="93.7" text-anchor="end" fill="#60a5fa" font-size="8" font-weight="600">4</text>
-  <path d="M541.3,256.7L509.3,233.7L501.6,223.3L498.4,212.7L494.4,199.3L491.2,179.6L487.9,160.5L472.2,140.9L468.9,138.6L441.2,124.9L441.1,124.1" fill="none" stroke="#f87171" stroke-width="1.5" stroke-opacity="0.6"/>
-  <circle cx="541.3" cy="256.7" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
-  <text x="547.3" y="256.7" text-anchor="start" fill="#f87171" font-size="8" font-weight="600">-7</text>
-  <circle cx="509.3" cy="233.7" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
-  <circle cx="501.6" cy="223.3" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
-  <circle cx="498.4" cy="212.7" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
-  <text x="504.4" y="212.7" text-anchor="start" fill="#f87171" font-size="8" font-weight="600">-4</text>
-  <circle cx="494.4" cy="199.3" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
-  <circle cx="491.2" cy="179.6" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
-  <circle cx="487.9" cy="160.5" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
-  <text x="493.9" y="160.5" text-anchor="start" fill="#f87171" font-size="8" font-weight="600">-1</text>
-  <circle cx="472.2" cy="140.9" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
-  <circle cx="468.9" cy="138.6" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
-  <circle cx="441.2" cy="124.9" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
-  <text x="447.2" y="124.9" text-anchor="start" fill="#f87171" font-size="8" font-weight="600">3</text>
-  <circle cx="441.1" cy="124.1" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
-  <text x="435.1" y="124.1" text-anchor="end" fill="#f87171" font-size="8" font-weight="600">4</text>
+  <path d="M540.4,256.7L507.3,233.7L499.8,223.3L496.9,212.7L493.5,199.3L490.3,179.6L487.6,160.5L472.3,140.9L469.5,138.6L443.0,124.9L442.9,124.1" fill="none" stroke="#f87171" stroke-width="1.5" stroke-opacity="0.6"/>
+  <circle cx="540.4" cy="256.7" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
+  <text x="546.4" y="256.7" text-anchor="start" fill="#f87171" font-size="8" font-weight="600">-7</text>
+  <circle cx="507.3" cy="233.7" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
+  <circle cx="499.8" cy="223.3" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
+  <circle cx="496.9" cy="212.7" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
+  <text x="502.9" y="212.7" text-anchor="start" fill="#f87171" font-size="8" font-weight="600">-4</text>
+  <circle cx="493.5" cy="199.3" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
+  <circle cx="490.3" cy="179.6" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
+  <circle cx="487.6" cy="160.5" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
+  <text x="493.6" y="160.5" text-anchor="start" fill="#f87171" font-size="8" font-weight="600">-1</text>
+  <circle cx="472.3" cy="140.9" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
+  <circle cx="469.5" cy="138.6" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
+  <circle cx="443.0" cy="124.9" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
+  <text x="449.0" y="124.9" text-anchor="start" fill="#f87171" font-size="8" font-weight="600">3</text>
+  <circle cx="442.9" cy="124.1" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
+  <text x="436.9" y="124.1" text-anchor="end" fill="#f87171" font-size="8" font-weight="600">4</text>
   <path d="M425.0,215.2L423.2,208.9L422.1,201.9L418.9,193.8L415.8,181.6L412.5,171.1L408.3,164.9L404.9,161.4L391.4,157.0L336.9,159.8L337.6,158.5" fill="none" stroke="#f59e0b" stroke-width="1.5" stroke-opacity="0.6"/>
   <circle cx="425.0" cy="215.2" r="3.5" fill="#f59e0b" stroke="#0d1117" stroke-width="1"/>
   <text x="431.0" y="215.2" text-anchor="start" fill="#f59e0b" font-size="8" font-weight="600">-7</text>
@@ -118,23 +118,23 @@
   <text x="330.3" y="410.9" text-anchor="start" fill="#60a5fa" font-size="8" font-weight="600">3</text>
   <circle cx="318.8" cy="407.3" r="3.5" fill="#60a5fa" stroke="#0d1117" stroke-width="1"/>
   <text x="312.8" y="407.3" text-anchor="end" fill="#60a5fa" font-size="8" font-weight="600">4</text>
-  <path d="M412.9,580.5L387.9,556.0L383.5,550.6L379.3,542.7L372.7,530.1L367.3,519.2L360.7,507.3L340.5,474.7L327.4,463.7L295.1,464.7L294.1,460.9" fill="none" stroke="#f87171" stroke-width="1.5" stroke-opacity="0.6"/>
-  <circle cx="412.9" cy="580.5" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
-  <text x="418.9" y="580.5" text-anchor="start" fill="#f87171" font-size="8" font-weight="600">-7</text>
-  <circle cx="387.9" cy="556.0" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
-  <circle cx="383.5" cy="550.6" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
-  <circle cx="379.3" cy="542.7" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
-  <text x="385.3" y="542.7" text-anchor="start" fill="#f87171" font-size="8" font-weight="600">-4</text>
-  <circle cx="372.7" cy="530.1" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
-  <circle cx="367.3" cy="519.2" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
-  <circle cx="360.7" cy="507.3" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
-  <text x="366.7" y="507.3" text-anchor="start" fill="#f87171" font-size="8" font-weight="600">-1</text>
-  <circle cx="340.5" cy="474.7" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
-  <circle cx="327.4" cy="463.7" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
-  <circle cx="295.1" cy="464.7" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
-  <text x="301.1" y="464.7" text-anchor="start" fill="#f87171" font-size="8" font-weight="600">3</text>
-  <circle cx="294.1" cy="460.9" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
-  <text x="288.1" y="460.9" text-anchor="end" fill="#f87171" font-size="8" font-weight="600">4</text>
+  <path d="M417.6,580.5L390.3,556.0L386.0,550.6L382.0,542.7L375.6,530.1L370.1,519.2L363.7,507.3L341.2,474.7L329.7,463.7L298.0,464.7L296.2,460.9" fill="none" stroke="#f87171" stroke-width="1.5" stroke-opacity="0.6"/>
+  <circle cx="417.6" cy="580.5" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
+  <text x="423.6" y="580.5" text-anchor="start" fill="#f87171" font-size="8" font-weight="600">-7</text>
+  <circle cx="390.3" cy="556.0" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
+  <circle cx="386.0" cy="550.6" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
+  <circle cx="382.0" cy="542.7" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
+  <text x="388.0" y="542.7" text-anchor="start" fill="#f87171" font-size="8" font-weight="600">-4</text>
+  <circle cx="375.6" cy="530.1" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
+  <circle cx="370.1" cy="519.2" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
+  <circle cx="363.7" cy="507.3" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
+  <text x="369.7" y="507.3" text-anchor="start" fill="#f87171" font-size="8" font-weight="600">-1</text>
+  <circle cx="341.2" cy="474.7" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
+  <circle cx="329.7" cy="463.7" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
+  <circle cx="298.0" cy="464.7" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
+  <text x="304.0" y="464.7" text-anchor="start" fill="#f87171" font-size="8" font-weight="600">3</text>
+  <circle cx="296.2" cy="460.9" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
+  <text x="290.2" y="460.9" text-anchor="end" fill="#f87171" font-size="8" font-weight="600">4</text>
   <path d="M357.1,500.4L355.1,496.6L351.4,491.9L347.5,485.2L342.8,477.6L337.5,469.7L329.7,462.0L326.6,446.5L293.4,420.8L218.1,410.6L215.2,404.1" fill="none" stroke="#f59e0b" stroke-width="1.5" stroke-opacity="0.6"/>
   <circle cx="357.1" cy="500.4" r="3.5" fill="#f59e0b" stroke="#0d1117" stroke-width="1"/>
   <text x="363.1" y="500.4" text-anchor="start" fill="#f59e0b" font-size="8" font-weight="600">-7</text>
@@ -198,23 +198,23 @@
   <text x="258.4" y="734.2" text-anchor="start" fill="#60a5fa" font-size="8" font-weight="600">3</text>
   <circle cx="239.3" cy="703.9" r="3.5" fill="#60a5fa" stroke="#0d1117" stroke-width="1"/>
   <text x="245.3" y="703.9" text-anchor="start" fill="#60a5fa" font-size="8" font-weight="600">4</text>
-  <path d="M718.0,907.4L722.6,908.2L672.5,903.7L628.1,896.6L607.1,893.4L600.5,894.8L542.3,887.0L378.1,842.3L315.8,808.8L292.9,812.8L280.0,792.6" fill="none" stroke="#f87171" stroke-width="1.5" stroke-opacity="0.6"/>
-  <circle cx="718.0" cy="907.4" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
-  <text x="724.0" y="907.4" text-anchor="start" fill="#f87171" font-size="8" font-weight="600">-7</text>
-  <circle cx="722.6" cy="908.2" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
-  <circle cx="672.5" cy="903.7" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
-  <circle cx="628.1" cy="896.6" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
-  <text x="634.1" y="896.6" text-anchor="start" fill="#f87171" font-size="8" font-weight="600">-4</text>
-  <circle cx="607.1" cy="893.4" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
-  <circle cx="600.5" cy="894.8" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
-  <circle cx="542.3" cy="887.0" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
-  <text x="548.3" y="887.0" text-anchor="start" fill="#f87171" font-size="8" font-weight="600">-1</text>
-  <circle cx="378.1" cy="842.3" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
-  <circle cx="315.8" cy="808.8" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
-  <circle cx="292.9" cy="812.8" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
-  <text x="298.9" y="812.8" text-anchor="start" fill="#f87171" font-size="8" font-weight="600">3</text>
-  <circle cx="280.0" cy="792.6" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
-  <text x="286.0" y="792.6" text-anchor="start" fill="#f87171" font-size="8" font-weight="600">4</text>
+  <path d="M712.4,907.4L716.6,908.2L668.5,903.7L625.7,896.6L605.6,893.4L600.1,894.8L544.9,887.0L378.6,842.3L318.9,808.8L292.5,812.8L279.4,792.6" fill="none" stroke="#f87171" stroke-width="1.5" stroke-opacity="0.6"/>
+  <circle cx="712.4" cy="907.4" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
+  <text x="718.4" y="907.4" text-anchor="start" fill="#f87171" font-size="8" font-weight="600">-7</text>
+  <circle cx="716.6" cy="908.2" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
+  <circle cx="668.5" cy="903.7" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
+  <circle cx="625.7" cy="896.6" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
+  <text x="631.7" y="896.6" text-anchor="start" fill="#f87171" font-size="8" font-weight="600">-4</text>
+  <circle cx="605.6" cy="893.4" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
+  <circle cx="600.1" cy="894.8" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
+  <circle cx="544.9" cy="887.0" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
+  <text x="550.9" y="887.0" text-anchor="start" fill="#f87171" font-size="8" font-weight="600">-1</text>
+  <circle cx="378.6" cy="842.3" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
+  <circle cx="318.9" cy="808.8" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
+  <circle cx="292.5" cy="812.8" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
+  <text x="298.5" y="812.8" text-anchor="start" fill="#f87171" font-size="8" font-weight="600">3</text>
+  <circle cx="279.4" cy="792.6" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
+  <text x="285.4" y="792.6" text-anchor="start" fill="#f87171" font-size="8" font-weight="600">4</text>
   <path d="M374.3,824.5L374.5,825.4L370.6,823.1L367.2,821.3L361.1,817.3L358.1,817.7L347.5,814.5L340.4,807.6L289.7,780.6L177.5,748.4L142.4,716.5" fill="none" stroke="#f59e0b" stroke-width="1.5" stroke-opacity="0.6"/>
   <circle cx="374.3" cy="824.5" r="3.5" fill="#f59e0b" stroke="#0d1117" stroke-width="1"/>
   <text x="380.3" y="824.5" text-anchor="start" fill="#f59e0b" font-size="8" font-weight="600">-7</text>

--- a/doc/charts/x86_64/summary.svg
+++ b/doc/charts/x86_64/summary.svg
@@ -14,9 +14,9 @@
   <rect x="167.0" y="259.0" width="80.0" height="22.8" fill="#4680c4" rx="1"/>
   <rect x="167.0" y="252.0" width="80.0" height="7.0" fill="#60a5fa" rx="1"/>
   <text x="207.0" y="321" text-anchor="middle" fill="#e6edf3" font-size="10" font-weight="600">C zstd</text>
-  <rect x="279.0" y="270.7" width="80.0" height="34.3" fill="#f87171" rx="1"/>
-  <rect x="279.0" y="245.6" width="80.0" height="25.1" fill="#c45050" rx="1"/>
-  <rect x="279.0" y="233.6" width="80.0" height="12.0" fill="#f87171" rx="1"/>
+  <rect x="279.0" y="270.8" width="80.0" height="34.2" fill="#f87171" rx="1"/>
+  <rect x="279.0" y="245.7" width="80.0" height="25.1" fill="#c45050" rx="1"/>
+  <rect x="279.0" y="233.5" width="80.0" height="12.1" fill="#f87171" rx="1"/>
   <text x="319.0" y="321" text-anchor="middle" fill="#e6edf3" font-size="10" font-weight="600">zrip</text>
   <rect x="391.0" y="260.0" width="80.0" height="45.0" fill="#f59e0b" rx="1"/>
   <rect x="391.0" y="230.7" width="80.0" height="29.3" fill="#c47d08" rx="1"/>


### PR DESCRIPTION
- Recover encode and decode throughput lost in unsafe encapsulation refactor (`copy_match` inlining, direct `wildcopy_16` in scalar exec, bitstream flush elision)
- Reset Huffman output Vec on decode error to prevent exposing uninitialized memory
- Guard `num_sequences == 0` in `decode_execute_sequences` and AVX2 decoder to prevent `u32` underflow
- Add `debug_assert!` before `assert_unchecked` in `assert_rep_valid` (was the only unsafe wrapper without one)
- Restrict `decode_execute_avx2_safe` to `pub(crate)` (safe wrapper around `target_feature` function)
- Strengthen `refill_fast` debug_asserts (byte_shift bounds, data length)
- Add `debug_assert!` for 16-byte fast path write width in `copy_literals_fast`
- Guard negative `i32`-to-`usize` cast in FSE `init_state` and `encode_transition!`
- Add `debug_assert!(a >= b)` in `ptr_offset_from_mut`
- Update benchmark charts