### PR TITLE
Add JSR WASM package (`@paddor/zrip`)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@
 /bench/corpus/
 /bench/target/
 Cargo.lock
+/jsr/src/pkg/
+/jsr/wasm/target/
+/jsr/deno.lock

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace]
 members = ["crates/core", "crates/encode", "crates/decode"]
-exclude = ["fuzz", "bench"]
+exclude = ["fuzz", "bench", "jsr"]
 
 [package]
 name = "zrip"

--- a/README.md
+++ b/README.md
@@ -26,6 +26,10 @@ that only matter in archival storage, not transfer pipelines.
 **`no_std` + `alloc`.** Works in embedded and kernel contexts with the `alloc`
 feature; `frame` requires `std`.
 
+**WebAssembly.** Available as [`@paddor/zrip`](https://jsr.io/@paddor/zrip)
+on JSR. Auto-detects WASM SIMD support. 15% faster encode and 14% faster
+decode than C zstd compiled to WASM.
+
 **Dictionary compression.** COVER and FastCOVER training built in for
 small-message workloads (log lines, JSON records, RPC payloads).
 

--- a/jsr/README.md
+++ b/jsr/README.md
@@ -1,0 +1,111 @@
+# @paddor/zrip
+
+Pure Rust zstd codec compiled to WebAssembly. Levels -7 through 4
+(Fast and DFast strategies). Optimized for encode throughput in transfer
+pipelines that need standard zstd frames at high speed.
+
+Automatically detects WASM SIMD support and loads the appropriate binary.
+
+## Usage
+
+```ts
+import { init, compress, decompress } from "@paddor/zrip";
+
+await init();
+
+const data = new TextEncoder().encode("hello world".repeat(1000));
+const compressed = compress(data, 1);
+const original = decompress(compressed);
+```
+
+### Compression levels
+
+| Level | Strategy | Notes |
+|------:|:---------|:------|
+| -7 | Fast | Fastest, lowest ratio |
+| -6..-1 | Fast | |
+| 0 | | Alias for level 1 |
+| 1 | Fast | Default |
+| 2 | Fast | |
+| 3 | DFast | Dual hash tables |
+| 4 | DFast | Best ratio |
+
+### Reusable contexts
+
+Amortize internal allocations across multiple compress/decompress calls:
+
+```ts
+import { init, Compressor, Decompressor } from "@paddor/zrip";
+
+await init();
+
+const compressor = new Compressor(1);
+const c1 = compressor.compress(data1);
+const c2 = compressor.compress(data2);
+compressor.free();
+
+const decompressor = new Decompressor();
+const d1 = decompressor.decompress(c1);
+const d2 = decompressor.decompress(c2);
+decompressor.free();
+```
+
+### Dictionary compression
+
+For small-message workloads (log lines, JSON records, RPC payloads) that
+share common structure:
+
+```ts
+import {
+  init,
+  compressWithDict,
+  decompressWithDict,
+  Dictionary,
+  Compressor,
+  Decompressor,
+} from "@paddor/zrip";
+
+await init();
+
+const dict = new Dictionary(dictBytes);
+const compressed = compressWithDict(data, 1, dict);
+const original = decompressWithDict(compressed, dict);
+
+// Stateful with dict
+const compressor = Compressor.withDict(1, dict);
+const c = compressor.compress(data);
+compressor.free();
+
+const decompressor = Decompressor.withDict(dict);
+const d = decompressor.decompress(c);
+decompressor.free();
+```
+
+### Synchronous initialization
+
+When you have pre-loaded WASM bytes (e.g. bundled or read from disk):
+
+```ts
+import { initSyncFromBytes, compress } from "@paddor/zrip";
+
+const wasmBytes = Deno.readFileSync("path/to/zrip_simd.wasm");
+initSyncFromBytes(wasmBytes);
+
+const compressed = compress(data);
+```
+
+## Performance
+
+WASM benchmark at level 1 (geomean across Silesia corpus, 4 MiB cap per file):
+
+| Impl | Encode MB/s | Decode MB/s |
+|:-----|------------:|------------:|
+| zrip | **153.6** | **306.1** |
+| C zstd (zstd-codec) | 133.7 | 269.5 |
+
+zrip WASM is 15% faster encode, 14% faster decode than C zstd compiled to
+WASM via Emscripten.
+
+## Source
+
+Rust source and native benchmarks: [github.com/paddor/zrip](https://github.com/paddor/zrip)

--- a/jsr/build.sh
+++ b/jsr/build.sh
@@ -1,0 +1,38 @@
+#!/bin/sh
+set -e
+cd "$(dirname "$0")"
+
+PKG=src/pkg
+TMP=src/pkg-tmp
+
+rm -rf "$PKG" "$TMP"
+mkdir -p "$PKG"
+
+echo "==> Building scalar WASM..."
+cd wasm
+RUSTFLAGS="" wasm-pack build --target web --release --out-dir "../$TMP"
+cd ..
+
+cp "$TMP/zrip_wasm.js" "$PKG/"
+cp "$TMP/zrip_wasm.d.ts" "$PKG/"
+cp "$TMP/zrip_wasm_bg.wasm.d.ts" "$PKG/"
+mv "$TMP/zrip_wasm_bg.wasm" "$PKG/zrip_scalar.wasm"
+
+echo "==> Building simd128 WASM..."
+cd wasm
+RUSTFLAGS="-C target-feature=+simd128" wasm-pack build --target web --release --out-dir "../$TMP"
+cd ..
+
+mv "$TMP/zrip_wasm_bg.wasm" "$PKG/zrip_simd.wasm"
+
+echo "==> Verifying JS glue is identical..."
+if ! diff -q "$TMP/zrip_wasm.js" "$PKG/zrip_wasm.js" > /dev/null 2>&1; then
+    echo "WARNING: JS glue differs between scalar and simd128 builds!"
+    exit 1
+fi
+
+rm -rf "$TMP"
+
+SCALAR_SIZE=$(wc -c < "$PKG/zrip_scalar.wasm")
+SIMD_SIZE=$(wc -c < "$PKG/zrip_simd.wasm")
+echo "==> Done. scalar: ${SCALAR_SIZE} bytes, simd128: ${SIMD_SIZE} bytes"

--- a/jsr/deno.json
+++ b/jsr/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@paddor/zrip",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "license": "MIT",
   "exports": "./src/mod.ts",
   "publish": {

--- a/jsr/deno.json
+++ b/jsr/deno.json
@@ -5,6 +5,6 @@
   "exports": "./src/mod.ts",
   "publish": {
     "include": ["src/", "deno.json", "LICENSE"],
-    "exclude": ["src/pkg/package.json"]
+    "exclude": ["src/pkg/package.json", "!src/pkg/"]
   }
 }

--- a/jsr/deno.json
+++ b/jsr/deno.json
@@ -4,7 +4,7 @@
   "license": "MIT",
   "exports": "./src/mod.ts",
   "publish": {
-    "include": ["src/", "deno.json", "LICENSE"],
+    "include": ["src/", "deno.json", "LICENSE", "README.md"],
     "exclude": ["src/pkg/package.json", "!src/pkg/"]
   }
 }

--- a/jsr/deno.json
+++ b/jsr/deno.json
@@ -1,0 +1,10 @@
+{
+  "name": "@paddor/zrip",
+  "version": "0.1.0",
+  "license": "MIT",
+  "exports": "./src/mod.ts",
+  "publish": {
+    "include": ["src/", "deno.json", "LICENSE"],
+    "exclude": ["src/pkg/package.json"]
+  }
+}

--- a/jsr/src/bench.ts
+++ b/jsr/src/bench.ts
@@ -1,0 +1,151 @@
+import { init, compress, decompress } from "./mod.ts";
+import { ZstdCodec } from "npm:zstd-codec";
+
+function bench(
+  fn: () => void,
+  warmup: number,
+  iters: number,
+): number {
+  for (let i = 0; i < warmup; i++) fn();
+  const t0 = performance.now();
+  for (let i = 0; i < iters; i++) fn();
+  const elapsed = performance.now() - t0;
+  return elapsed / iters;
+}
+
+interface CZstd {
+  compress(data: Uint8Array, level: number): Uint8Array;
+  decompress(data: Uint8Array): Uint8Array;
+}
+
+async function initCZstd(): Promise<CZstd> {
+  return new Promise((resolve) => {
+    ZstdCodec.run((zstd: { Simple: new () => CZstd }) => {
+      resolve(new zstd.Simple());
+    });
+  });
+}
+
+const CORPUS_DIR = "../bench/corpus";
+
+const FILES = [
+  "dickens.txt",
+  "hdfs.json",
+  "reymont.pdf",
+  "xml_collection.xml",
+  "silesia/mr",
+  "silesia/mozilla",
+  "silesia/nci",
+  "silesia/osdb",
+  "silesia/samba",
+  "silesia/sao",
+  "silesia/webster",
+  "silesia/x-ray",
+];
+
+function fmtSize(bytes: number): string {
+  if (bytes >= 1024 * 1024) return (bytes / 1024 / 1024).toFixed(1) + " MB";
+  return (bytes / 1024).toFixed(0) + " KB";
+}
+
+async function main() {
+  await init();
+  const czstd = await initCZstd();
+  const level = 1;
+
+  console.log(
+    `${"File".padEnd(22)} ${"Size".padStart(9)}  ` +
+      `${"Impl".padEnd(10)} ${"Ratio".padStart(6)} ` +
+      `${"Enc MB/s".padStart(10)} ${"Dec MB/s".padStart(10)}`,
+  );
+  console.log("-".repeat(78));
+
+  const zripEncs: number[] = [];
+  const czstdEncs: number[] = [];
+  const zripDecs: number[] = [];
+  const czstdDecs: number[] = [];
+  const sizes: number[] = [];
+
+  for (const file of FILES) {
+    const path = `${CORPUS_DIR}/${file}`;
+    const full = await Deno.readFile(path);
+    const data = full.length > 4 * 1024 * 1024 ? full.slice(0, 4 * 1024 * 1024) : full;
+    const name = file.replace("silesia/", "");
+    sizes.push(data.length);
+
+    const zripCompressed = compress(data, level);
+
+    let czstdCompressed: Uint8Array | null = null;
+    try {
+      czstdCompressed = czstd.compress(data, level);
+    } catch {
+      // Emscripten OOM on large files
+    }
+
+    const zripRatio = zripCompressed.length / data.length;
+
+    // Scale iterations to file size
+    const iters = Math.max(5, Math.floor(50_000_000 / data.length));
+    const warmup = Math.max(2, Math.floor(iters / 4));
+
+    const mbps = (bytes: number, ms: number) =>
+      (bytes / 1024 / 1024) / (ms / 1000);
+
+    const zripEncMs = bench(() => compress(data, level), warmup, iters);
+    const zripDecMs = bench(() => decompress(zripCompressed), warmup, iters);
+    const zEnc = mbps(data.length, zripEncMs);
+    const zDec = mbps(data.length, zripDecMs);
+    zripEncs.push(zEnc);
+    zripDecs.push(zDec);
+
+    console.log(
+      `${name.padEnd(22)} ${fmtSize(data.length).padStart(9)}  ` +
+        `${"zrip".padEnd(10)} ${zripRatio.toFixed(3).padStart(6)} ` +
+        `${zEnc.toFixed(1).padStart(10)} ${zDec.toFixed(1).padStart(10)}`,
+    );
+
+    if (czstdCompressed) {
+      const czstdRatio = czstdCompressed.length / data.length;
+      const czstdEncMs = bench(() => czstd.compress(data, level), warmup, iters);
+      const czstdDecMs = bench(
+        () => czstd.decompress(czstdCompressed!),
+        warmup,
+        iters,
+      );
+      const cEnc = mbps(data.length, czstdEncMs);
+      const cDec = mbps(data.length, czstdDecMs);
+      czstdEncs.push(cEnc);
+      czstdDecs.push(cDec);
+
+      console.log(
+        `${"".padEnd(22)} ${"".padStart(9)}  ` +
+          `${"C zstd".padEnd(10)} ${czstdRatio.toFixed(3).padStart(6)} ` +
+          `${cEnc.toFixed(1).padStart(10)} ${cDec.toFixed(1).padStart(10)}`,
+      );
+    } else {
+      console.log(
+        `${"".padEnd(22)} ${"".padStart(9)}  ` +
+          `${"C zstd".padEnd(10)} ${"OOM".padStart(6)}`,
+      );
+    }
+    console.log("");
+  }
+
+  // Geometric means
+  const geomean = (arr: number[]) =>
+    Math.exp(arr.reduce((s, v) => s + Math.log(v), 0) / arr.length);
+
+  console.log("-".repeat(78));
+  console.log(
+    `${"GEOMEAN".padEnd(22)} ${"".padStart(9)}  ` +
+      `${"zrip".padEnd(10)} ${"".padStart(6)} ` +
+      `${geomean(zripEncs).toFixed(1).padStart(10)} ${geomean(zripDecs).toFixed(1).padStart(10)}`,
+  );
+  console.log(
+    `${"".padEnd(22)} ${"".padStart(9)}  ` +
+      `${"C zstd".padEnd(10)} ${"".padStart(6)} ` +
+      `${geomean(czstdEncs).toFixed(1).padStart(10)} ${geomean(czstdDecs).toFixed(1).padStart(10)}`,
+  );
+}
+
+main();

--- a/jsr/src/cross_test.ts
+++ b/jsr/src/cross_test.ts
@@ -1,5 +1,12 @@
 import { assertEquals } from "https://deno.land/std@0.224.0/assert/mod.ts";
-import { init, compress, decompress } from "./mod.ts";
+import {
+  init,
+  compress,
+  decompress,
+  compressWithDict,
+  decompressWithDict,
+  Dictionary,
+} from "./mod.ts";
 
 await init();
 
@@ -42,4 +49,140 @@ Deno.test("cross-validate: zstd compress -> zrip decompress", async () => {
 
   const decompressed = decompress(new Uint8Array(output.stdout));
   assertEquals(decompressed, data);
+});
+
+// Cross-validate all levels
+for (const level of [-7, -3, -1, 1, 2, 3, 4]) {
+  Deno.test(`cross-validate L${level}: zrip compress -> zstd decompress`, async () => {
+    const data = new TextEncoder().encode(
+      `level ${level} cross-validation data `.repeat(200),
+    );
+    const compressed = compress(data, level);
+
+    const proc = new Deno.Command("zstd", {
+      args: ["-d", "--stdout"],
+      stdin: "piped",
+      stdout: "piped",
+    });
+    const child = proc.spawn();
+    const writer = child.stdin.getWriter();
+    await writer.write(compressed);
+    await writer.close();
+    const output = await child.output();
+    assertEquals(output.code, 0, `zstd failed to decompress zrip L${level} output`);
+    assertEquals(new Uint8Array(output.stdout), data);
+  });
+}
+
+// Cross-validate with dictionary
+Deno.test("cross-validate: dict compress zrip -> decompress zstd", async () => {
+  const samples: string[] = [];
+  for (let i = 0; i < 200; i++) {
+    samples.push(
+      JSON.stringify({
+        id: i,
+        user: `user_${i % 20}`,
+        action: ["click", "view", "scroll", "type"][i % 4],
+        ts: 1700000000 + i * 60,
+      }),
+    );
+  }
+
+  // Train dict via zstd CLI
+  const tmpDir = Deno.makeTempDirSync();
+  for (let i = 0; i < samples.length; i++) {
+    Deno.writeTextFileSync(`${tmpDir}/s${i}`, samples[i]);
+  }
+  const trainResult = new Deno.Command("zstd", {
+    args: [
+      "--train",
+      ...Array.from({ length: samples.length }, (_, i) => `${tmpDir}/s${i}`),
+      "-o",
+      `${tmpDir}/dict`,
+    ],
+    stdout: "piped",
+    stderr: "piped",
+  }).outputSync();
+  assertEquals(trainResult.code, 0, "zstd --train failed");
+
+  const dictPath = `${tmpDir}/dict`;
+  const dictBytes = Deno.readFileSync(dictPath);
+  const dict = new Dictionary(dictBytes);
+
+  // Compress with zrip + dict, decompress with C zstd + dict
+  const input = new TextEncoder().encode(samples.slice(0, 10).join("\n"));
+  const compressed = compressWithDict(input, 1, dict);
+
+  const proc = new Deno.Command("zstd", {
+    args: ["-d", "--stdout", "-D", dictPath],
+    stdin: "piped",
+    stdout: "piped",
+  });
+  const child = proc.spawn();
+  const writer = child.stdin.getWriter();
+  await writer.write(compressed);
+  await writer.close();
+  const output = await child.output();
+  assertEquals(output.code, 0, "zstd failed to decompress zrip dict output");
+  assertEquals(new Uint8Array(output.stdout), input);
+
+  // Cleanup
+  for (let i = 0; i < samples.length; i++) Deno.removeSync(`${tmpDir}/s${i}`);
+  Deno.removeSync(dictPath);
+  Deno.removeSync(tmpDir);
+});
+
+Deno.test("cross-validate: dict compress zstd -> decompress zrip", async () => {
+  const samples: string[] = [];
+  for (let i = 0; i < 200; i++) {
+    samples.push(
+      JSON.stringify({
+        id: i,
+        user: `user_${i % 20}`,
+        action: ["click", "view", "scroll", "type"][i % 4],
+        ts: 1700000000 + i * 60,
+      }),
+    );
+  }
+
+  const tmpDir = Deno.makeTempDirSync();
+  for (let i = 0; i < samples.length; i++) {
+    Deno.writeTextFileSync(`${tmpDir}/s${i}`, samples[i]);
+  }
+  const trainResult = new Deno.Command("zstd", {
+    args: [
+      "--train",
+      ...Array.from({ length: samples.length }, (_, i) => `${tmpDir}/s${i}`),
+      "-o",
+      `${tmpDir}/dict`,
+    ],
+    stdout: "piped",
+    stderr: "piped",
+  }).outputSync();
+  assertEquals(trainResult.code, 0, "zstd --train failed");
+
+  const dictPath = `${tmpDir}/dict`;
+  const dictBytes = Deno.readFileSync(dictPath);
+  const dict = new Dictionary(dictBytes);
+
+  // Compress with C zstd + dict, decompress with zrip + dict
+  const input = new TextEncoder().encode(samples.slice(0, 10).join("\n"));
+  Deno.writeFileSync(`${tmpDir}/input`, input);
+
+  const proc = new Deno.Command("zstd", {
+    args: ["-1", "--stdout", "-D", dictPath, `${tmpDir}/input`],
+    stdout: "piped",
+    stderr: "piped",
+  });
+  const result = proc.outputSync();
+  assertEquals(result.code, 0, "zstd compress failed");
+
+  const decompressed = decompressWithDict(new Uint8Array(result.stdout), dict);
+  assertEquals(decompressed, input);
+
+  // Cleanup
+  for (let i = 0; i < samples.length; i++) Deno.removeSync(`${tmpDir}/s${i}`);
+  Deno.removeSync(dictPath);
+  Deno.removeSync(`${tmpDir}/input`);
+  Deno.removeSync(tmpDir);
 });

--- a/jsr/src/cross_test.ts
+++ b/jsr/src/cross_test.ts
@@ -1,0 +1,45 @@
+import { assertEquals } from "https://deno.land/std@0.224.0/assert/mod.ts";
+import { init, compress, decompress } from "./mod.ts";
+
+await init();
+
+Deno.test("cross-validate: zrip compress -> zstd decompress", async () => {
+  const data = new TextEncoder().encode(
+    "cross-validation test data".repeat(200),
+  );
+  const compressed = compress(data, 1);
+
+  const proc = new Deno.Command("zstd", {
+    args: ["-d", "--stdout"],
+    stdin: "piped",
+    stdout: "piped",
+  });
+  const child = proc.spawn();
+  const writer = child.stdin.getWriter();
+  await writer.write(compressed);
+  await writer.close();
+  const output = await child.output();
+  assertEquals(output.code, 0);
+  assertEquals(new Uint8Array(output.stdout), data);
+});
+
+Deno.test("cross-validate: zstd compress -> zrip decompress", async () => {
+  const data = new TextEncoder().encode(
+    "reverse cross-validation".repeat(200),
+  );
+
+  const proc = new Deno.Command("zstd", {
+    args: ["-1", "--stdout"],
+    stdin: "piped",
+    stdout: "piped",
+  });
+  const child = proc.spawn();
+  const writer = child.stdin.getWriter();
+  await writer.write(data);
+  await writer.close();
+  const output = await child.output();
+  assertEquals(output.code, 0);
+
+  const decompressed = decompress(new Uint8Array(output.stdout));
+  assertEquals(decompressed, data);
+});

--- a/jsr/src/mod.ts
+++ b/jsr/src/mod.ts
@@ -1,3 +1,53 @@
+/**
+ * @module
+ *
+ * Pure Rust zstd codec compiled to WebAssembly. Levels -7 through 4
+ * (Fast and DFast strategies). Optimized for encode throughput in transfer
+ * pipelines that need standard zstd frames at high speed.
+ *
+ * Automatically detects WASM SIMD support and loads the appropriate binary.
+ *
+ * ```ts
+ * import { init, compress, decompress } from "@paddor/zrip";
+ *
+ * await init();
+ *
+ * const data = new TextEncoder().encode("hello world".repeat(1000));
+ * const compressed = compress(data, 1);
+ * const original = decompress(compressed);
+ * ```
+ *
+ * Reusable contexts amortize internal allocations across calls:
+ *
+ * ```ts
+ * import { init, Compressor, Decompressor } from "@paddor/zrip";
+ *
+ * await init();
+ *
+ * const compressor = new Compressor(1);
+ * const c1 = compressor.compress(data1);
+ * const c2 = compressor.compress(data2);
+ * compressor.free();
+ *
+ * const decompressor = new Decompressor();
+ * const d1 = decompressor.decompress(c1);
+ * const d2 = decompressor.decompress(c2);
+ * decompressor.free();
+ * ```
+ *
+ * Dictionary compression for small-message workloads:
+ *
+ * ```ts
+ * import { init, compress, compressWithDict, decompressWithDict, Dictionary } from "@paddor/zrip";
+ *
+ * await init();
+ *
+ * const dict = new Dictionary(dictBytes);
+ * const compressed = compressWithDict(data, 1, dict);
+ * const original = decompressWithDict(compressed, dict);
+ * ```
+ */
+
 import {
   initSync,
   compress as wasmCompress,
@@ -40,7 +90,8 @@ export async function init(): Promise<void> {
 
 /**
  * Initialize synchronously with a pre-loaded WASM binary.
- * Use when you have already loaded the WASM bytes (e.g. via fs.readFileSync in Node.js).
+ * Use when you have already loaded the WASM bytes (e.g. via `Deno.readFileSync`
+ * or `fs.readFileSync` in Node.js).
  */
 export function initSyncFromBytes(bytes: BufferSource): void {
   if (initialized) return;
@@ -49,24 +100,52 @@ export function initSyncFromBytes(bytes: BufferSource): void {
 }
 
 /**
- * Compress data at the given level (-7 to 4). Default level is 1.
- * Returns a standard zstd frame.
+ * Compress data at the given zstd level. Returns a standard zstd frame.
+ *
+ * @param input The data to compress.
+ * @param level Compression level from -7 (fastest) to 4 (best ratio). Default: 1.
+ * @returns Compressed zstd frame as a `Uint8Array`.
+ *
+ * @example
+ * ```ts
+ * const compressed = compress(data);           // level 1
+ * const fast = compress(data, -7);             // fastest
+ * const best = compress(data, 4);              // best ratio
+ * ```
  */
 export function compress(input: Uint8Array, level = 1): Uint8Array {
   return wasmCompress(input, level);
 }
 
-/** Decompress a zstd frame. */
+/**
+ * Decompress a zstd frame.
+ *
+ * @param input Compressed zstd frame.
+ * @returns Decompressed data as a `Uint8Array`.
+ * @throws On invalid, truncated, or corrupted input.
+ */
 export function decompress(input: Uint8Array): Uint8Array {
   return wasmDecompress(input);
 }
 
-/** Upper bound on compressed size for a given input length. */
+/**
+ * Upper bound on compressed size for a given input length.
+ * Useful for pre-allocating output buffers.
+ */
 export function compressBound(inputLen: number): number {
   return wasmCompressBound(inputLen);
 }
 
-/** Compress with a pre-parsed dictionary. */
+/**
+ * Compress with a pre-parsed dictionary. Dictionaries improve compression
+ * ratio on small messages (log lines, JSON records, RPC payloads) that
+ * share common structure.
+ *
+ * @param input The data to compress.
+ * @param level Compression level from -7 to 4.
+ * @param dict A {@linkcode Dictionary} instance.
+ * @returns Compressed zstd frame as a `Uint8Array`.
+ */
 export function compressWithDict(
   input: Uint8Array,
   level: number,
@@ -75,7 +154,14 @@ export function compressWithDict(
   return wasmCompressWithDict(input, level, dict);
 }
 
-/** Decompress with a pre-parsed dictionary. */
+/**
+ * Decompress a zstd frame that was compressed with a dictionary.
+ *
+ * @param input Compressed zstd frame.
+ * @param dict The same {@linkcode Dictionary} used during compression.
+ * @returns Decompressed data as a `Uint8Array`.
+ * @throws On invalid input or dictionary mismatch.
+ */
 export function decompressWithDict(
   input: Uint8Array,
   dict: Dictionary,

--- a/jsr/src/mod.ts
+++ b/jsr/src/mod.ts
@@ -1,0 +1,84 @@
+import {
+  initSync,
+  compress as wasmCompress,
+  decompress as wasmDecompress,
+  compressBound as wasmCompressBound,
+  compressWithDict as wasmCompressWithDict,
+  decompressWithDict as wasmDecompressWithDict,
+  Compressor,
+  Decompressor,
+  Dictionary,
+} from "./pkg/zrip_wasm.js";
+
+export { Compressor, Decompressor, Dictionary };
+
+// Minimal valid WASM module that uses a v128 instruction.
+// WebAssembly.validate() returns true only if the engine supports simd128.
+const SIMD_TEST = new Uint8Array([
+  0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00, 0x01, 0x05, 0x01, 0x60,
+  0x00, 0x01, 0x7b, 0x03, 0x02, 0x01, 0x00, 0x0a, 0x0a, 0x01, 0x08, 0x00,
+  0x41, 0x00, 0xfd, 0x0f, 0xfd, 0x62, 0x0b,
+]);
+
+let initialized = false;
+
+/**
+ * Initialize the WASM module. Must be called before any other function.
+ * Automatically detects WASM SIMD support and loads the appropriate binary.
+ */
+export async function init(): Promise<void> {
+  if (initialized) return;
+
+  const simd = WebAssembly.validate(SIMD_TEST);
+  const wasmFile = simd ? "zrip_simd.wasm" : "zrip_scalar.wasm";
+  const wasmUrl = new URL(`./pkg/${wasmFile}`, import.meta.url);
+  const response = await fetch(wasmUrl);
+  const bytes = await response.arrayBuffer();
+  initSync({ module: new WebAssembly.Module(bytes) });
+  initialized = true;
+}
+
+/**
+ * Initialize synchronously with a pre-loaded WASM binary.
+ * Use when you have already loaded the WASM bytes (e.g. via fs.readFileSync in Node.js).
+ */
+export function initSyncFromBytes(bytes: BufferSource): void {
+  if (initialized) return;
+  initSync({ module: new WebAssembly.Module(bytes) });
+  initialized = true;
+}
+
+/**
+ * Compress data at the given level (-7 to 4). Default level is 1.
+ * Returns a standard zstd frame.
+ */
+export function compress(input: Uint8Array, level = 1): Uint8Array {
+  return wasmCompress(input, level);
+}
+
+/** Decompress a zstd frame. */
+export function decompress(input: Uint8Array): Uint8Array {
+  return wasmDecompress(input);
+}
+
+/** Upper bound on compressed size for a given input length. */
+export function compressBound(inputLen: number): number {
+  return wasmCompressBound(inputLen);
+}
+
+/** Compress with a pre-parsed dictionary. */
+export function compressWithDict(
+  input: Uint8Array,
+  level: number,
+  dict: Dictionary,
+): Uint8Array {
+  return wasmCompressWithDict(input, level, dict);
+}
+
+/** Decompress with a pre-parsed dictionary. */
+export function decompressWithDict(
+  input: Uint8Array,
+  dict: Dictionary,
+): Uint8Array {
+  return wasmDecompressWithDict(input, dict);
+}

--- a/jsr/src/mod_test.ts
+++ b/jsr/src/mod_test.ts
@@ -1,16 +1,25 @@
-import { assertEquals, assert } from "https://deno.land/std@0.224.0/assert/mod.ts";
+import {
+  assertEquals,
+  assert,
+  assertThrows,
+} from "https://deno.land/std@0.224.0/assert/mod.ts";
 import {
   init,
   compress,
   decompress,
   compressBound,
+  compressWithDict,
+  decompressWithDict,
   Compressor,
   Decompressor,
+  Dictionary,
 } from "./mod.ts";
 
 Deno.test("init", async () => {
   await init();
 });
+
+// --- One-shot ---
 
 Deno.test("one-shot round-trip", () => {
   const data = new TextEncoder().encode("hello world, hello zstd!".repeat(100));
@@ -41,6 +50,15 @@ Deno.test("empty input", () => {
   assertEquals(decompressed, empty);
 });
 
+Deno.test("incompressible data", () => {
+  const random = crypto.getRandomValues(new Uint8Array(4096));
+  const compressed = compress(random);
+  const decompressed = decompress(compressed);
+  assertEquals(decompressed, random);
+});
+
+// --- Stateful ---
+
 Deno.test("stateful compressor", () => {
   const compressor = new Compressor(1);
   const data1 = new TextEncoder().encode("first message".repeat(50));
@@ -69,9 +87,157 @@ Deno.test("stateful decompressor", () => {
   decompressor.free();
 });
 
-Deno.test("incompressible data", () => {
-  const random = crypto.getRandomValues(new Uint8Array(4096));
-  const compressed = compress(random);
-  const decompressed = decompress(compressed);
-  assertEquals(decompressed, random);
+// --- Dictionary ---
+
+function trainDict(): { dict: Dictionary; samples: Uint8Array } {
+  const sampleStrings: string[] = [];
+  for (let i = 0; i < 200; i++) {
+    sampleStrings.push(
+      JSON.stringify({
+        id: i,
+        user: `user_${i % 20}`,
+        action: ["click", "view", "scroll", "type"][i % 4],
+        ts: 1700000000 + i * 60,
+      }),
+    );
+  }
+  const samples = new TextEncoder().encode(sampleStrings.join("\n"));
+
+  const tmpDir = Deno.makeTempDirSync();
+  for (let i = 0; i < sampleStrings.length; i++) {
+    Deno.writeTextFileSync(`${tmpDir}/s${i}`, sampleStrings[i]);
+  }
+
+  const result = new Deno.Command("zstd", {
+    args: ["--train", ...Array.from({ length: sampleStrings.length }, (_, i) => `${tmpDir}/s${i}`), "-o", `${tmpDir}/dict`],
+    stdout: "piped",
+    stderr: "piped",
+  }).outputSync();
+
+  if (result.code !== 0) {
+    throw new Error(`zstd --train failed: ${new TextDecoder().decode(result.stderr)}`);
+  }
+
+  const dictBytes = Deno.readFileSync(`${tmpDir}/dict`);
+
+  for (let i = 0; i < sampleStrings.length; i++) Deno.removeSync(`${tmpDir}/s${i}`);
+  Deno.removeSync(`${tmpDir}/dict`);
+  Deno.removeSync(tmpDir);
+
+  return { dict: new Dictionary(dictBytes), samples };
+}
+
+let _dictCache: { dict: Dictionary; samples: Uint8Array } | null = null;
+function getDict(): { dict: Dictionary; samples: Uint8Array } {
+  if (!_dictCache) {
+    _dictCache = trainDict();
+  }
+  return _dictCache;
+}
+
+Deno.test("dictionary one-shot round-trip", () => {
+  const { dict, samples } = getDict();
+  const compressed = compressWithDict(samples, 1, dict);
+  const decompressed = decompressWithDict(compressed, dict);
+  assertEquals(decompressed, samples);
+});
+
+Deno.test("dictionary all levels", () => {
+  const { dict, samples } = getDict();
+  for (let level = -7; level <= 4; level++) {
+    const compressed = compressWithDict(samples, level, dict);
+    const decompressed = decompressWithDict(compressed, dict);
+    assertEquals(decompressed, samples, `dict round-trip failed at level ${level}`);
+  }
+});
+
+Deno.test("dictionary improves ratio", () => {
+  const { dict } = getDict();
+  // Compress a single sample that matches the dict's training data
+  const sample = new TextEncoder().encode(
+    JSON.stringify({ id: 999, user: "user_5", action: "click", ts: 1700060000 }),
+  );
+  const withDict = compressWithDict(sample, 1, dict);
+  const withoutDict = compress(sample, 1);
+  assert(
+    withDict.length <= withoutDict.length,
+    `dict should help: ${withDict.length} > ${withoutDict.length}`,
+  );
+});
+
+Deno.test("dictionary id", () => {
+  const { dict } = getDict();
+  assert(dict.id > 0, "dict id should be nonzero");
+});
+
+Deno.test("stateful compressor with dict", () => {
+  const { dict } = getDict();
+  const compressor = Compressor.withDict(1, dict);
+  const sample = new TextEncoder().encode(
+    JSON.stringify({ id: 42, user: "user_1", action: "view", ts: 1700002520 }),
+  );
+
+  const compressed = compressor.compress(sample);
+  const decompressor = Decompressor.withDict(dict);
+  const decompressed = decompressor.decompress(compressed);
+  assertEquals(decompressed, sample);
+
+  compressor.free();
+  decompressor.free();
+});
+
+Deno.test("stateful compressor compressWithDict", () => {
+  const { dict } = getDict();
+  const compressor = new Compressor(1);
+  const sample = new TextEncoder().encode(
+    JSON.stringify({ id: 77, user: "user_10", action: "scroll", ts: 1700004620 }),
+  );
+
+  const compressed = compressor.compressWithDict(sample, dict);
+  const decompressor = Decompressor.withDict(dict);
+  const decompressed = decompressor.decompress(compressed);
+  assertEquals(decompressed, sample);
+
+  compressor.free();
+  decompressor.free();
+});
+
+// --- Error paths ---
+
+Deno.test("decompress invalid data throws", () => {
+  assertThrows(
+    () => decompress(new Uint8Array([0, 1, 2, 3, 4, 5])),
+    Error,
+  );
+});
+
+Deno.test("decompress truncated frame throws", () => {
+  const data = new TextEncoder().encode("hello".repeat(100));
+  const compressed = compress(data);
+  // Truncate the compressed data
+  assertThrows(
+    () => decompress(compressed.slice(0, compressed.length / 2)),
+    Error,
+  );
+});
+
+Deno.test("decompress corrupted frame throws", () => {
+  const data = new TextEncoder().encode("test data for corruption".repeat(50));
+  const compressed = compress(data);
+  // Flip some bytes in the middle
+  const corrupted = new Uint8Array(compressed);
+  corrupted[compressed.length / 2] ^= 0xff;
+  corrupted[compressed.length / 2 + 1] ^= 0xff;
+  assertThrows(
+    () => decompress(corrupted),
+    Error,
+  );
+});
+
+Deno.test("invalid compression level throws", () => {
+  const data = new TextEncoder().encode("test");
+  assertThrows(
+    () => compress(data, 99),
+    Error,
+  );
 });

--- a/jsr/src/mod_test.ts
+++ b/jsr/src/mod_test.ts
@@ -1,0 +1,77 @@
+import { assertEquals, assert } from "https://deno.land/std@0.224.0/assert/mod.ts";
+import {
+  init,
+  compress,
+  decompress,
+  compressBound,
+  Compressor,
+  Decompressor,
+} from "./mod.ts";
+
+Deno.test("init", async () => {
+  await init();
+});
+
+Deno.test("one-shot round-trip", () => {
+  const data = new TextEncoder().encode("hello world, hello zstd!".repeat(100));
+  const compressed = compress(data);
+  assert(compressed.length < data.length);
+  const decompressed = decompress(compressed);
+  assertEquals(decompressed, data);
+});
+
+Deno.test("all levels", () => {
+  const data = new TextEncoder().encode("test data for all levels".repeat(50));
+  for (let level = -7; level <= 4; level++) {
+    const compressed = compress(data, level);
+    const decompressed = decompress(compressed);
+    assertEquals(decompressed, data, `round-trip failed at level ${level}`);
+  }
+});
+
+Deno.test("compressBound", () => {
+  const bound = compressBound(1000);
+  assert(bound >= 1000);
+});
+
+Deno.test("empty input", () => {
+  const empty = new Uint8Array(0);
+  const compressed = compress(empty);
+  const decompressed = decompress(compressed);
+  assertEquals(decompressed, empty);
+});
+
+Deno.test("stateful compressor", () => {
+  const compressor = new Compressor(1);
+  const data1 = new TextEncoder().encode("first message".repeat(50));
+  const data2 = new TextEncoder().encode("second message".repeat(50));
+
+  const c1 = compressor.compress(data1);
+  const c2 = compressor.compress(data2);
+
+  assertEquals(decompress(c1), data1);
+  assertEquals(decompress(c2), data2);
+
+  compressor.free();
+});
+
+Deno.test("stateful decompressor", () => {
+  const data1 = new TextEncoder().encode("decompress test 1".repeat(50));
+  const data2 = new TextEncoder().encode("decompress test 2".repeat(50));
+
+  const c1 = compress(data1);
+  const c2 = compress(data2);
+
+  const decompressor = new Decompressor();
+  assertEquals(decompressor.decompress(c1), data1);
+  assertEquals(decompressor.decompress(c2), data2);
+
+  decompressor.free();
+});
+
+Deno.test("incompressible data", () => {
+  const random = crypto.getRandomValues(new Uint8Array(4096));
+  const compressed = compress(random);
+  const decompressed = decompress(compressed);
+  assertEquals(decompressed, random);
+});

--- a/jsr/wasm/.cargo/config.toml
+++ b/jsr/wasm/.cargo/config.toml
@@ -1,0 +1,5 @@
+[target.wasm32-unknown-unknown]
+rustflags = []
+
+[build]
+rustflags = []

--- a/jsr/wasm/Cargo.toml
+++ b/jsr/wasm/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "zrip-wasm"
+version = "0.1.0"
+edition = "2024"
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+zrip = { path = "../..", default-features = false, features = ["std"] }
+wasm-bindgen = "0.2"
+
+[package.metadata.wasm-pack.profile.release]
+wasm-opt = false
+
+[profile.release]
+opt-level = 3
+lto = true
+codegen-units = 1
+strip = true

--- a/jsr/wasm/src/lib.rs
+++ b/jsr/wasm/src/lib.rs
@@ -1,0 +1,132 @@
+use wasm_bindgen::prelude::*;
+
+// === One-shot functions ===
+
+#[wasm_bindgen]
+pub fn compress(input: &[u8], level: i32) -> Result<Vec<u8>, JsError> {
+    zrip::compress(input, level).map_err(|e| JsError::new(&e.to_string()))
+}
+
+#[wasm_bindgen]
+pub fn decompress(input: &[u8]) -> Result<Vec<u8>, JsError> {
+    zrip::decompress(input).map_err(|e| JsError::new(&e.to_string()))
+}
+
+#[wasm_bindgen(js_name = "compressBound")]
+pub fn compress_bound(input_len: usize) -> usize {
+    zrip::compress_bound(input_len)
+}
+
+// === Dictionary ===
+
+#[wasm_bindgen(js_name = "Dictionary")]
+pub struct ZstdDictionary {
+    inner: zrip::Dictionary,
+}
+
+#[wasm_bindgen(js_class = "Dictionary")]
+impl ZstdDictionary {
+    #[wasm_bindgen(constructor)]
+    pub fn new(data: &[u8]) -> Result<ZstdDictionary, JsError> {
+        zrip::Dictionary::from_bytes(data)
+            .map(|d| ZstdDictionary { inner: d })
+            .map_err(|e| JsError::new(&e.to_string()))
+    }
+
+    #[wasm_bindgen(getter)]
+    pub fn id(&self) -> u32 {
+        self.inner.id()
+    }
+}
+
+// === One-shot with dict ===
+
+#[wasm_bindgen(js_name = "compressWithDict")]
+pub fn compress_with_dict(
+    input: &[u8],
+    level: i32,
+    dict: &ZstdDictionary,
+) -> Result<Vec<u8>, JsError> {
+    zrip::compress_with_dict(input, level, &dict.inner)
+        .map_err(|e| JsError::new(&e.to_string()))
+}
+
+#[wasm_bindgen(js_name = "decompressWithDict")]
+pub fn decompress_with_dict(input: &[u8], dict: &ZstdDictionary) -> Result<Vec<u8>, JsError> {
+    zrip::decompress_with_dict(input, &dict.inner)
+        .map_err(|e| JsError::new(&e.to_string()))
+}
+
+// === Stateful Compressor ===
+
+#[wasm_bindgen]
+pub struct Compressor {
+    ctx: zrip::CompressContext,
+}
+
+#[wasm_bindgen]
+impl Compressor {
+    #[wasm_bindgen(constructor)]
+    pub fn new(level: i32) -> Result<Compressor, JsError> {
+        zrip::CompressContext::new(level)
+            .map(|ctx| Compressor { ctx })
+            .map_err(|e| JsError::new(&e.to_string()))
+    }
+
+    #[wasm_bindgen(js_name = "withDict")]
+    pub fn with_dict(level: i32, dict: &ZstdDictionary) -> Result<Compressor, JsError> {
+        zrip::CompressContext::with_dict(level, dict.inner.clone())
+            .map(|ctx| Compressor { ctx })
+            .map_err(|e| JsError::new(&e.to_string()))
+    }
+
+    pub fn compress(&mut self, input: &[u8]) -> Result<Vec<u8>, JsError> {
+        self.ctx
+            .compress(input)
+            .map(|cow| cow.into_owned())
+            .map_err(|e| JsError::new(&e.to_string()))
+    }
+
+    #[wasm_bindgen(js_name = "compressWithDict")]
+    pub fn compress_with_dict(
+        &mut self,
+        input: &[u8],
+        dict: &ZstdDictionary,
+    ) -> Result<Vec<u8>, JsError> {
+        self.ctx
+            .compress_with_dict(input, &dict.inner)
+            .map(|cow| cow.into_owned())
+            .map_err(|e| JsError::new(&e.to_string()))
+    }
+}
+
+// === Stateful Decompressor ===
+
+#[wasm_bindgen]
+pub struct Decompressor {
+    ctx: zrip::DecompressContext,
+}
+
+#[wasm_bindgen]
+impl Decompressor {
+    #[wasm_bindgen(constructor)]
+    pub fn new() -> Decompressor {
+        Decompressor {
+            ctx: zrip::DecompressContext::new(),
+        }
+    }
+
+    #[wasm_bindgen(js_name = "withDict")]
+    pub fn with_dict(dict: &ZstdDictionary) -> Decompressor {
+        Decompressor {
+            ctx: zrip::DecompressContext::with_dict(dict.inner.clone()),
+        }
+    }
+
+    pub fn decompress(&mut self, input: &[u8]) -> Result<Vec<u8>, JsError> {
+        self.ctx
+            .decompress(input)
+            .map(|cow| cow.into_owned())
+            .map_err(|e| JsError::new(&e.to_string()))
+    }
+}


### PR DESCRIPTION
- WASM build via `wasm-pack` with scalar and SIMD128 variants, auto-detected at init
- Full JS/TS API: one-shot compress/decompress, reusable `Compressor`/`Decompressor` contexts, dictionary support
- 29 tests: all levels, dictionary round-trips, cross-validation against C zstd (both directions), error paths
- JSR package docs: README overview, JSDoc on all exports
- WASM benchmark on Silesia corpus at L1: 15% faster encode, 14% faster decode than C zstd WASM (zstd-codec)
- Published as `@paddor/zrip` 0.1.1 on JSR