### PR TITLE
Fix aarch64 NEON decode path

### DIFF
--- a/crates/decode/src/simd_decode/aarch64/decode.rs
+++ b/crates/decode/src/simd_decode/aarch64/decode.rs
@@ -1,18 +1,18 @@
 #[cfg(feature = "alloc")]
 use alloc::vec::Vec;
 
-use crate::sequences::{SequenceDecodeTables, compute_offset};
+#[cfg(target_arch = "aarch64")]
+use core::arch::aarch64::*;
+
+use crate::sequences::SequenceDecodeTables;
 use zrip_core::bitstream::reader_reverse::ReverseBitReader;
 use zrip_core::error::DecompressError;
 use zrip_core::fse::FseSeqDecodeEntry;
 use zrip_core::hint::{likely, unlikely};
 
-/// Fused sequence decode + execute with NEON wildcopy.
-/// Uses raw `op` pointer throughout the loop to eliminate per-sequence Vec overhead.
-///
 /// # Safety
 /// Must be called on aarch64 with NEON available (always true on ARMv8-A).
-pub unsafe fn decode_execute_neon(
+unsafe fn decode_execute_neon_inner<const HAS_HISTORY: bool>(
     seq_data: &[u8],
     num_sequences: u32,
     tables: &SequenceDecodeTables,
@@ -21,6 +21,9 @@ pub unsafe fn decode_execute_neon(
     output: &mut Vec<u8>,
     history: &[u8],
 ) -> Result<(), DecompressError> {
+    if num_sequences == 0 {
+        return Ok(());
+    }
     if seq_data.is_empty() {
         return Err(DecompressError::CorruptSequences);
     }
@@ -33,148 +36,251 @@ pub unsafe fn decode_execute_neon(
     let mut ml_state = init_state(&tables.ml_table, tables.ml_accuracy, &mut rev_reader)?;
 
     const WILDCOPY_OVERLENGTH: usize = 64;
-    output.reserve(zrip_core::frame::MAX_BLOCK_SIZE + WILDCOPY_OVERLENGTH);
+    let max_output = zrip_core::frame::MAX_BLOCK_SIZE;
+    output.reserve(max_output + WILDCOPY_OVERLENGTH);
 
     let out_base = output.as_mut_ptr();
     let mut op = unsafe { out_base.add(output.len()) };
     let op_limit = unsafe { out_base.add(output.capacity() - WILDCOPY_OVERLENGTH) };
-    let lit_ptr = literals.as_ptr();
-    let mut lit_off: usize = 0;
+
+    let of_tbl = tables.of_table.as_ptr();
+    let ml_tbl = tables.ml_table.as_ptr();
+    let ll_tbl = tables.ll_table.as_ptr();
     let of_mask = ((1u32 << tables.of_accuracy) - 1) as usize;
     let ml_mask = ((1u32 << tables.ml_accuracy) - 1) as usize;
     let ll_mask = ((1u32 << tables.ll_accuracy) - 1) as usize;
+    let lit_ptr = literals.as_ptr();
+    let lit_end = unsafe { lit_ptr.add(literals.len()) };
+    let hist_len = if HAS_HISTORY { history.len() } else { 0 };
+    let mut lit_pos = lit_ptr;
 
-    macro_rules! decode_fields {
-        ($rev_reader:expr, $rep_offsets:expr) => {{
-            let of_e = tables.of_table[of_state as usize & of_mask];
-            let ml_e = tables.ml_table[ml_state as usize & ml_mask];
-            let ll_e = tables.ll_table[ll_state as usize & ll_mask];
+    let mut bs_container = rev_reader.container;
+    let mut bs_consumed = rev_reader.bits_consumed;
+    let seq_base = seq_data.as_ptr();
+    let mut bs_ptr = unsafe { seq_base.add(rev_reader.ptr) };
+    let bs_fast_limit_off = rev_reader.limit_ptr.saturating_add(16);
 
-            let of_extra = $rev_reader.read_bits_branchless(of_e.extra_bits);
-            let offset_value = of_e.baseline_value + of_extra;
+    let last_seq = num_sequences - 1;
 
-            let ml_extra = $rev_reader.read_bits_branchless(ml_e.extra_bits);
-            let match_length = ml_e.baseline_value + ml_extra;
+    let mut rep0 = rep_offsets[0];
+    let mut rep1 = rep_offsets[1];
+    let mut rep2 = rep_offsets[2];
 
-            let ll_extra = $rev_reader.read_bits_branchless(ll_e.extra_bits);
-            let literal_length = ll_e.baseline_value + ll_extra;
-
-            let offset = compute_offset(offset_value, literal_length, $rep_offsets);
-            (literal_length, match_length, offset)
+    macro_rules! read_bits {
+        ($n:expr) => {{
+            let r = ((bs_container << (bs_consumed & 63)) >> 1 >> (63 - $n as u32)) as u32;
+            bs_consumed += $n as u32;
+            r
         }};
     }
 
-    macro_rules! update_fse_states {
-        ($rev_reader:expr) => {{
-            let ll_entry = tables.ll_table[ll_state as usize & ll_mask];
-            let ml_entry = tables.ml_table[ml_state as usize & ml_mask];
-            let of_entry = tables.of_table[of_state as usize & of_mask];
+    macro_rules! refill_fast {
+        () => {{
+            let byte_shift = (bs_consumed >> 3) as usize;
+            bs_ptr = unsafe { bs_ptr.sub(byte_shift) };
+            bs_consumed -= (byte_shift as u32) * 8;
+            bs_container = unsafe { (bs_ptr as *const u64).read_unaligned() };
+        }};
+    }
 
-            ll_state =
-                ll_entry.base_line as u32 + $rev_reader.read_bits_branchless(ll_entry.num_bits);
-            ml_state =
-                ml_entry.base_line as u32 + $rev_reader.read_bits_branchless(ml_entry.num_bits);
-            of_state =
-                of_entry.base_line as u32 + $rev_reader.read_bits_branchless(of_entry.num_bits);
+    macro_rules! compute_offset_inline {
+        ($offset_value:expr, $literal_length:expr) => {{
+            let ov = $offset_value;
+            if ov > 3 {
+                let offset = ov - 3;
+                rep2 = rep1;
+                rep1 = rep0;
+                rep0 = offset;
+                offset
+            } else {
+                let ll0 = ($literal_length == 0) as u32;
+                let rep_idx = ov - 1 + ll0;
+                let offset = if rep_idx == 0 {
+                    rep0
+                } else if rep_idx == 1 {
+                    rep1
+                } else if rep_idx == 2 {
+                    rep2
+                } else {
+                    rep0.wrapping_sub(1)
+                };
+                if rep_idx >= 2 {
+                    rep2 = rep1;
+                }
+                if rep_idx >= 1 {
+                    rep1 = rep0;
+                }
+                rep0 = offset;
+                offset
+            }
+        }};
+    }
+
+    macro_rules! decode_and_update {
+        () => {{
+            refill_fast!();
+
+            let of_e = unsafe { *of_tbl.add(of_state as usize & of_mask) };
+            let ml_e = unsafe { *ml_tbl.add(ml_state as usize & ml_mask) };
+            let ll_e = unsafe { *ll_tbl.add(ll_state as usize & ll_mask) };
+
+            let offset_value = of_e.baseline_value + read_bits!(of_e.extra_bits);
+            let match_length = ml_e.baseline_value + read_bits!(ml_e.extra_bits);
+            let literal_length = ll_e.baseline_value + read_bits!(ll_e.extra_bits);
+
+            let offset = compute_offset_inline!(offset_value, literal_length);
+
+            refill_fast!();
+            ll_state = ll_e.base_line as u32 + read_bits!(ll_e.num_bits);
+            ml_state = ml_e.base_line as u32 + read_bits!(ml_e.num_bits);
+            of_state = of_e.base_line as u32 + read_bits!(of_e.num_bits);
+
+            (literal_length, match_length, offset)
         }};
     }
 
     macro_rules! execute_seq {
         ($literal_length:expr, $match_length:expr, $offset:expr) => {{
             let ll = $literal_length as usize;
-            let ml_check = $match_length as usize;
-            if unlikely(unsafe { op.add(ll + ml_check) } > op_limit) {
+            let ml = $match_length as usize;
+            if unlikely(unsafe { op.add(ll + ml) } > op_limit) {
                 return Err(DecompressError::CorruptSequences);
             }
-            if unlikely(lit_off + ll > literals.len()) {
-                return Err(DecompressError::CorruptLiterals);
+            let lit_remaining = unsafe { lit_end.offset_from(lit_pos) } as usize;
+            if unlikely(ll > lit_remaining) {
+                return Err(DecompressError::CorruptSequences);
             }
-            if ll > 0 {
-                unsafe {
-                    let src = lit_ptr.add(lit_off);
-                    (op as *mut u64).write_unaligned((src as *const u64).read_unaligned());
-                    (op.add(8) as *mut u64)
-                        .write_unaligned((src.add(8) as *const u64).read_unaligned());
+            unsafe {
+                if lit_remaining >= 16 {
+                    let chunk = vld1q_u8(lit_pos);
+                    vst1q_u8(op, chunk);
                     if ll > 16 {
-                        core::ptr::copy_nonoverlapping(src.add(16), op.add(16), ll - 16);
+                        core::ptr::copy_nonoverlapping(lit_pos.add(16), op.add(16), ll - 16);
                     }
+                } else if ll > 0 {
+                    core::ptr::copy_nonoverlapping(lit_pos, op, ll);
                 }
-                op = unsafe { op.add(ll) };
-                lit_off += ll;
+                op = op.add(ll);
+                lit_pos = lit_pos.add(ll);
             }
 
-            let ml = $match_length as usize;
             let offset = $offset;
             if unlikely(offset == 0) {
                 return Err(DecompressError::CorruptSequences);
             }
             let off = offset as usize;
             let out_pos = unsafe { op.offset_from(out_base) } as usize;
-            if unlikely(off > out_pos + history.len()) {
+            if unlikely(off > out_pos + hist_len) {
+                return Err(DecompressError::CorruptSequences);
+            }
+            if unlikely(ml == 0) {
                 return Err(DecompressError::CorruptSequences);
             }
             unsafe {
-                if likely(off <= out_pos) {
-                    super::neon::copy_match_neon(op, off, ml);
+                if !HAS_HISTORY || likely(off <= out_pos) {
+                    if off >= 16 {
+                        let mut s = op.sub(off);
+                        let mut d = op;
+                        let end = op.add(ml);
+                        loop {
+                            let chunk = vld1q_u8(s);
+                            vst1q_u8(d, chunk);
+                            s = s.add(16);
+                            d = d.add(16);
+                            if d >= end {
+                                break;
+                            }
+                        }
+                    } else if off >= 8 {
+                        let s = op.sub(off);
+                        (op as *mut u64).write_unaligned((s as *const u64).read_unaligned());
+                        (op.add(8) as *mut u64)
+                            .write_unaligned((s.add(8) as *const u64).read_unaligned());
+                        if ml > 16 {
+                            let mut cs = s.add(16);
+                            let mut cd = op.add(16);
+                            let end = op.add(ml);
+                            while cd < end {
+                                (cd as *mut u64)
+                                    .write_unaligned((cs as *const u64).read_unaligned());
+                                cs = cs.add(8);
+                                cd = cd.add(8);
+                            }
+                        }
+                    } else {
+                        zrip_core::simd::scalar::copy_match(op, off, ml);
+                    }
                 } else {
-                    copy_match_from_history(op, history, off, out_pos, ml);
+                    copy_match_from_history(op, out_base, history, off, out_pos, ml);
                 }
+                op = op.add(ml);
             }
-            op = unsafe { op.add(ml) };
         }};
     }
 
-    let last_seq = num_sequences - 1;
-    let mut seq_idx: u32 = 0;
-    let fast_limit = rev_reader.limit_ptr.saturating_add(16);
-    while seq_idx + 2 <= last_seq && rev_reader.ptr >= fast_limit {
-        rev_reader.refill_fast();
-        let (ll1, ml1, off1) = decode_fields!(rev_reader, rep_offsets);
-        rev_reader.refill_fast();
-        update_fse_states!(rev_reader);
-        execute_seq!(ll1, ml1, off1);
-
-        rev_reader.refill_fast();
-        let (ll2, ml2, off2) = decode_fields!(rev_reader, rep_offsets);
-        rev_reader.refill_fast();
-        update_fse_states!(rev_reader);
-        execute_seq!(ll2, ml2, off2);
-
-        seq_idx += 2;
-    }
-    while seq_idx < last_seq && rev_reader.ptr >= fast_limit {
-        rev_reader.refill_fast();
-        let (ll, ml, off) = decode_fields!(rev_reader, rep_offsets);
-        rev_reader.refill_fast();
-        update_fse_states!(rev_reader);
+    let mut remaining = last_seq;
+    while remaining > 0 && unsafe { bs_ptr.offset_from(seq_base) } as usize >= bs_fast_limit_off {
+        let (ll, ml, off) = decode_and_update!();
         execute_seq!(ll, ml, off);
-        seq_idx += 1;
+        remaining -= 1;
     }
-    while seq_idx < last_seq {
+
+    // Slow path: restore ReverseBitReader for checked refills
+    rev_reader.container = bs_container;
+    rev_reader.bits_consumed = bs_consumed;
+    rev_reader.ptr = unsafe { bs_ptr.offset_from(seq_data.as_ptr()) } as usize;
+
+    while remaining > 0 {
         rev_reader.refill();
-        let (ll, ml, off) = decode_fields!(rev_reader, rep_offsets);
+
+        let of_e = unsafe { *of_tbl.add(of_state as usize & of_mask) };
+        let ml_e = unsafe { *ml_tbl.add(ml_state as usize & ml_mask) };
+        let ll_e = unsafe { *ll_tbl.add(ll_state as usize & ll_mask) };
+
+        let of_extra = rev_reader.read_bits_branchless(of_e.extra_bits);
+        let offset_value = of_e.baseline_value + of_extra;
+        let ml_extra = rev_reader.read_bits_branchless(ml_e.extra_bits);
+        let match_length = ml_e.baseline_value + ml_extra;
+        let ll_extra = rev_reader.read_bits_branchless(ll_e.extra_bits);
+        let literal_length = ll_e.baseline_value + ll_extra;
+        let offset = compute_offset_inline!(offset_value, literal_length);
+
         rev_reader.refill();
-        update_fse_states!(rev_reader);
-        execute_seq!(ll, ml, off);
-        seq_idx += 1;
+        ll_state = ll_e.base_line as u32 + rev_reader.read_bits_branchless(ll_e.num_bits);
+        ml_state = ml_e.base_line as u32 + rev_reader.read_bits_branchless(ml_e.num_bits);
+        of_state = of_e.base_line as u32 + rev_reader.read_bits_branchless(of_e.num_bits);
+
+        execute_seq!(literal_length, match_length, offset);
+        remaining -= 1;
     }
 
     // Last sequence: no FSE state update
-    {
+    if num_sequences > 0 {
         rev_reader.refill();
-        let (ll, ml, off) = decode_fields!(rev_reader, rep_offsets);
-        execute_seq!(ll, ml, off);
+        let of_e = unsafe { *of_tbl.add(of_state as usize & of_mask) };
+        let ml_e = unsafe { *ml_tbl.add(ml_state as usize & ml_mask) };
+        let ll_e = unsafe { *ll_tbl.add(ll_state as usize & ll_mask) };
+        let offset_value = of_e.baseline_value + rev_reader.read_bits_branchless(of_e.extra_bits);
+        let match_length = ml_e.baseline_value + rev_reader.read_bits_branchless(ml_e.extra_bits);
+        let literal_length = ll_e.baseline_value + rev_reader.read_bits_branchless(ll_e.extra_bits);
+        let offset = compute_offset_inline!(offset_value, literal_length);
+        execute_seq!(literal_length, match_length, offset);
     }
 
-    if lit_off < literals.len() {
-        let remaining = literals.len() - lit_off;
+    rep_offsets[0] = rep0;
+    rep_offsets[1] = rep1;
+    rep_offsets[2] = rep2;
+
+    // Trailing literals
+    if lit_pos < lit_end {
+        let remaining = unsafe { lit_end.offset_from(lit_pos) } as usize;
         if unsafe { op.add(remaining) } > unsafe { out_base.add(output.capacity()) } {
             return Err(DecompressError::CorruptSequences);
         }
         unsafe {
-            core::ptr::copy_nonoverlapping(lit_ptr.add(lit_off), op, remaining);
+            core::ptr::copy_nonoverlapping(lit_pos, op, remaining);
+            op = op.add(remaining);
         }
-        op = unsafe { op.add(remaining) };
     }
 
     let new_len = unsafe { op.offset_from(out_base) } as usize;
@@ -188,8 +294,71 @@ pub unsafe fn decode_execute_neon(
     Ok(())
 }
 
+/// Fused sequence decode + execute with NEON wildcopy.
+///
+/// # Safety
+/// Must be called on aarch64 with NEON available (always true on ARMv8-A).
+pub unsafe fn decode_execute_neon(
+    seq_data: &[u8],
+    num_sequences: u32,
+    tables: &SequenceDecodeTables,
+    rep_offsets: &mut [u32; 3],
+    literals: &[u8],
+    output: &mut Vec<u8>,
+    history: &[u8],
+) -> Result<(), DecompressError> {
+    if history.is_empty() {
+        unsafe {
+            decode_execute_neon_inner::<false>(
+                seq_data,
+                num_sequences,
+                tables,
+                rep_offsets,
+                literals,
+                output,
+                history,
+            )
+        }
+    } else {
+        unsafe {
+            decode_execute_neon_with_history(
+                seq_data,
+                num_sequences,
+                tables,
+                rep_offsets,
+                literals,
+                output,
+                history,
+            )
+        }
+    }
+}
+
+#[inline(never)]
+unsafe fn decode_execute_neon_with_history(
+    seq_data: &[u8],
+    num_sequences: u32,
+    tables: &SequenceDecodeTables,
+    rep_offsets: &mut [u32; 3],
+    literals: &[u8],
+    output: &mut Vec<u8>,
+    history: &[u8],
+) -> Result<(), DecompressError> {
+    unsafe {
+        decode_execute_neon_inner::<true>(
+            seq_data,
+            num_sequences,
+            tables,
+            rep_offsets,
+            literals,
+            output,
+            history,
+        )
+    }
+}
+
 /// Safe wrapper around `decode_execute_neon`.
-pub fn decode_execute_neon_safe(
+pub(crate) fn decode_execute_neon_safe(
     seq_data: &[u8],
     num_sequences: u32,
     tables: &SequenceDecodeTables,
@@ -223,6 +392,7 @@ fn init_state(
 #[inline(always)]
 unsafe fn copy_match_from_history(
     op: *mut u8,
+    _out_base: *const u8,
     history: &[u8],
     offset: usize,
     out_pos: usize,
@@ -236,8 +406,24 @@ unsafe fn copy_match_from_history(
     }
     let remaining = match_length - from_history;
     if remaining > 0 {
+        let dst = unsafe { op.add(from_history) };
         unsafe {
-            super::neon::copy_match_neon(op.add(from_history), offset, remaining);
+            if offset >= 16 {
+                let mut s = dst.sub(offset);
+                let mut d = dst;
+                let end = dst.add(remaining);
+                loop {
+                    let chunk = vld1q_u8(s);
+                    vst1q_u8(d, chunk);
+                    s = s.add(16);
+                    d = d.add(16);
+                    if d >= end {
+                        break;
+                    }
+                }
+            } else {
+                zrip_core::simd::scalar::copy_match(dst, offset, remaining);
+            }
         }
     }
 }

--- a/doc/charts/aarch64/matrix.svg
+++ b/doc/charts/aarch64/matrix.svg
@@ -1,0 +1,133 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 850 940" font-family="system-ui, -apple-system, sans-serif">
+  <rect width="850" height="940" fill="#0d1117"/>
+  <text x="450.0" y="22" text-anchor="middle" fill="#e6edf3" font-size="14" font-weight="700">zstd Pipeline @100 MB/s: Aggregate across corpus (lower is better)</text>
+  <text x="22" y="435.0" text-anchor="middle" fill="#e6edf3" font-size="11" font-weight="600" transform="rotate(-90,22,435.0)">seconds / GB</text>
+  <text x="450.0" y="54" text-anchor="middle" fill="#e6edf3" font-size="12" font-weight="600">High compressibility</text>
+  <line x1="70" y1="218.9" x2="830" y2="218.9" stroke="#21262d" stroke-width="1"/>
+  <text x="62" y="218.9" text-anchor="end" dominant-baseline="middle" fill="#7d8590" font-size="10">1.0</text>
+  <line x1="70" y1="177.7" x2="830" y2="177.7" stroke="#21262d" stroke-width="1"/>
+  <text x="62" y="177.7" text-anchor="end" dominant-baseline="middle" fill="#7d8590" font-size="10">2.0</text>
+  <line x1="70" y1="136.6" x2="830" y2="136.6" stroke="#21262d" stroke-width="1"/>
+  <text x="62" y="136.6" text-anchor="end" dominant-baseline="middle" fill="#7d8590" font-size="10">3.0</text>
+  <line x1="70" y1="95.4" x2="830" y2="95.4" stroke="#21262d" stroke-width="1"/>
+  <text x="62" y="95.4" text-anchor="end" dominant-baseline="middle" fill="#7d8590" font-size="10">4.0</text>
+  <line x1="70" y1="260" x2="830" y2="260" stroke="#30363d" stroke-width="1.5"/>
+  <rect x="95.3" y="226.5" width="50.0" height="33.5" fill="#60a5fa" rx="1"/>
+  <rect x="95.3" y="153.1" width="50.0" height="73.4" fill="#4680c4" rx="1"/>
+  <rect x="95.3" y="142.0" width="50.0" height="11.0" fill="#60a5fa" rx="1"/>
+  <rect x="147.8" y="213.0" width="50.0" height="47.0" fill="#f87171" rx="1"/>
+  <rect x="147.8" y="134.9" width="50.0" height="78.1" fill="#c45050" rx="1"/>
+  <rect x="147.8" y="110.9" width="50.0" height="24.0" fill="#f87171" rx="1"/>
+  <rect x="200.3" y="199.3" width="50.0" height="60.7" fill="#f59e0b" rx="1"/>
+  <rect x="200.3" y="135.8" width="50.0" height="63.6" fill="#c47d08" rx="1"/>
+  <rect x="200.3" y="111.8" width="50.0" height="24.0" fill="#f59e0b" rx="1"/>
+  <text x="196.7" y="278" text-anchor="middle" fill="#e6edf3" font-size="11" font-weight="600">Level −1</text>
+  <rect x="348.7" y="223.7" width="50.0" height="36.3" fill="#60a5fa" rx="1"/>
+  <rect x="348.7" y="161.5" width="50.0" height="62.2" fill="#4680c4" rx="1"/>
+  <rect x="348.7" y="149.3" width="50.0" height="12.2" fill="#60a5fa" rx="1"/>
+  <rect x="401.2" y="206.9" width="50.0" height="53.1" fill="#f87171" rx="1"/>
+  <rect x="401.2" y="135.6" width="50.0" height="71.3" fill="#c45050" rx="1"/>
+  <rect x="401.2" y="108.2" width="50.0" height="27.4" fill="#f87171" rx="1"/>
+  <rect x="453.7" y="197.2" width="50.0" height="62.8" fill="#f59e0b" rx="1"/>
+  <rect x="453.7" y="135.0" width="50.0" height="62.3" fill="#c47d08" rx="1"/>
+  <rect x="453.7" y="111.1" width="50.0" height="23.9" fill="#f59e0b" rx="1"/>
+  <text x="450.0" y="278" text-anchor="middle" fill="#e6edf3" font-size="11" font-weight="600">Level 1</text>
+  <rect x="602.0" y="214.7" width="50.0" height="45.3" fill="#60a5fa" rx="1"/>
+  <rect x="602.0" y="156.6" width="50.0" height="58.1" fill="#4680c4" rx="1"/>
+  <rect x="602.0" y="144.4" width="50.0" height="12.2" fill="#60a5fa" rx="1"/>
+  <rect x="654.5" y="203.8" width="50.0" height="56.2" fill="#f87171" rx="1"/>
+  <rect x="654.5" y="137.3" width="50.0" height="66.6" fill="#c45050" rx="1"/>
+  <rect x="654.5" y="114.0" width="50.0" height="23.3" fill="#f87171" rx="1"/>
+  <rect x="707.0" y="169.8" width="50.0" height="90.2" fill="#f59e0b" rx="1"/>
+  <rect x="707.0" y="109.3" width="50.0" height="60.5" fill="#c47d08" rx="1"/>
+  <rect x="707.0" y="86.1" width="50.0" height="23.2" fill="#f59e0b" rx="1"/>
+  <text x="703.3" y="278" text-anchor="middle" fill="#e6edf3" font-size="11" font-weight="600">Level 3</text>
+  <text x="450.0" y="329" text-anchor="middle" fill="#e6edf3" font-size="12" font-weight="600">Medium compressibility</text>
+  <line x1="70" y1="494.8" x2="830" y2="494.8" stroke="#21262d" stroke-width="1"/>
+  <text x="62" y="494.8" text-anchor="end" dominant-baseline="middle" fill="#7d8590" font-size="10">2.0</text>
+  <line x1="70" y1="454.7" x2="830" y2="454.7" stroke="#21262d" stroke-width="1"/>
+  <text x="62" y="454.7" text-anchor="end" dominant-baseline="middle" fill="#7d8590" font-size="10">4.0</text>
+  <line x1="70" y1="414.5" x2="830" y2="414.5" stroke="#21262d" stroke-width="1"/>
+  <text x="62" y="414.5" text-anchor="end" dominant-baseline="middle" fill="#7d8590" font-size="10">6.0</text>
+  <line x1="70" y1="374.4" x2="830" y2="374.4" stroke="#21262d" stroke-width="1"/>
+  <text x="62" y="374.4" text-anchor="end" dominant-baseline="middle" fill="#7d8590" font-size="10">8.0</text>
+  <line x1="70" y1="535" x2="830" y2="535" stroke="#30363d" stroke-width="1.5"/>
+  <rect x="95.3" y="509.2" width="50.0" height="25.8" fill="#60a5fa" rx="1"/>
+  <rect x="95.3" y="419.9" width="50.0" height="89.3" fill="#4680c4" rx="1"/>
+  <rect x="95.3" y="412.4" width="50.0" height="7.4" fill="#60a5fa" rx="1"/>
+  <rect x="147.8" y="496.4" width="50.0" height="38.6" fill="#f87171" rx="1"/>
+  <rect x="147.8" y="407.3" width="50.0" height="89.1" fill="#c45050" rx="1"/>
+  <rect x="147.8" y="392.0" width="50.0" height="15.2" fill="#f87171" rx="1"/>
+  <rect x="200.3" y="486.8" width="50.0" height="48.2" fill="#f59e0b" rx="1"/>
+  <rect x="200.3" y="409.7" width="50.0" height="77.2" fill="#c47d08" rx="1"/>
+  <rect x="200.3" y="391.9" width="50.0" height="17.8" fill="#f59e0b" rx="1"/>
+  <text x="196.7" y="553" text-anchor="middle" fill="#e6edf3" font-size="11" font-weight="600">Level −1</text>
+  <rect x="348.7" y="506.1" width="50.0" height="28.9" fill="#60a5fa" rx="1"/>
+  <rect x="348.7" y="431.9" width="50.0" height="74.2" fill="#4680c4" rx="1"/>
+  <rect x="348.7" y="421.8" width="50.0" height="10.1" fill="#60a5fa" rx="1"/>
+  <rect x="401.2" y="486.6" width="50.0" height="48.4" fill="#f87171" rx="1"/>
+  <rect x="401.2" y="407.0" width="50.0" height="79.6" fill="#c45050" rx="1"/>
+  <rect x="401.2" y="387.9" width="50.0" height="19.1" fill="#f87171" rx="1"/>
+  <rect x="453.7" y="485.8" width="50.0" height="49.2" fill="#f59e0b" rx="1"/>
+  <rect x="453.7" y="411.3" width="50.0" height="74.6" fill="#c47d08" rx="1"/>
+  <rect x="453.7" y="393.5" width="50.0" height="17.8" fill="#f59e0b" rx="1"/>
+  <text x="450.0" y="553" text-anchor="middle" fill="#e6edf3" font-size="11" font-weight="600">Level 1</text>
+  <rect x="602.0" y="487.1" width="50.0" height="47.9" fill="#60a5fa" rx="1"/>
+  <rect x="602.0" y="420.0" width="50.0" height="67.0" fill="#4680c4" rx="1"/>
+  <rect x="602.0" y="409.4" width="50.0" height="10.6" fill="#60a5fa" rx="1"/>
+  <rect x="654.5" y="482.1" width="50.0" height="52.9" fill="#f87171" rx="1"/>
+  <rect x="654.5" y="406.3" width="50.0" height="75.9" fill="#c45050" rx="1"/>
+  <rect x="654.5" y="391.0" width="50.0" height="15.3" fill="#f87171" rx="1"/>
+  <rect x="707.0" y="448.9" width="50.0" height="86.1" fill="#f59e0b" rx="1"/>
+  <rect x="707.0" y="380.7" width="50.0" height="68.2" fill="#c47d08" rx="1"/>
+  <rect x="707.0" y="361.1" width="50.0" height="19.6" fill="#f59e0b" rx="1"/>
+  <text x="703.3" y="553" text-anchor="middle" fill="#e6edf3" font-size="11" font-weight="600">Level 3</text>
+  <text x="450.0" y="604" text-anchor="middle" fill="#e6edf3" font-size="12" font-weight="600">Low compressibility</text>
+  <line x1="70" y1="747.2" x2="830" y2="747.2" stroke="#21262d" stroke-width="1"/>
+  <text x="62" y="747.2" text-anchor="end" dominant-baseline="middle" fill="#7d8590" font-size="10">5.0</text>
+  <line x1="70" y1="684.4" x2="830" y2="684.4" stroke="#21262d" stroke-width="1"/>
+  <text x="62" y="684.4" text-anchor="end" dominant-baseline="middle" fill="#7d8590" font-size="10">10.0</text>
+  <line x1="70" y1="621.7" x2="830" y2="621.7" stroke="#21262d" stroke-width="1"/>
+  <text x="62" y="621.7" text-anchor="end" dominant-baseline="middle" fill="#7d8590" font-size="10">15.0</text>
+  <line x1="70" y1="810" x2="830" y2="810" stroke="#30363d" stroke-width="1.5"/>
+  <rect x="95.3" y="804.3" width="50.0" height="5.7" fill="#60a5fa" rx="1"/>
+  <rect x="95.3" y="684.4" width="50.0" height="119.9" fill="#4680c4" rx="1"/>
+  <rect x="95.3" y="683.2" width="50.0" height="1.2" fill="#60a5fa" rx="1"/>
+  <rect x="147.8" y="802.0" width="50.0" height="8.0" fill="#f87171" rx="1"/>
+  <rect x="147.8" y="681.6" width="50.0" height="120.5" fill="#c45050" rx="1"/>
+  <rect x="147.8" y="678.2" width="50.0" height="3.4" fill="#f87171" rx="1"/>
+  <rect x="200.3" y="783.0" width="50.0" height="27.0" fill="#f59e0b" rx="1"/>
+  <rect x="200.3" y="677.9" width="50.0" height="105.1" fill="#c47d08" rx="1"/>
+  <rect x="200.3" y="668.5" width="50.0" height="9.4" fill="#f59e0b" rx="1"/>
+  <text x="196.7" y="828" text-anchor="middle" fill="#e6edf3" font-size="11" font-weight="600">Level −1</text>
+  <rect x="348.7" y="795.3" width="50.0" height="14.7" fill="#60a5fa" rx="1"/>
+  <rect x="348.7" y="691.3" width="50.0" height="104.0" fill="#4680c4" rx="1"/>
+  <rect x="348.7" y="682.7" width="50.0" height="8.6" fill="#60a5fa" rx="1"/>
+  <rect x="401.2" y="786.9" width="50.0" height="23.1" fill="#f87171" rx="1"/>
+  <rect x="401.2" y="676.2" width="50.0" height="110.7" fill="#c45050" rx="1"/>
+  <rect x="401.2" y="669.7" width="50.0" height="6.5" fill="#f87171" rx="1"/>
+  <rect x="453.7" y="781.7" width="50.0" height="28.3" fill="#f59e0b" rx="1"/>
+  <rect x="453.7" y="677.7" width="50.0" height="104.0" fill="#c47d08" rx="1"/>
+  <rect x="453.7" y="668.2" width="50.0" height="9.5" fill="#f59e0b" rx="1"/>
+  <text x="450.0" y="828" text-anchor="middle" fill="#e6edf3" font-size="11" font-weight="600">Level 1</text>
+  <rect x="602.0" y="768.0" width="50.0" height="42.0" fill="#60a5fa" rx="1"/>
+  <rect x="602.0" y="675.3" width="50.0" height="92.7" fill="#4680c4" rx="1"/>
+  <rect x="602.0" y="664.9" width="50.0" height="10.4" fill="#60a5fa" rx="1"/>
+  <rect x="654.5" y="775.2" width="50.0" height="34.8" fill="#f87171" rx="1"/>
+  <rect x="654.5" y="670.3" width="50.0" height="104.9" fill="#c45050" rx="1"/>
+  <rect x="654.5" y="663.3" width="50.0" height="7.0" fill="#f87171" rx="1"/>
+  <rect x="707.0" y="744.1" width="50.0" height="65.9" fill="#f59e0b" rx="1"/>
+  <rect x="707.0" y="649.2" width="50.0" height="94.8" fill="#c47d08" rx="1"/>
+  <rect x="707.0" y="636.1" width="50.0" height="13.2" fill="#f59e0b" rx="1"/>
+  <text x="703.3" y="828" text-anchor="middle" fill="#e6edf3" font-size="11" font-weight="600">Level 3</text>
+  <rect x="250" y="840" width="12" height="12" fill="#60a5fa" rx="2"/>
+  <text x="268" y="850" fill="#e6edf3" font-size="10" font-weight="500">C zstd 1.5.7 (libzstd)</text>
+  <rect x="250" y="858" width="12" height="12" fill="#f87171" rx="2"/>
+  <text x="268" y="868" fill="#e6edf3" font-size="10" font-weight="500">zrip (safe API, Rust)</text>
+  <rect x="460" y="840" width="12" height="12" fill="#f59e0b" rx="2"/>
+  <text x="478" y="850" fill="#e6edf3" font-size="10" font-weight="500">structured-zstd 0.0.41 (unsafe Rust)</text>
+  <rect x="460" y="858" width="12" height="12" fill="#c084fc" rx="2"/>
+  <text x="478" y="868" fill="#e6edf3" font-size="10" font-weight="500">lz4rip 0.3.1 (safe API, Rust, LZ4)</text>
+  <text x="240" y="893" fill="#e6edf3" font-size="9">bright = compress + decompress</text>
+  <text x="480" y="893" fill="#7d8590" font-size="9">dim = transfer @100 MB/s</text>
+</svg>

--- a/doc/charts/aarch64/scatter.svg
+++ b/doc/charts/aarch64/scatter.svg
@@ -1,0 +1,257 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 850 1005" font-family="system-ui, -apple-system, sans-serif">
+  <rect width="850" height="1005" fill="#0d1117"/>
+  <text x="425.0" y="18" text-anchor="middle" fill="#e6edf3" font-size="14" font-weight="700">Encode Speed vs Compression Ratio (geomean across corpus)</text>
+  <rect x="70" y="45" width="760" height="250" fill="#161b22" rx="4"/>
+  <text x="450.0" y="37" text-anchor="middle" fill="#e6edf3" font-size="12" font-weight="600">High compressibility</text>
+  <line x1="70" y1="245.0" x2="830" y2="245.0" stroke="#21262d" stroke-width="1"/>
+  <text x="64" y="245.0" text-anchor="end" dominant-baseline="middle" fill="#7d8590" font-size="9">4.00x</text>
+  <line x1="70" y1="178.3" x2="830" y2="178.3" stroke="#21262d" stroke-width="1"/>
+  <text x="64" y="178.3" text-anchor="end" dominant-baseline="middle" fill="#7d8590" font-size="9">6.00x</text>
+  <line x1="70" y1="111.7" x2="830" y2="111.7" stroke="#21262d" stroke-width="1"/>
+  <text x="64" y="111.7" text-anchor="end" dominant-baseline="middle" fill="#7d8590" font-size="9">8.00x</text>
+  <line x1="139.5" y1="45" x2="139.5" y2="295" stroke="#21262d" stroke-width="1"/>
+  <text x="139.5" y="309" text-anchor="middle" fill="#7d8590" font-size="9">50</text>
+  <line x1="233.8" y1="45" x2="233.8" y2="295" stroke="#21262d" stroke-width="1"/>
+  <text x="233.8" y="309" text-anchor="middle" fill="#7d8590" font-size="9">100</text>
+  <line x1="328.1" y1="45" x2="328.1" y2="295" stroke="#21262d" stroke-width="1"/>
+  <text x="328.1" y="309" text-anchor="middle" fill="#7d8590" font-size="9">200</text>
+  <line x1="452.8" y1="45" x2="452.8" y2="295" stroke="#21262d" stroke-width="1"/>
+  <text x="452.8" y="309" text-anchor="middle" fill="#7d8590" font-size="9">500</text>
+  <line x1="547.1" y1="45" x2="547.1" y2="295" stroke="#21262d" stroke-width="1"/>
+  <text x="547.1" y="309" text-anchor="middle" fill="#7d8590" font-size="9">1000</text>
+  <line x1="641.4" y1="45" x2="641.4" y2="295" stroke="#21262d" stroke-width="1"/>
+  <text x="641.4" y="309" text-anchor="middle" fill="#7d8590" font-size="9">2000</text>
+  <line x1="766.1" y1="45" x2="766.1" y2="295" stroke="#21262d" stroke-width="1"/>
+  <text x="766.1" y="309" text-anchor="middle" fill="#7d8590" font-size="9">5000</text>
+  <text x="450.0" y="323" text-anchor="middle" fill="#7d8590" font-size="10">encode MB/s (log scale)</text>
+  <path d="M603.2,261.6L597.1,253.1L593.4,245.7L586.4,233.6L582.1,217.0L577.2,201.2L571.7,188.5L560.8,151.3L542.9,147.1L532.1,138.8L530.5,137.9" fill="none" stroke="#60a5fa" stroke-width="1.5" stroke-opacity="0.6"/>
+  <circle cx="603.2" cy="261.6" r="3.5" fill="#60a5fa" stroke="#0d1117" stroke-width="1"/>
+  <text x="609.2" y="261.6" text-anchor="start" fill="#60a5fa" font-size="8" font-weight="600">-7</text>
+  <circle cx="597.1" cy="253.1" r="3.5" fill="#60a5fa" stroke="#0d1117" stroke-width="1"/>
+  <circle cx="593.4" cy="245.7" r="3.5" fill="#60a5fa" stroke="#0d1117" stroke-width="1"/>
+  <circle cx="586.4" cy="233.6" r="3.5" fill="#60a5fa" stroke="#0d1117" stroke-width="1"/>
+  <text x="592.4" y="233.6" text-anchor="start" fill="#60a5fa" font-size="8" font-weight="600">-4</text>
+  <circle cx="582.1" cy="217.0" r="3.5" fill="#60a5fa" stroke="#0d1117" stroke-width="1"/>
+  <circle cx="577.2" cy="201.2" r="3.5" fill="#60a5fa" stroke="#0d1117" stroke-width="1"/>
+  <circle cx="571.7" cy="188.5" r="3.5" fill="#60a5fa" stroke="#0d1117" stroke-width="1"/>
+  <text x="577.7" y="188.5" text-anchor="start" fill="#60a5fa" font-size="8" font-weight="600">-1</text>
+  <circle cx="560.8" cy="151.3" r="3.5" fill="#60a5fa" stroke="#0d1117" stroke-width="1"/>
+  <circle cx="542.9" cy="147.1" r="3.5" fill="#60a5fa" stroke="#0d1117" stroke-width="1"/>
+  <circle cx="532.1" cy="138.8" r="3.5" fill="#60a5fa" stroke="#0d1117" stroke-width="1"/>
+  <text x="538.1" y="138.8" text-anchor="start" fill="#60a5fa" font-size="8" font-weight="600">3</text>
+  <circle cx="530.5" cy="137.9" r="3.5" fill="#60a5fa" stroke="#0d1117" stroke-width="1"/>
+  <text x="524.5" y="137.9" text-anchor="end" fill="#60a5fa" font-size="8" font-weight="600">4</text>
+  <path d="M577.8,276.1L541.0,258.5L537.9,250.1L539.2,244.2L532.8,231.7L528.8,215.7L525.8,200.6L509.1,182.1L508.8,178.6L501.8,167.4L501.8,166.6" fill="none" stroke="#f87171" stroke-width="1.5" stroke-opacity="0.6"/>
+  <circle cx="577.8" cy="276.1" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
+  <text x="583.8" y="276.1" text-anchor="start" fill="#f87171" font-size="8" font-weight="600">-7</text>
+  <circle cx="541.0" cy="258.5" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
+  <circle cx="537.9" cy="250.1" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
+  <circle cx="539.2" cy="244.2" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
+  <text x="545.2" y="244.2" text-anchor="start" fill="#f87171" font-size="8" font-weight="600">-4</text>
+  <circle cx="532.8" cy="231.7" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
+  <circle cx="528.8" cy="215.7" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
+  <circle cx="525.8" cy="200.6" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
+  <text x="531.8" y="200.6" text-anchor="start" fill="#f87171" font-size="8" font-weight="600">-1</text>
+  <circle cx="509.1" cy="182.1" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
+  <circle cx="508.8" cy="178.6" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
+  <circle cx="501.8" cy="167.4" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
+  <text x="507.8" y="167.4" text-anchor="start" fill="#f87171" font-size="8" font-weight="600">3</text>
+  <circle cx="501.8" cy="166.6" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
+  <text x="495.8" y="166.6" text-anchor="end" fill="#f87171" font-size="8" font-weight="600">4</text>
+  <path d="M503.6,205.2L502.2,198.9L500.5,191.9L499.3,183.8L497.3,171.6L494.8,161.1L491.2,154.9L486.6,151.4L471.1,147.0L437.2,149.8L436.3,148.5" fill="none" stroke="#f59e0b" stroke-width="1.5" stroke-opacity="0.6"/>
+  <circle cx="503.6" cy="205.2" r="3.5" fill="#f59e0b" stroke="#0d1117" stroke-width="1"/>
+  <text x="509.6" y="205.2" text-anchor="start" fill="#f59e0b" font-size="8" font-weight="600">-7</text>
+  <circle cx="502.2" cy="198.9" r="3.5" fill="#f59e0b" stroke="#0d1117" stroke-width="1"/>
+  <circle cx="500.5" cy="191.9" r="3.5" fill="#f59e0b" stroke="#0d1117" stroke-width="1"/>
+  <circle cx="499.3" cy="183.8" r="3.5" fill="#f59e0b" stroke="#0d1117" stroke-width="1"/>
+  <text x="505.3" y="183.8" text-anchor="start" fill="#f59e0b" font-size="8" font-weight="600">-4</text>
+  <circle cx="497.3" cy="171.6" r="3.5" fill="#f59e0b" stroke="#0d1117" stroke-width="1"/>
+  <circle cx="494.8" cy="161.1" r="3.5" fill="#f59e0b" stroke="#0d1117" stroke-width="1"/>
+  <circle cx="491.2" cy="154.9" r="3.5" fill="#f59e0b" stroke="#0d1117" stroke-width="1"/>
+  <text x="497.2" y="154.9" text-anchor="start" fill="#f59e0b" font-size="8" font-weight="600">-1</text>
+  <circle cx="486.6" cy="151.4" r="3.5" fill="#f59e0b" stroke="#0d1117" stroke-width="1"/>
+  <circle cx="471.1" cy="147.0" r="3.5" fill="#f59e0b" stroke="#0d1117" stroke-width="1"/>
+  <circle cx="437.2" cy="149.8" r="3.5" fill="#f59e0b" stroke="#0d1117" stroke-width="1"/>
+  <text x="443.2" y="149.8" text-anchor="start" fill="#f59e0b" font-size="8" font-weight="600">3</text>
+  <circle cx="436.3" cy="148.5" r="3.5" fill="#f59e0b" stroke="#0d1117" stroke-width="1"/>
+  <text x="430.3" y="148.5" text-anchor="end" fill="#f59e0b" font-size="8" font-weight="600">4</text>
+  <circle cx="340.7" cy="228.9" r="3.5" fill="#4ade80" stroke="#0d1117" stroke-width="1"/>
+  <text x="346.7" y="228.9" text-anchor="start" fill="#4ade80" font-size="8" font-weight="600">L1</text>
+  <circle cx="582.9" cy="241.8" r="3.5" fill="#c084fc" stroke="#0d1117" stroke-width="1"/>
+  <text x="588.9" y="241.8" text-anchor="start" fill="#c084fc" font-size="8" font-weight="600">LZ4</text>
+  <rect x="70" y="360" width="760" height="250" fill="#161b22" rx="4"/>
+  <text x="450.0" y="352" text-anchor="middle" fill="#e6edf3" font-size="12" font-weight="600">Medium compressibility</text>
+  <line x1="70" y1="596.1" x2="830" y2="596.1" stroke="#21262d" stroke-width="1"/>
+  <text x="64" y="596.1" text-anchor="end" dominant-baseline="middle" fill="#7d8590" font-size="9">1.50x</text>
+  <line x1="70" y1="526.7" x2="830" y2="526.7" stroke="#21262d" stroke-width="1"/>
+  <text x="64" y="526.7" text-anchor="end" dominant-baseline="middle" fill="#7d8590" font-size="9">2.00x</text>
+  <line x1="70" y1="457.2" x2="830" y2="457.2" stroke="#21262d" stroke-width="1"/>
+  <text x="64" y="457.2" text-anchor="end" dominant-baseline="middle" fill="#7d8590" font-size="9">2.50x</text>
+  <line x1="70" y1="387.8" x2="830" y2="387.8" stroke="#21262d" stroke-width="1"/>
+  <text x="64" y="387.8" text-anchor="end" dominant-baseline="middle" fill="#7d8590" font-size="9">3.00x</text>
+  <line x1="139.5" y1="360" x2="139.5" y2="610" stroke="#21262d" stroke-width="1"/>
+  <text x="139.5" y="624" text-anchor="middle" fill="#7d8590" font-size="9">50</text>
+  <line x1="233.8" y1="360" x2="233.8" y2="610" stroke="#21262d" stroke-width="1"/>
+  <text x="233.8" y="624" text-anchor="middle" fill="#7d8590" font-size="9">100</text>
+  <line x1="328.1" y1="360" x2="328.1" y2="610" stroke="#21262d" stroke-width="1"/>
+  <text x="328.1" y="624" text-anchor="middle" fill="#7d8590" font-size="9">200</text>
+  <line x1="452.8" y1="360" x2="452.8" y2="610" stroke="#21262d" stroke-width="1"/>
+  <text x="452.8" y="624" text-anchor="middle" fill="#7d8590" font-size="9">500</text>
+  <line x1="547.1" y1="360" x2="547.1" y2="610" stroke="#21262d" stroke-width="1"/>
+  <text x="547.1" y="624" text-anchor="middle" fill="#7d8590" font-size="9">1000</text>
+  <line x1="641.4" y1="360" x2="641.4" y2="610" stroke="#21262d" stroke-width="1"/>
+  <text x="641.4" y="624" text-anchor="middle" fill="#7d8590" font-size="9">2000</text>
+  <line x1="766.1" y1="360" x2="766.1" y2="610" stroke="#21262d" stroke-width="1"/>
+  <text x="766.1" y="624" text-anchor="middle" fill="#7d8590" font-size="9">5000</text>
+  <text x="450.0" y="638" text-anchor="middle" fill="#7d8590" font-size="10">encode MB/s (log scale)</text>
+  <path d="M552.2,559.6L548.2,555.9L541.9,548.7L536.4,539.1L529.4,528.4L522.8,517.6L514.3,506.6L498.0,435.9L454.6,409.8L421.5,397.1L417.9,391.2" fill="none" stroke="#60a5fa" stroke-width="1.5" stroke-opacity="0.6"/>
+  <circle cx="552.2" cy="559.6" r="3.5" fill="#60a5fa" stroke="#0d1117" stroke-width="1"/>
+  <text x="558.2" y="559.6" text-anchor="start" fill="#60a5fa" font-size="8" font-weight="600">-7</text>
+  <circle cx="548.2" cy="555.9" r="3.5" fill="#60a5fa" stroke="#0d1117" stroke-width="1"/>
+  <circle cx="541.9" cy="548.7" r="3.5" fill="#60a5fa" stroke="#0d1117" stroke-width="1"/>
+  <circle cx="536.4" cy="539.1" r="3.5" fill="#60a5fa" stroke="#0d1117" stroke-width="1"/>
+  <text x="542.4" y="539.1" text-anchor="start" fill="#60a5fa" font-size="8" font-weight="600">-4</text>
+  <circle cx="529.4" cy="528.4" r="3.5" fill="#60a5fa" stroke="#0d1117" stroke-width="1"/>
+  <circle cx="522.8" cy="517.6" r="3.5" fill="#60a5fa" stroke="#0d1117" stroke-width="1"/>
+  <circle cx="514.3" cy="506.6" r="3.5" fill="#60a5fa" stroke="#0d1117" stroke-width="1"/>
+  <text x="520.3" y="506.6" text-anchor="start" fill="#60a5fa" font-size="8" font-weight="600">-1</text>
+  <circle cx="498.0" cy="435.9" r="3.5" fill="#60a5fa" stroke="#0d1117" stroke-width="1"/>
+  <circle cx="454.6" cy="409.8" r="3.5" fill="#60a5fa" stroke="#0d1117" stroke-width="1"/>
+  <circle cx="421.5" cy="397.1" r="3.5" fill="#60a5fa" stroke="#0d1117" stroke-width="1"/>
+  <text x="427.5" y="397.1" text-anchor="start" fill="#60a5fa" font-size="8" font-weight="600">3</text>
+  <circle cx="417.9" cy="391.2" r="3.5" fill="#60a5fa" stroke="#0d1117" stroke-width="1"/>
+  <text x="411.9" y="391.2" text-anchor="end" fill="#60a5fa" font-size="8" font-weight="600">4</text>
+  <path d="M499.3,564.9L473.8,541.4L470.2,538.0L468.0,530.8L463.2,518.7L460.7,508.4L456.4,496.5L427.1,460.5L415.8,445.0L410.7,443.7L402.6,438.1" fill="none" stroke="#f87171" stroke-width="1.5" stroke-opacity="0.6"/>
+  <circle cx="499.3" cy="564.9" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
+  <text x="505.3" y="564.9" text-anchor="start" fill="#f87171" font-size="8" font-weight="600">-7</text>
+  <circle cx="473.8" cy="541.4" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
+  <circle cx="470.2" cy="538.0" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
+  <circle cx="468.0" cy="530.8" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
+  <text x="474.0" y="530.8" text-anchor="start" fill="#f87171" font-size="8" font-weight="600">-4</text>
+  <circle cx="463.2" cy="518.7" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
+  <circle cx="460.7" cy="508.4" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
+  <circle cx="456.4" cy="496.5" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
+  <text x="462.4" y="496.5" text-anchor="start" fill="#f87171" font-size="8" font-weight="600">-1</text>
+  <circle cx="427.1" cy="460.5" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
+  <circle cx="415.8" cy="445.0" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
+  <circle cx="410.7" cy="443.7" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
+  <text x="416.7" y="443.7" text-anchor="start" fill="#f87171" font-size="8" font-weight="600">3</text>
+  <circle cx="402.6" cy="438.1" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
+  <text x="396.6" y="438.1" text-anchor="end" fill="#f87171" font-size="8" font-weight="600">4</text>
+  <path d="M450.0,490.4L448.6,486.6L444.4,481.9L442.7,475.2L438.9,467.6L435.5,459.7L429.6,452.0L427.1,436.5L395.3,410.8L347.2,400.6L338.5,394.1" fill="none" stroke="#f59e0b" stroke-width="1.5" stroke-opacity="0.6"/>
+  <circle cx="450.0" cy="490.4" r="3.5" fill="#f59e0b" stroke="#0d1117" stroke-width="1"/>
+  <text x="456.0" y="490.4" text-anchor="start" fill="#f59e0b" font-size="8" font-weight="600">-7</text>
+  <circle cx="448.6" cy="486.6" r="3.5" fill="#f59e0b" stroke="#0d1117" stroke-width="1"/>
+  <circle cx="444.4" cy="481.9" r="3.5" fill="#f59e0b" stroke="#0d1117" stroke-width="1"/>
+  <circle cx="442.7" cy="475.2" r="3.5" fill="#f59e0b" stroke="#0d1117" stroke-width="1"/>
+  <text x="448.7" y="475.2" text-anchor="start" fill="#f59e0b" font-size="8" font-weight="600">-4</text>
+  <circle cx="438.9" cy="467.6" r="3.5" fill="#f59e0b" stroke="#0d1117" stroke-width="1"/>
+  <circle cx="435.5" cy="459.7" r="3.5" fill="#f59e0b" stroke="#0d1117" stroke-width="1"/>
+  <circle cx="429.6" cy="452.0" r="3.5" fill="#f59e0b" stroke="#0d1117" stroke-width="1"/>
+  <text x="435.6" y="452.0" text-anchor="start" fill="#f59e0b" font-size="8" font-weight="600">-1</text>
+  <circle cx="427.1" cy="436.5" r="3.5" fill="#f59e0b" stroke="#0d1117" stroke-width="1"/>
+  <circle cx="395.3" cy="410.8" r="3.5" fill="#f59e0b" stroke="#0d1117" stroke-width="1"/>
+  <circle cx="347.2" cy="400.6" r="3.5" fill="#f59e0b" stroke="#0d1117" stroke-width="1"/>
+  <text x="353.2" y="400.6" text-anchor="start" fill="#f59e0b" font-size="8" font-weight="600">3</text>
+  <circle cx="338.5" cy="394.1" r="3.5" fill="#f59e0b" stroke="#0d1117" stroke-width="1"/>
+  <text x="332.5" y="394.1" text-anchor="end" fill="#f59e0b" font-size="8" font-weight="600">4</text>
+  <circle cx="279.4" cy="505.4" r="3.5" fill="#4ade80" stroke="#0d1117" stroke-width="1"/>
+  <text x="285.4" y="505.4" text-anchor="start" fill="#4ade80" font-size="8" font-weight="600">L1</text>
+  <circle cx="536.7" cy="554.2" r="3.5" fill="#c084fc" stroke="#0d1117" stroke-width="1"/>
+  <text x="542.7" y="554.2" text-anchor="start" fill="#c084fc" font-size="8" font-weight="600">LZ4</text>
+  <rect x="70" y="675" width="760" height="250" fill="#161b22" rx="4"/>
+  <text x="450.0" y="667" text-anchor="middle" fill="#e6edf3" font-size="12" font-weight="600">Low compressibility</text>
+  <line x1="70" y1="904.2" x2="830" y2="904.2" stroke="#21262d" stroke-width="1"/>
+  <text x="64" y="904.2" text-anchor="end" dominant-baseline="middle" fill="#7d8590" font-size="9">1.00x</text>
+  <line x1="70" y1="862.5" x2="830" y2="862.5" stroke="#21262d" stroke-width="1"/>
+  <text x="64" y="862.5" text-anchor="end" dominant-baseline="middle" fill="#7d8590" font-size="9">1.10x</text>
+  <line x1="70" y1="820.8" x2="830" y2="820.8" stroke="#21262d" stroke-width="1"/>
+  <text x="64" y="820.8" text-anchor="end" dominant-baseline="middle" fill="#7d8590" font-size="9">1.20x</text>
+  <line x1="70" y1="779.2" x2="830" y2="779.2" stroke="#21262d" stroke-width="1"/>
+  <text x="64" y="779.2" text-anchor="end" dominant-baseline="middle" fill="#7d8590" font-size="9">1.30x</text>
+  <line x1="70" y1="737.5" x2="830" y2="737.5" stroke="#21262d" stroke-width="1"/>
+  <text x="64" y="737.5" text-anchor="end" dominant-baseline="middle" fill="#7d8590" font-size="9">1.40x</text>
+  <line x1="70" y1="695.8" x2="830" y2="695.8" stroke="#21262d" stroke-width="1"/>
+  <text x="64" y="695.8" text-anchor="end" dominant-baseline="middle" fill="#7d8590" font-size="9">1.50x</text>
+  <line x1="139.5" y1="675" x2="139.5" y2="925" stroke="#21262d" stroke-width="1"/>
+  <text x="139.5" y="939" text-anchor="middle" fill="#7d8590" font-size="9">50</text>
+  <line x1="233.8" y1="675" x2="233.8" y2="925" stroke="#21262d" stroke-width="1"/>
+  <text x="233.8" y="939" text-anchor="middle" fill="#7d8590" font-size="9">100</text>
+  <line x1="328.1" y1="675" x2="328.1" y2="925" stroke="#21262d" stroke-width="1"/>
+  <text x="328.1" y="939" text-anchor="middle" fill="#7d8590" font-size="9">200</text>
+  <line x1="452.8" y1="675" x2="452.8" y2="925" stroke="#21262d" stroke-width="1"/>
+  <text x="452.8" y="939" text-anchor="middle" fill="#7d8590" font-size="9">500</text>
+  <line x1="547.1" y1="675" x2="547.1" y2="925" stroke="#21262d" stroke-width="1"/>
+  <text x="547.1" y="939" text-anchor="middle" fill="#7d8590" font-size="9">1000</text>
+  <line x1="641.4" y1="675" x2="641.4" y2="925" stroke="#21262d" stroke-width="1"/>
+  <text x="641.4" y="939" text-anchor="middle" fill="#7d8590" font-size="9">2000</text>
+  <line x1="766.1" y1="675" x2="766.1" y2="925" stroke="#21262d" stroke-width="1"/>
+  <text x="766.1" y="939" text-anchor="middle" fill="#7d8590" font-size="9">5000</text>
+  <text x="450.0" y="953" text-anchor="middle" fill="#7d8590" font-size="10">encode MB/s (log scale)</text>
+  <path d="M778.0,894.6L763.1,890.9L759.7,891.8L753.1,889.4L743.6,887.4L731.2,884.7L709.7,882.1L525.4,818.8L473.2,796.3L383.3,757.6L365.2,732.4" fill="none" stroke="#60a5fa" stroke-width="1.5" stroke-opacity="0.6"/>
+  <circle cx="778.0" cy="894.6" r="3.5" fill="#60a5fa" stroke="#0d1117" stroke-width="1"/>
+  <text x="784.0" y="894.6" text-anchor="start" fill="#60a5fa" font-size="8" font-weight="600">-7</text>
+  <circle cx="763.1" cy="890.9" r="3.5" fill="#60a5fa" stroke="#0d1117" stroke-width="1"/>
+  <circle cx="759.7" cy="891.8" r="3.5" fill="#60a5fa" stroke="#0d1117" stroke-width="1"/>
+  <circle cx="753.1" cy="889.4" r="3.5" fill="#60a5fa" stroke="#0d1117" stroke-width="1"/>
+  <text x="759.1" y="889.4" text-anchor="start" fill="#60a5fa" font-size="8" font-weight="600">-4</text>
+  <circle cx="743.6" cy="887.4" r="3.5" fill="#60a5fa" stroke="#0d1117" stroke-width="1"/>
+  <circle cx="731.2" cy="884.7" r="3.5" fill="#60a5fa" stroke="#0d1117" stroke-width="1"/>
+  <circle cx="709.7" cy="882.1" r="3.5" fill="#60a5fa" stroke="#0d1117" stroke-width="1"/>
+  <text x="715.7" y="882.1" text-anchor="start" fill="#60a5fa" font-size="8" font-weight="600">-1</text>
+  <circle cx="525.4" cy="818.8" r="3.5" fill="#60a5fa" stroke="#0d1117" stroke-width="1"/>
+  <circle cx="473.2" cy="796.3" r="3.5" fill="#60a5fa" stroke="#0d1117" stroke-width="1"/>
+  <circle cx="383.3" cy="757.6" r="3.5" fill="#60a5fa" stroke="#0d1117" stroke-width="1"/>
+  <text x="389.3" y="757.6" text-anchor="start" fill="#60a5fa" font-size="8" font-weight="600">3</text>
+  <circle cx="365.2" cy="732.4" r="3.5" fill="#60a5fa" stroke="#0d1117" stroke-width="1"/>
+  <text x="371.2" y="732.4" text-anchor="start" fill="#60a5fa" font-size="8" font-weight="600">4</text>
+  <path d="M746.2,902.0L756.1,902.7L710.6,898.9L666.0,893.0L652.7,890.3L653.5,891.5L627.4,885.0L467.2,847.8L415.3,819.9L416.1,823.2L404.6,806.4" fill="none" stroke="#f87171" stroke-width="1.5" stroke-opacity="0.6"/>
+  <circle cx="746.2" cy="902.0" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
+  <text x="752.2" y="902.0" text-anchor="start" fill="#f87171" font-size="8" font-weight="600">-7</text>
+  <circle cx="756.1" cy="902.7" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
+  <circle cx="710.6" cy="898.9" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
+  <circle cx="666.0" cy="893.0" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
+  <text x="672.0" y="893.0" text-anchor="start" fill="#f87171" font-size="8" font-weight="600">-4</text>
+  <circle cx="652.7" cy="890.3" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
+  <circle cx="653.5" cy="891.5" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
+  <circle cx="627.4" cy="885.0" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
+  <text x="633.4" y="885.0" text-anchor="start" fill="#f87171" font-size="8" font-weight="600">-1</text>
+  <circle cx="467.2" cy="847.8" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
+  <circle cx="415.3" cy="819.9" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
+  <circle cx="416.1" cy="823.2" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
+  <text x="422.1" y="823.2" text-anchor="start" fill="#f87171" font-size="8" font-weight="600">3</text>
+  <circle cx="404.6" cy="806.4" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
+  <text x="410.6" y="806.4" text-anchor="start" fill="#f87171" font-size="8" font-weight="600">4</text>
+  <path d="M464.6,832.9L464.3,833.7L462.2,831.7L459.0,830.3L453.5,826.9L450.8,827.2L442.6,824.6L436.2,818.8L397.8,796.3L321.6,769.5L289.2,743.0" fill="none" stroke="#f59e0b" stroke-width="1.5" stroke-opacity="0.6"/>
+  <circle cx="464.6" cy="832.9" r="3.5" fill="#f59e0b" stroke="#0d1117" stroke-width="1"/>
+  <text x="470.6" y="832.9" text-anchor="start" fill="#f59e0b" font-size="8" font-weight="600">-7</text>
+  <circle cx="464.3" cy="833.7" r="3.5" fill="#f59e0b" stroke="#0d1117" stroke-width="1"/>
+  <circle cx="462.2" cy="831.7" r="3.5" fill="#f59e0b" stroke="#0d1117" stroke-width="1"/>
+  <circle cx="459.0" cy="830.3" r="3.5" fill="#f59e0b" stroke="#0d1117" stroke-width="1"/>
+  <text x="453.0" y="830.3" text-anchor="end" fill="#f59e0b" font-size="8" font-weight="600">-4</text>
+  <circle cx="453.5" cy="826.9" r="3.5" fill="#f59e0b" stroke="#0d1117" stroke-width="1"/>
+  <circle cx="450.8" cy="827.2" r="3.5" fill="#f59e0b" stroke="#0d1117" stroke-width="1"/>
+  <circle cx="442.6" cy="824.6" r="3.5" fill="#f59e0b" stroke="#0d1117" stroke-width="1"/>
+  <text x="436.6" y="824.6" text-anchor="end" fill="#f59e0b" font-size="8" font-weight="600">-1</text>
+  <circle cx="436.2" cy="818.8" r="3.5" fill="#f59e0b" stroke="#0d1117" stroke-width="1"/>
+  <circle cx="397.8" cy="796.3" r="3.5" fill="#f59e0b" stroke="#0d1117" stroke-width="1"/>
+  <circle cx="321.6" cy="769.5" r="3.5" fill="#f59e0b" stroke="#0d1117" stroke-width="1"/>
+  <text x="327.6" y="769.5" text-anchor="start" fill="#f59e0b" font-size="8" font-weight="600">3</text>
+  <circle cx="289.2" cy="743.0" r="3.5" fill="#f59e0b" stroke="#0d1117" stroke-width="1"/>
+  <text x="295.2" y="743.0" text-anchor="start" fill="#f59e0b" font-size="8" font-weight="600">4</text>
+  <circle cx="230.9" cy="832.5" r="3.5" fill="#4ade80" stroke="#0d1117" stroke-width="1"/>
+  <text x="236.9" y="832.5" text-anchor="start" fill="#4ade80" font-size="8" font-weight="600">L1</text>
+  <circle cx="794.8" cy="897.7" r="3.5" fill="#c084fc" stroke="#0d1117" stroke-width="1"/>
+  <text x="800.8" y="897.7" text-anchor="start" fill="#c084fc" font-size="8" font-weight="600">LZ4</text>
+  <text x="16" y="485.0" text-anchor="middle" fill="#e6edf3" font-size="11" font-weight="600" transform="rotate(-90,16,485.0)">compression ratio</text>
+  <circle cx="137" cy="965" r="4" fill="#60a5fa"/>
+  <text x="145" y="968.5" fill="#e6edf3" font-size="10" font-weight="500">C zstd 1.5.7 (libzstd)</text>
+  <circle cx="310" cy="965" r="4" fill="#f87171"/>
+  <text x="318" y="968.5" fill="#e6edf3" font-size="10" font-weight="500">zrip (safe API, Rust)</text>
+  <circle cx="476" cy="965" r="4" fill="#f59e0b"/>
+  <text x="484" y="968.5" fill="#e6edf3" font-size="10" font-weight="500">structured-zstd 0.0.41 (unsafe Rust)</text>
+  <circle cx="220" cy="983" r="4" fill="#4ade80"/>
+  <text x="228" y="986.5" fill="#e6edf3" font-size="10" font-weight="500">ruzstd 0.8.2 (safe Rust)</text>
+  <circle cx="405" cy="983" r="4" fill="#c084fc"/>
+  <text x="413" y="986.5" fill="#e6edf3" font-size="10" font-weight="500">lz4rip 0.3.1 (safe API, Rust, LZ4)</text>
+</svg>

--- a/doc/charts/aarch64/summary.svg
+++ b/doc/charts/aarch64/summary.svg
@@ -1,0 +1,38 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 700 401" font-family="system-ui, -apple-system, sans-serif">
+  <rect width="700" height="401" fill="#0d1117"/>
+  <text x="350.0" y="22" text-anchor="middle" fill="#e6edf3" font-size="14" font-weight="700">zstd Pipeline @100 MB/s: Corpus geomean, Level 1 (lower is better)</text>
+  <text x="22" y="170.0" text-anchor="middle" fill="#e6edf3" font-size="11" font-weight="600" transform="rotate(-90,22,170.0)">seconds / GB</text>
+  <line x1="70" y1="213.7" x2="680" y2="213.7" stroke="#21262d" stroke-width="1"/>
+  <text x="62" y="213.7" text-anchor="end" dominant-baseline="middle" fill="#7d8590" font-size="10">5.0</text>
+  <line x1="70" y1="132.5" x2="680" y2="132.5" stroke="#21262d" stroke-width="1"/>
+  <text x="62" y="132.5" text-anchor="end" dominant-baseline="middle" fill="#7d8590" font-size="10">10.0</text>
+  <line x1="70" y1="51.2" x2="680" y2="51.2" stroke="#21262d" stroke-width="1"/>
+  <text x="62" y="51.2" text-anchor="end" dominant-baseline="middle" fill="#7d8590" font-size="10">15.0</text>
+  <line x1="70" y1="295" x2="680" y2="295" stroke="#30363d" stroke-width="1.5"/>
+  <rect x="167.0" y="274.9" width="80.0" height="20.1" fill="#60a5fa" rx="1"/>
+  <rect x="167.0" y="215.7" width="80.0" height="59.2" fill="#4680c4" rx="1"/>
+  <rect x="167.0" y="208.0" width="80.0" height="7.7" fill="#60a5fa" rx="1"/>
+  <text x="207.0" y="311" text-anchor="middle" fill="#e6edf3" font-size="10" font-weight="600">C zstd</text>
+  <rect x="279.0" y="262.8" width="80.0" height="32.2" fill="#f87171" rx="1"/>
+  <rect x="279.0" y="198.5" width="80.0" height="64.4" fill="#c45050" rx="1"/>
+  <rect x="279.0" y="186.0" width="80.0" height="12.4" fill="#f87171" rx="1"/>
+  <text x="319.0" y="311" text-anchor="middle" fill="#e6edf3" font-size="10" font-weight="600">zrip</text>
+  <rect x="391.0" y="259.9" width="80.0" height="35.1" fill="#f59e0b" rx="1"/>
+  <rect x="391.0" y="200.6" width="80.0" height="59.3" fill="#c47d08" rx="1"/>
+  <rect x="391.0" y="188.3" width="80.0" height="12.4" fill="#f59e0b" rx="1"/>
+  <text x="431.0" y="311" text-anchor="middle" fill="#e6edf3" font-size="10" font-weight="600">structured-zstd</text>
+  <rect x="503.0" y="181.1" width="80.0" height="113.9" fill="#4ade80" rx="1"/>
+  <rect x="503.0" y="107.7" width="80.0" height="73.4" fill="#3aaf60" rx="1"/>
+  <rect x="503.0" y="77.6" width="80.0" height="30.1" fill="#4ade80" rx="1"/>
+  <text x="543.0" y="311" text-anchor="middle" fill="#e6edf3" font-size="10" font-weight="600">ruzstd</text>
+  <rect x="150" y="325" width="12" height="12" fill="#60a5fa" rx="2"/>
+  <text x="168" y="335" fill="#e6edf3" font-size="10" font-weight="500">C zstd 1.5.7 (libzstd)</text>
+  <rect x="150" y="343" width="12" height="12" fill="#f87171" rx="2"/>
+  <text x="168" y="353" fill="#e6edf3" font-size="10" font-weight="500">zrip (safe API, Rust)</text>
+  <rect x="360" y="325" width="12" height="12" fill="#f59e0b" rx="2"/>
+  <text x="378" y="335" fill="#e6edf3" font-size="10" font-weight="500">structured-zstd 0.0.41 (unsafe Rust)</text>
+  <rect x="360" y="343" width="12" height="12" fill="#4ade80" rx="2"/>
+  <text x="378" y="353" fill="#e6edf3" font-size="10" font-weight="500">ruzstd 0.8.2 (safe Rust)</text>
+  <text x="140" y="378" fill="#e6edf3" font-size="9">bright = compress + decompress</text>
+  <text x="380" y="378" fill="#7d8590" font-size="9">dim = transfer @100 MB/s</text>
+</svg>

--- a/scripts/plot_scatter.py
+++ b/scripts/plot_scatter.py
@@ -59,11 +59,11 @@ MIN_FILE_SIZE = 10_000
 
 # Fixed axis ranges so the chart doesn't shift when data changes.
 FIXED_LOG_X_MIN = 1.477  # 10^1.477 ≈ 30 MB/s
-FIXED_LOG_X_MAX = 3.602  # 10^3.602 ≈ 4000 MB/s
+FIXED_LOG_X_MAX = 3.903  # 10^3.903 ≈ 8000 MB/s
 FIXED_Y_RANGES = {
     "High compressibility":   (2.5, 10.0),
     "Medium compressibility": (1.4, 3.2),
-    "Low compressibility":    (0.95, 1.45),
+    "Low compressibility":    (0.95, 1.55),
 }
 
 


### PR DESCRIPTION
- Rewrite `decode_execute_neon` in `crates/decode/src/simd_decode/aarch64/decode.rs`: inline bitstream reads (`read_bits!`/`refill_fast!` macros with local state), rep offset computation (`compute_offset_inline!`), and literal/match copies (direct `vld1q_u8`/`vst1q_u8`) instead of calling through `ReverseBitReader`, `compute_offset`, and `neon::copy_match_neon`
- Monomorphize via `decode_execute_neon_inner<const HAS_HISTORY: bool>` to eliminate history branch from the common no-history path
- Fix `num_sequences == 0` underflow on `last_seq = num_sequences - 1`
- Add `lit_remaining >= 16` guard before unconditional 16-byte NEON literal read
- Fix broken `super::neon::copy_match_neon` module path (inlined instead)
- Narrow `decode_execute_neon_safe` visibility to `pub(crate)`
- Extend scatter plot axis ranges for M4 decode throughput (x-max 4000 -> 8000 MB/s, low-compressibility y-max 1.45 -> 1.55)
- Add aarch64 benchmark charts (M4)