### PR TITLE
Release 0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,31 @@
 
 ## [Unreleased]
 
+## [0.5.0]
+
+### Added
+
+- `paranoid` feature: compiles pure safe Rust with zero unsafe code.
+  `#![forbid(unsafe_code)]` enforced on all four crate roots. Every
+  unchecked operation has a safe alternative behind `#[cfg(feature =
+  "paranoid")]`. SIMD modules gated out entirely; `cpu_tier()` returns
+  `Scalar`. Even with paranoid, zrip L1 encode is >2x faster than
+  ruzstd.
+- CI job for `--features paranoid`: test + clippy.
+- WebAssembly package published as
+  [`@paddor/zrip`](https://jsr.io/@paddor/zrip) on JSR. Scalar and
+  SIMD128 variants with auto-detection. 15% faster encode and 14%
+  faster decode than C zstd compiled to WASM.
+
+### Changed
+
+- Replaced pointer-based `exec.rs` (scalar sequence decoder) with safe
+  index-based implementation using `Vec<u8>` operations. Zero
+  performance impact on default builds (SIMD handles all decode on
+  AVX2/NEON hardware). Deleted `decode/src/primitives.rs` (dead code
+  after this change).
+- Regenerated x86_64 benchmark charts with paranoid data.
+
 ## [0.4.0]
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ exclude = ["fuzz", "bench", "jsr"]
 
 [package]
 name = "zrip"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2024"
 rust-version = "1.85"
 description = "Fast, memory-safe Rust implementation of Zstandard compression (levels -7..4)"
@@ -24,9 +24,9 @@ nightly = ["zrip-core/nightly", "zrip-encode/nightly", "zrip-decode/nightly"]
 paranoid = ["zrip-core/paranoid", "zrip-encode/paranoid", "zrip-decode/paranoid"]
 
 [dependencies]
-zrip-core = { version = "0.4.0", path = "crates/core", default-features = false }
-zrip-encode = { version = "0.4.0", path = "crates/encode", default-features = false }
-zrip-decode = { version = "0.4.0", path = "crates/decode", default-features = false }
+zrip-core = { version = "0.5.0", path = "crates/core", default-features = false }
+zrip-encode = { version = "0.5.0", path = "crates/encode", default-features = false }
+zrip-decode = { version = "0.5.0", path = "crates/decode", default-features = false }
 
 [lints]
 workspace = true

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zrip-core"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2024"
 rust-version = "1.85"
 description = "Shared types and codecs for zrip (internal crate)"

--- a/crates/decode/Cargo.toml
+++ b/crates/decode/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zrip-decode"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2024"
 rust-version = "1.85"
 description = "zstd decoder for zrip (internal crate)"
@@ -20,7 +20,7 @@ nightly = ["zrip-core/nightly"]
 paranoid = ["zrip-core/paranoid"]
 
 [dependencies]
-zrip-core = { version = "0.4.0", path = "../core", default-features = false }
+zrip-core = { version = "0.5.0", path = "../core", default-features = false }
 
 [dev-dependencies]
 zrip = { path = "../.." }

--- a/crates/encode/Cargo.toml
+++ b/crates/encode/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zrip-encode"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2024"
 rust-version = "1.85"
 description = "zstd encoder for zrip (internal crate)"
@@ -20,7 +20,7 @@ nightly = ["zrip-core/nightly"]
 paranoid = ["zrip-core/paranoid"]
 
 [dependencies]
-zrip-core = { version = "0.4.0", path = "../core", default-features = false }
+zrip-core = { version = "0.5.0", path = "../core", default-features = false }
 
 [dev-dependencies]
 zrip = { path = "../.." }


### PR DESCRIPTION
- `paranoid` feature: pure safe Rust, `#![forbid(unsafe_code)]` on all crates, SIMD gated out
- CI job for `--features paranoid`
- Replaced pointer-based `exec.rs` with safe index-based implementation (zero perf impact on default build)
- Deleted dead `decode/src/primitives.rs`
- Regenerated x86_64 charts with paranoid data
- WebAssembly package `@paddor/zrip` on JSR
- Bumped all crate versions 0.4.0 -> 0.5.0