### PR TITLE
Release 0.3.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## [Unreleased]
 
+## [0.3.3]
+
+### Changed
+
+- Improved crate description for crates.io.
+- Added README.md to sub-crates (zrip-core, zrip-encode, zrip-decode).
+- Removed two non-library bugs from SAFETY.md vulnerability table
+  (#94 was in fullbench tool, CVE-2022-4899 was in CLI util.c).
+
 ## [0.3.2]
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,10 @@
 
 ## [0.3.3]
 
-### Changed
+### Fixed
 
-- Improved crate description for crates.io.
-- Added README.md to sub-crates (zrip-core, zrip-encode, zrip-decode).
-- Removed two non-library bugs from SAFETY.md vulnerability table
-  (#94 was in fullbench tool, CVE-2022-4899 was in CLI util.c).
+- Bump sub-crate versions to allow publishing on crates.io (0.3.2
+  sub-crates were never published).
 
 ## [0.3.2]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ exclude = ["fuzz", "bench"]
 
 [package]
 name = "zrip"
-version = "0.3.2"
+version = "0.3.3"
 edition = "2024"
 rust-version = "1.85"
 description = "Fast, memory-safe Rust implementation of Zstandard compression (levels -7..4)"
@@ -23,9 +23,9 @@ dict_builder = ["std", "zrip-core/dict_builder"]
 nightly = ["zrip-core/nightly", "zrip-encode/nightly", "zrip-decode/nightly"]
 
 [dependencies]
-zrip-core = { version = "0.3.1", path = "crates/core", default-features = false }
-zrip-encode = { version = "0.3.1", path = "crates/encode", default-features = false }
-zrip-decode = { version = "0.3.1", path = "crates/decode", default-features = false }
+zrip-core = { version = "0.3.3", path = "crates/core", default-features = false }
+zrip-encode = { version = "0.3.3", path = "crates/encode", default-features = false }
+zrip-decode = { version = "0.3.3", path = "crates/decode", default-features = false }
 
 [lints]
 workspace = true

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zrip-core"
-version = "0.3.1"
+version = "0.3.3"
 edition = "2024"
 rust-version = "1.85"
 description = "Shared types and codecs for zrip (internal crate)"

--- a/crates/decode/Cargo.toml
+++ b/crates/decode/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zrip-decode"
-version = "0.3.1"
+version = "0.3.3"
 edition = "2024"
 rust-version = "1.85"
 description = "zstd decoder for zrip (internal crate)"
@@ -19,7 +19,7 @@ frame = ["std"]
 nightly = ["zrip-core/nightly"]
 
 [dependencies]
-zrip-core = { version = "0.3.1", path = "../core", default-features = false }
+zrip-core = { version = "0.3.3", path = "../core", default-features = false }
 
 [dev-dependencies]
 zrip = { path = "../.." }

--- a/crates/encode/Cargo.toml
+++ b/crates/encode/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zrip-encode"
-version = "0.3.1"
+version = "0.3.3"
 edition = "2024"
 rust-version = "1.85"
 description = "zstd encoder for zrip (internal crate)"
@@ -19,7 +19,7 @@ frame = ["std"]
 nightly = ["zrip-core/nightly"]
 
 [dependencies]
-zrip-core = { version = "0.3.1", path = "../core", default-features = false }
+zrip-core = { version = "0.3.3", path = "../core", default-features = false }
 
 [dev-dependencies]
 zrip = { path = "../.." }


### PR DESCRIPTION
- Bump all crates (zrip, zrip-core, zrip-encode, zrip-decode) to 0.3.3 so sub-crates can be published on crates.io (0.3.2 sub-crates were never published)