### PR TITLE
Improve JSR package quality and add publish workflow

### DIFF
--- a/.github/workflows/jsr.yml
+++ b/.github/workflows/jsr.yml
@@ -1,0 +1,23 @@
+name: jsr-publish
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-unknown
+      - uses: denoland/setup-deno@v2
+        with:
+          deno-version: v2.x
+      - run: cargo install wasm-pack
+      - run: cd jsr && bash build.sh
+      - run: cd jsr && deno publish

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,10 +23,15 @@
 ### Added
 
 - `tests/spec_conformance.rs`: comprehensive test suite covering all
-  new validation paths and existing error paths.
+  new decoder validation paths and existing error paths.
+- JSR publish workflow (`.github/workflows/jsr.yml`) with provenance
+  via OIDC. Builds WASM and publishes `@paddor/zrip` on push to main.
 
 ### Changed
 
+- JSR package `@paddor/zrip` bumped to 0.2.0: added package description,
+  JSDoc on all exported symbols (`Compressor`, `Decompressor`,
+  `Dictionary`), and rebuilt WASM artifacts.
 - Bumped structured-zstd bench dependency to 0.0.44 and regenerated
   benchmark charts.
 

--- a/jsr/deno.json
+++ b/jsr/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@paddor/zrip",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "license": "MIT",
   "exports": "./src/mod.ts",
   "publish": {

--- a/jsr/deno.json
+++ b/jsr/deno.json
@@ -1,7 +1,8 @@
 {
   "name": "@paddor/zrip",
-  "version": "0.1.2",
+  "version": "0.2.0",
   "license": "MIT",
+  "description": "Pure Rust zstd codec compiled to WebAssembly. Fast compression levels -7..4 with SIMD auto-detection.",
   "exports": "./src/mod.ts",
   "publish": {
     "include": ["src/", "deno.json", "LICENSE", "README.md"],

--- a/jsr/src/mod.ts
+++ b/jsr/src/mod.ts
@@ -55,12 +55,60 @@ import {
   compressBound as wasmCompressBound,
   compressWithDict as wasmCompressWithDict,
   decompressWithDict as wasmDecompressWithDict,
-  Compressor,
-  Decompressor,
-  Dictionary,
+  Compressor as _Compressor,
+  Decompressor as _Decompressor,
+  Dictionary as _Dictionary,
 } from "./pkg/zrip_wasm.js";
 
-export { Compressor, Decompressor, Dictionary };
+/**
+ * Reusable compression context. Amortizes internal allocations across
+ * multiple compress calls. Call {@linkcode Compressor.free | .free()} when done,
+ * or use `using` for automatic disposal.
+ *
+ * @example
+ * ```ts
+ * const compressor = new Compressor(1);
+ * const c1 = compressor.compress(data1);
+ * const c2 = compressor.compress(data2);
+ * compressor.free();
+ * ```
+ */
+export const Compressor: typeof _Compressor = _Compressor;
+/** Type alias for {@linkcode Compressor} instances. */
+export type Compressor = _Compressor;
+
+/**
+ * Reusable decompression context. Amortizes internal allocations across
+ * multiple decompress calls. Call {@linkcode Decompressor.free | .free()} when done,
+ * or use `using` for automatic disposal.
+ *
+ * @example
+ * ```ts
+ * const decompressor = new Decompressor();
+ * const d1 = decompressor.decompress(c1);
+ * const d2 = decompressor.decompress(c2);
+ * decompressor.free();
+ * ```
+ */
+export const Decompressor: typeof _Decompressor = _Decompressor;
+/** Type alias for {@linkcode Decompressor} instances. */
+export type Decompressor = _Decompressor;
+
+/**
+ * Pre-parsed zstd dictionary for use with dictionary compression.
+ * Construct from raw dictionary bytes (trained externally via `zstd --train`
+ * or similar). Reuse across compress/decompress calls.
+ *
+ * @example
+ * ```ts
+ * const dict = new Dictionary(dictBytes);
+ * const compressed = compressWithDict(data, 1, dict);
+ * dict.free();
+ * ```
+ */
+export const Dictionary: typeof _Dictionary = _Dictionary;
+/** Type alias for {@linkcode Dictionary} instances. */
+export type Dictionary = _Dictionary;
 
 // Minimal valid WASM module that uses a v128 instruction.
 // WebAssembly.validate() returns true only if the engine supports simd128.


### PR DESCRIPTION
- Add JSDoc to re-exported `Compressor`, `Decompressor`, `Dictionary` classes (70% -> 100% symbol docs)
- Add `description` field to `jsr/deno.json`
- Bump `@paddor/zrip` to 0.2.0
- Add `.github/workflows/jsr.yml`: builds WASM, publishes to JSR with OIDC provenance on push to main
- After merge, link the package to this repo at https://jsr.io/@paddor/zrip/settings and mark Deno + browsers as compatible runtimes (web-UI-only settings)