### PR TITLE
Prepare release 0.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,34 @@
 
 ## [Unreleased]
 
+## [0.5.1]
+
+### Fixed
+
+- Decoder now enforces per-table accuracy log limits: literal lengths
+  and match lengths max 9, offsets max 8 (RFC 8878 section 3.1.1.3.2.1).
+- Decoder rejects Huffman weight FSE tables with accuracy log > 6
+  (RFC 8878 section 4.2.1).
+- Decoder rejects Huffman streams with leftover bits after decoding.
+- Decoder validates match offset does not exceed total output produced
+  so far (current block + previous blocks + dictionary).
+- Decoder validates sequence execution does not consume more literals
+  than available, and that the last sequence uses all remaining literals.
+- Decoder validates cooked match length and literal length values are
+  within bounds.
+- Decoder rejects Repeat_Mode on first block when no prior FSE table
+  exists.
+
+### Added
+
+- `tests/spec_conformance.rs`: comprehensive test suite covering all
+  new validation paths and existing error paths.
+
+### Changed
+
+- Bumped structured-zstd bench dependency to 0.0.44 and regenerated
+  benchmark charts.
+
 ## [0.5.0]
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ exclude = ["fuzz", "bench", "jsr"]
 
 [package]
 name = "zrip"
-version = "0.5.0"
+version = "0.5.1"
 edition = "2024"
 rust-version = "1.85"
 description = "Fast, memory-safe Rust implementation of Zstandard compression (levels -7..4)"
@@ -24,9 +24,9 @@ nightly = ["zrip-core/nightly", "zrip-encode/nightly", "zrip-decode/nightly"]
 paranoid = ["zrip-core/paranoid", "zrip-encode/paranoid", "zrip-decode/paranoid"]
 
 [dependencies]
-zrip-core = { version = "0.5.0", path = "crates/core", default-features = false }
-zrip-encode = { version = "0.5.0", path = "crates/encode", default-features = false }
-zrip-decode = { version = "0.5.0", path = "crates/decode", default-features = false }
+zrip-core = { version = "0.5.1", path = "crates/core", default-features = false }
+zrip-encode = { version = "0.5.1", path = "crates/encode", default-features = false }
+zrip-decode = { version = "0.5.1", path = "crates/decode", default-features = false }
 
 [lints]
 workspace = true

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zrip-core"
-version = "0.5.0"
+version = "0.5.1"
 edition = "2024"
 rust-version = "1.85"
 description = "Shared types and codecs for zrip (internal crate)"

--- a/crates/decode/Cargo.toml
+++ b/crates/decode/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zrip-decode"
-version = "0.5.0"
+version = "0.5.1"
 edition = "2024"
 rust-version = "1.85"
 description = "zstd decoder for zrip (internal crate)"
@@ -20,7 +20,7 @@ nightly = ["zrip-core/nightly"]
 paranoid = ["zrip-core/paranoid"]
 
 [dependencies]
-zrip-core = { version = "0.5.0", path = "../core", default-features = false }
+zrip-core = { version = "0.5.1", path = "../core", default-features = false }
 
 [dev-dependencies]
 zrip = { path = "../.." }

--- a/crates/encode/Cargo.toml
+++ b/crates/encode/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zrip-encode"
-version = "0.5.0"
+version = "0.5.1"
 edition = "2024"
 rust-version = "1.85"
 description = "zstd encoder for zrip (internal crate)"
@@ -20,7 +20,7 @@ nightly = ["zrip-core/nightly"]
 paranoid = ["zrip-core/paranoid"]
 
 [dependencies]
-zrip-core = { version = "0.5.0", path = "../core", default-features = false }
+zrip-core = { version = "0.5.1", path = "../core", default-features = false }
 
 [dev-dependencies]
 zrip = { path = "../.." }


### PR DESCRIPTION
- Bump zrip, zrip-core, zrip-encode, zrip-decode to 0.5.1
- Add changelog entry for decoder spec conformance fixes from #18