### PR TITLE
Add WASM SIMD128 decode path

### DIFF
--- a/bench/wasm/Cargo.toml
+++ b/bench/wasm/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "zrip-bench-wasm"
+version = "0.1.0"
+edition = "2024"
+publish = false
+
+[dependencies]
+zrip = { path = "../.." }
+zstd = { version = "0.13", optional = true }
+
+[features]
+default = []
+czstd = ["zstd"]
+paranoid = ["zrip/paranoid"]

--- a/bench/wasm/src/main.rs
+++ b/bench/wasm/src/main.rs
@@ -1,0 +1,177 @@
+use std::env;
+use std::io::Read;
+use std::time::Instant;
+
+fn main() {
+    let args: Vec<String> = env::args().collect();
+
+    let mut iters: u32 = 0;
+    let mut label = String::from("stdin");
+    let mut level: i32 = 1;
+
+    let mut i = 1;
+    while i < args.len() {
+        match args[i].as_str() {
+            "--iters" => {
+                i += 1;
+                iters = args[i].parse().expect("invalid --iters value");
+            }
+            "--label" => {
+                i += 1;
+                label = args[i].clone();
+            }
+            "--level" => {
+                i += 1;
+                level = args[i].parse().expect("invalid --level value");
+            }
+            _ => {
+                eprintln!("unknown arg: {}", args[i]);
+                std::process::exit(1);
+            }
+        }
+        i += 1;
+    }
+
+    let mut raw = Vec::new();
+    std::io::stdin()
+        .read_to_end(&mut raw)
+        .expect("failed to read stdin");
+
+    if raw.is_empty() {
+        eprintln!("no data on stdin");
+        std::process::exit(1);
+    }
+
+    let original_size = raw.len();
+
+    // Encode benchmark
+    let compressed = bench_encode("zrip", &label, &raw, level, iters);
+    #[cfg(feature = "czstd")]
+    let _czstd_compressed = bench_encode_czstd(&label, &raw, level, iters);
+
+    // Decode benchmark (using zrip-compressed data for zrip, same for C zstd)
+    bench_decode("zrip", &label, &compressed, original_size, iters);
+    #[cfg(feature = "czstd")]
+    bench_decode_czstd(&label, &compressed, original_size, iters);
+}
+
+fn bench_encode(
+    impl_name: &str,
+    label: &str,
+    raw: &[u8],
+    level: i32,
+    iters: u32,
+) -> Vec<u8> {
+    let compressed = zrip::compress(raw, level).expect("zrip compress failed");
+    let ratio = raw.len() as f64 / compressed.len() as f64;
+
+    let iters = if iters == 0 {
+        calibrate(|| {
+            let _ = zrip::compress(raw, level).unwrap();
+        })
+    } else {
+        iters
+    };
+
+    let start = Instant::now();
+    for _ in 0..iters {
+        let _ = zrip::compress(raw, level).unwrap();
+    }
+    let elapsed = start.elapsed();
+    print_result(impl_name, "encode", label, raw.len(), iters, elapsed, ratio);
+    compressed
+}
+
+#[cfg(feature = "czstd")]
+fn bench_encode_czstd(label: &str, raw: &[u8], level: i32, iters: u32) -> Vec<u8> {
+    let compressed = zstd::encode_all(raw, level).expect("C zstd compress failed");
+    let ratio = raw.len() as f64 / compressed.len() as f64;
+
+    let iters = if iters == 0 {
+        calibrate(|| {
+            let _ = zstd::encode_all(raw, level).unwrap();
+        })
+    } else {
+        iters
+    };
+
+    let start = Instant::now();
+    for _ in 0..iters {
+        let _ = zstd::encode_all(raw, level).unwrap();
+    }
+    let elapsed = start.elapsed();
+    print_result("C zstd", "encode", label, raw.len(), iters, elapsed, ratio);
+    compressed
+}
+
+fn bench_decode(
+    impl_name: &str,
+    label: &str,
+    compressed: &[u8],
+    original_size: usize,
+    iters: u32,
+) {
+    let iters = if iters == 0 {
+        calibrate(|| {
+            let _ = zrip::decompress(compressed).unwrap();
+        })
+    } else {
+        iters
+    };
+
+    let start = Instant::now();
+    for _ in 0..iters {
+        let _ = zrip::decompress(compressed).expect("decompression failed");
+    }
+    let elapsed = start.elapsed();
+    print_result(impl_name, "decode", label, original_size, iters, elapsed, 0.0);
+}
+
+#[cfg(feature = "czstd")]
+fn bench_decode_czstd(label: &str, compressed: &[u8], original_size: usize, iters: u32) {
+    let iters = if iters == 0 {
+        calibrate(|| {
+            let _ = zstd::decode_all(compressed).unwrap();
+        })
+    } else {
+        iters
+    };
+
+    let start = Instant::now();
+    for _ in 0..iters {
+        let _ = zstd::decode_all(compressed).expect("C zstd decompression failed");
+    }
+    let elapsed = start.elapsed();
+    print_result("C zstd", "decode", label, original_size, iters, elapsed, 0.0);
+}
+
+fn calibrate(mut f: impl FnMut()) -> u32 {
+    let target_ns: u64 = 500_000_000;
+    let start = Instant::now();
+    f();
+    let single_ns = start.elapsed().as_nanos() as u64;
+    ((target_ns / single_ns.max(1)) as u32).clamp(4, 10000)
+}
+
+fn print_result(
+    impl_name: &str,
+    op: &str,
+    label: &str,
+    size: usize,
+    iters: u32,
+    elapsed: std::time::Duration,
+    ratio: f64,
+) {
+    let total_bytes = size as u64 * iters as u64;
+    let throughput_mbps = total_bytes as f64 / elapsed.as_secs_f64() / 1_000_000.0;
+    let per_iter_us = elapsed.as_micros() as f64 / iters as f64;
+    if ratio > 0.0 {
+        println!(
+            "{impl_name:>8} {op:>6} {label}: {throughput_mbps:.1} MB/s ({ratio:.2}x, {iters} iters, {per_iter_us:.0} \u{00b5}s/iter)",
+        );
+    } else {
+        println!(
+            "{impl_name:>8} {op:>6} {label}: {throughput_mbps:.1} MB/s ({iters} iters, {per_iter_us:.0} \u{00b5}s/iter)",
+        );
+    }
+}

--- a/crates/core/src/simd/copy.rs
+++ b/crates/core/src/simd/copy.rs
@@ -1,7 +1,10 @@
 #[cfg(feature = "alloc")]
 use alloc::vec::Vec;
 
-#[cfg(all(target_arch = "x86_64", not(feature = "paranoid")))]
+#[cfg(all(
+    any(target_arch = "x86_64", target_arch = "wasm32"),
+    not(feature = "paranoid")
+))]
 use super::CpuTier;
 
 #[inline]
@@ -43,6 +46,18 @@ pub fn append_literals(dst: &mut Vec<u8>, src: &[u8]) {
                 unsafe {
                     let dst_ptr = dst.as_mut_ptr().add(dst_offset);
                     super::aarch64::neon::wildcopy_neon(src.as_ptr(), dst_ptr, len);
+                    dst.set_len(dst_offset + len);
+                }
+                return;
+            }
+        }
+
+        #[cfg(target_arch = "wasm32")]
+        {
+            if super::cpu_tier() >= CpuTier::Wasm32Simd128 && len >= 16 {
+                unsafe {
+                    let dst_ptr = dst.as_mut_ptr().add(dst_offset);
+                    super::wasm32::simd128::wildcopy_wasm32(src.as_ptr(), dst_ptr, len);
                     dst.set_len(dst_offset + len);
                 }
                 return;
@@ -115,6 +130,12 @@ pub fn common_prefix_len(a: &[u8], b: &[u8]) -> usize {
     {
         if a.len() >= 16 && b.len() >= 16 {
             return unsafe { super::aarch64::neon::common_prefix_len_neon(a, b) };
+        }
+    }
+    #[cfg(all(target_arch = "wasm32", not(feature = "paranoid")))]
+    {
+        if super::cpu_tier() >= CpuTier::Wasm32Simd128 && a.len() >= 16 && b.len() >= 16 {
+            return unsafe { super::wasm32::simd128::common_prefix_len_wasm32(a, b) };
         }
     }
     super::scalar::common_prefix_len(a, b)

--- a/crates/core/src/simd/mod.rs
+++ b/crates/core/src/simd/mod.rs
@@ -6,6 +6,9 @@ pub mod x86_64;
 #[cfg(all(target_arch = "aarch64", not(feature = "paranoid")))]
 pub mod aarch64;
 
+#[cfg(all(target_arch = "wasm32", not(feature = "paranoid")))]
+pub mod wasm32;
+
 pub mod copy;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
@@ -19,6 +22,8 @@ pub enum CpuTier {
     Avx2,
     #[cfg(target_arch = "aarch64")]
     Neon,
+    #[cfg(target_arch = "wasm32")]
+    Wasm32Simd128,
 }
 
 #[cfg(all(feature = "std", not(feature = "paranoid")))]
@@ -60,7 +65,19 @@ fn detect_cpu_tier() -> CpuTier {
     {
         CpuTier::Neon
     }
-    #[cfg(not(any(target_arch = "x86_64", target_arch = "aarch64")))]
+    #[cfg(target_arch = "wasm32")]
+    {
+        if cfg!(target_feature = "simd128") {
+            CpuTier::Wasm32Simd128
+        } else {
+            CpuTier::Scalar
+        }
+    }
+    #[cfg(not(any(
+        target_arch = "x86_64",
+        target_arch = "aarch64",
+        target_arch = "wasm32"
+    )))]
     {
         CpuTier::Scalar
     }
@@ -84,7 +101,19 @@ fn compile_time_tier() -> CpuTier {
     {
         CpuTier::Neon
     }
-    #[cfg(not(any(target_arch = "x86_64", target_arch = "aarch64")))]
+    #[cfg(target_arch = "wasm32")]
+    {
+        if cfg!(target_feature = "simd128") {
+            CpuTier::Wasm32Simd128
+        } else {
+            CpuTier::Scalar
+        }
+    }
+    #[cfg(not(any(
+        target_arch = "x86_64",
+        target_arch = "aarch64",
+        target_arch = "wasm32"
+    )))]
     {
         CpuTier::Scalar
     }

--- a/crates/core/src/simd/wasm32/mod.rs
+++ b/crates/core/src/simd/wasm32/mod.rs
@@ -1,0 +1,1 @@
+pub mod simd128;

--- a/crates/core/src/simd/wasm32/simd128.rs
+++ b/crates/core/src/simd/wasm32/simd128.rs
@@ -1,0 +1,150 @@
+#[cfg(target_arch = "wasm32")]
+use core::arch::wasm32::*;
+
+/// Copy `len` bytes from `src` to `dst` using 16-byte SIMD128 loads/stores.
+/// Overshoots by up to 15 bytes.
+///
+/// # Safety
+/// - `src` must be valid for reads of `len + 15` bytes.
+/// - `dst` must be valid for writes of `len + 15` bytes.
+/// - Regions must NOT overlap.
+#[target_feature(enable = "simd128")]
+#[inline]
+pub unsafe fn wildcopy_wasm32(mut src: *const u8, mut dst: *mut u8, len: usize) {
+    debug_assert!(len > 0);
+    unsafe {
+        let end = dst.add(len);
+        loop {
+            let chunk = v128_load(src as *const v128);
+            v128_store(dst as *mut v128, chunk);
+            src = src.add(16);
+            dst = dst.add(16);
+            if dst >= end {
+                break;
+            }
+        }
+    }
+}
+
+/// Copy match with SIMD128 16-byte copies. For offset >= 16, uses non-overlapping
+/// 16-byte copies. For smaller offsets, falls back to scalar overlap handling.
+///
+/// # Safety
+/// - `dst` must have at least `len + 15` bytes of writable space.
+/// - `dst - offset` must be valid for reading.
+#[target_feature(enable = "simd128")]
+#[inline]
+pub unsafe fn copy_match_wasm32(dst: *mut u8, offset: usize, len: usize) {
+    debug_assert!(offset > 0);
+    debug_assert!(len > 0);
+    unsafe {
+        if offset >= 16 {
+            wildcopy_wasm32(dst.sub(offset), dst, len);
+        } else {
+            super::super::scalar::copy_match(dst, offset, len);
+        }
+    }
+}
+
+/// Count common prefix length using SIMD128.
+/// Compares 16 bytes at a time, returns the byte offset of the first mismatch.
+///
+/// # Safety
+/// Caller must ensure `a` and `b` slices are accessible for reads up to
+/// their length (no overshoot beyond slice bounds in the SIMD path since
+/// we only enter when 16+ bytes remain).
+#[target_feature(enable = "simd128")]
+#[inline]
+pub unsafe fn common_prefix_len_wasm32(a: &[u8], b: &[u8]) -> usize {
+    let len = a.len().min(b.len());
+    let mut i = 0;
+
+    unsafe {
+        while i + 16 <= len {
+            let va = v128_load(a.as_ptr().add(i) as *const v128);
+            let vb = v128_load(b.as_ptr().add(i) as *const v128);
+            let cmp = u8x16_eq(va, vb);
+            let mask = u8x16_bitmask(cmp);
+            if mask != 0xFFFF {
+                return i + (!mask).trailing_zeros() as usize;
+            }
+            i += 16;
+        }
+    }
+
+    while i < len {
+        if a[i] != b[i] {
+            return i;
+        }
+        i += 1;
+    }
+    i
+}
+
+#[cfg(all(test, target_arch = "wasm32"))]
+mod tests {
+    use super::*;
+    extern crate alloc;
+    use alloc::vec;
+    use alloc::vec::Vec;
+
+    #[test]
+    fn wildcopy_wasm32_basic() {
+        let src: Vec<u8> = (0..64).collect();
+        let mut dst = vec![0u8; 80];
+        unsafe {
+            wildcopy_wasm32(src.as_ptr(), dst.as_mut_ptr(), 64);
+        }
+        assert_eq!(&dst[..64], &src[..64]);
+    }
+
+    #[test]
+    fn copy_match_wasm32_large_offset() {
+        let mut buf = vec![0u8; 128];
+        for i in 0..32 {
+            buf[i] = (i + 1) as u8;
+        }
+        unsafe {
+            copy_match_wasm32(buf.as_mut_ptr().add(32), 32, 32);
+        }
+        assert_eq!(&buf[32..64], &buf[..32]);
+    }
+
+    #[test]
+    fn copy_match_wasm32_small_offset() {
+        let mut buf = vec![0u8; 64];
+        buf[0..3].copy_from_slice(&[1, 2, 3]);
+        unsafe {
+            copy_match_wasm32(buf.as_mut_ptr().add(3), 3, 12);
+        }
+        assert_eq!(&buf[..15], &[1, 2, 3, 1, 2, 3, 1, 2, 3, 1, 2, 3, 1, 2, 3]);
+    }
+
+    #[test]
+    fn common_prefix_len_wasm32_basic() {
+        let a = vec![0x55u8; 200];
+        let mut b = vec![0x55u8; 200];
+        b[73] = 0xAA;
+        unsafe {
+            assert_eq!(common_prefix_len_wasm32(&a, &b), 73);
+        }
+    }
+
+    #[test]
+    fn common_prefix_len_wasm32_identical() {
+        let a = vec![0x42u8; 100];
+        let b = vec![0x42u8; 100];
+        unsafe {
+            assert_eq!(common_prefix_len_wasm32(&a, &b), 100);
+        }
+    }
+
+    #[test]
+    fn common_prefix_len_wasm32_first_byte() {
+        let a = vec![1u8; 64];
+        let b = vec![2u8; 64];
+        unsafe {
+            assert_eq!(common_prefix_len_wasm32(&a, &b), 0);
+        }
+    }
+}

--- a/crates/decode/src/lib.rs
+++ b/crates/decode/src/lib.rs
@@ -16,7 +16,11 @@ pub(crate) mod sequences;
 pub mod streaming;
 
 #[cfg(all(
-    any(target_arch = "x86_64", target_arch = "aarch64"),
+    any(
+        target_arch = "x86_64",
+        target_arch = "aarch64",
+        target_arch = "wasm32"
+    ),
     not(feature = "paranoid")
 ))]
 pub(crate) mod simd_decode;
@@ -35,7 +39,11 @@ use zrip_core::frame::MAX_WINDOW_SIZE;
 use zrip_core::frame::header::parse_frame_header;
 use zrip_core::huffman::HuffmanDecodeEntry;
 #[cfg(all(
-    any(target_arch = "x86_64", target_arch = "aarch64"),
+    any(
+        target_arch = "x86_64",
+        target_arch = "aarch64",
+        target_arch = "wasm32"
+    ),
     not(feature = "paranoid")
 ))]
 use zrip_core::simd::CpuTier;
@@ -411,6 +419,24 @@ fn decode_compressed_block(
             return Ok(());
         }
     }
+    #[cfg(all(target_arch = "wasm32", not(feature = "paranoid")))]
+    {
+        if zrip_core::simd::cpu_tier() >= CpuTier::Wasm32Simd128 {
+            decode_execute_block_wasm32(
+                seq_data,
+                num_sequences,
+                seq_tables,
+                rep_offsets,
+                &ws.literal_buf,
+                output,
+                dict_history,
+            )?;
+            if output.len() - before > zrip_core::frame::MAX_BLOCK_SIZE {
+                return Err(DecompressError::BlockTooLarge);
+            }
+            return Ok(());
+        }
+    }
 
     decode_execute_sequences(
         seq_data,
@@ -460,6 +486,27 @@ fn decode_execute_block_neon(
     history: &[u8],
 ) -> Result<(), DecompressError> {
     crate::simd_decode::aarch64::decode::decode_execute_neon_safe(
+        seq_data,
+        num_sequences,
+        tables,
+        rep_offsets,
+        literals,
+        output,
+        history,
+    )
+}
+
+#[cfg(all(target_arch = "wasm32", not(feature = "paranoid")))]
+fn decode_execute_block_wasm32(
+    seq_data: &[u8],
+    num_sequences: u32,
+    tables: &mut SequenceDecodeTables,
+    rep_offsets: &mut [u32; 3],
+    literals: &[u8],
+    output: &mut Vec<u8>,
+    history: &[u8],
+) -> Result<(), DecompressError> {
+    crate::simd_decode::wasm32::decode::decode_execute_wasm32_safe(
         seq_data,
         num_sequences,
         tables,

--- a/crates/decode/src/literals.rs
+++ b/crates/decode/src/literals.rs
@@ -75,12 +75,12 @@ fn parse_compressed_header(data: &[u8]) -> Result<(usize, usize, usize, usize), 
             if data.len() < 5 {
                 return Err(DecompressError::CorruptLiterals);
             }
-            let both = (header_byte as usize >> 4)
-                | ((data[1] as usize) << 4)
-                | ((data[2] as usize) << 12)
-                | ((data[3] as usize) << 20)
-                | ((data[4] as usize) << 28);
-            Ok((both & 0x3FFFF, both >> 18, 4, 5))
+            let both = (header_byte as u64 >> 4)
+                | ((data[1] as u64) << 4)
+                | ((data[2] as u64) << 12)
+                | ((data[3] as u64) << 20)
+                | ((data[4] as u64) << 28);
+            Ok(((both & 0x3FFFF) as usize, (both >> 18) as usize, 4, 5))
         }
         _ => unreachable!(),
     }

--- a/crates/decode/src/simd_decode/mod.rs
+++ b/crates/decode/src/simd_decode/mod.rs
@@ -3,3 +3,6 @@ pub mod x86_64;
 
 #[cfg(target_arch = "aarch64")]
 pub mod aarch64;
+
+#[cfg(target_arch = "wasm32")]
+pub mod wasm32;

--- a/crates/decode/src/simd_decode/wasm32/decode.rs
+++ b/crates/decode/src/simd_decode/wasm32/decode.rs
@@ -1,0 +1,436 @@
+#[cfg(feature = "alloc")]
+use alloc::vec::Vec;
+
+#[cfg(target_arch = "wasm32")]
+use core::arch::wasm32::*;
+
+use crate::sequences::SequenceDecodeTables;
+use zrip_core::bitstream::reader_reverse::ReverseBitReader;
+use zrip_core::error::DecompressError;
+use zrip_core::fse::FseSeqDecodeEntry;
+use zrip_core::hint::{likely, unlikely};
+
+/// # Safety
+/// Must be called on wasm32 with simd128 target feature enabled.
+#[target_feature(enable = "simd128")]
+unsafe fn decode_execute_wasm32_inner<const HAS_HISTORY: bool>(
+    seq_data: &[u8],
+    num_sequences: u32,
+    tables: &SequenceDecodeTables,
+    rep_offsets: &mut [u32; 3],
+    literals: &[u8],
+    output: &mut Vec<u8>,
+    history: &[u8],
+) -> Result<(), DecompressError> {
+    if num_sequences == 0 {
+        return Ok(());
+    }
+    if seq_data.is_empty() {
+        return Err(DecompressError::CorruptSequences);
+    }
+
+    let mut rev_reader =
+        ReverseBitReader::new(seq_data).map_err(|_| DecompressError::CorruptSequences)?;
+
+    let mut ll_state = init_state(&tables.ll_table, tables.ll_accuracy, &mut rev_reader)?;
+    let mut of_state = init_state(&tables.of_table, tables.of_accuracy, &mut rev_reader)?;
+    let mut ml_state = init_state(&tables.ml_table, tables.ml_accuracy, &mut rev_reader)?;
+
+    const WILDCOPY_OVERLENGTH: usize = 64;
+    let max_output = zrip_core::frame::MAX_BLOCK_SIZE;
+    output.reserve(max_output + WILDCOPY_OVERLENGTH);
+
+    let out_base = output.as_mut_ptr();
+    let mut op = unsafe { out_base.add(output.len()) };
+    let op_limit = unsafe { out_base.add(output.capacity() - WILDCOPY_OVERLENGTH) };
+
+    let of_tbl = tables.of_table.as_ptr();
+    let ml_tbl = tables.ml_table.as_ptr();
+    let ll_tbl = tables.ll_table.as_ptr();
+    let of_mask = ((1u32 << tables.of_accuracy) - 1) as usize;
+    let ml_mask = ((1u32 << tables.ml_accuracy) - 1) as usize;
+    let ll_mask = ((1u32 << tables.ll_accuracy) - 1) as usize;
+    let lit_ptr = literals.as_ptr();
+    let lit_end = unsafe { lit_ptr.add(literals.len()) };
+    let hist_len = if HAS_HISTORY { history.len() } else { 0 };
+    let mut lit_pos = lit_ptr;
+
+    let mut bs_container = rev_reader.container;
+    let mut bs_consumed = rev_reader.bits_consumed;
+    let seq_base = seq_data.as_ptr();
+    let mut bs_ptr = unsafe { seq_base.add(rev_reader.ptr) };
+    let bs_fast_limit_off = rev_reader.limit_ptr.saturating_add(16);
+
+    let last_seq = num_sequences - 1;
+
+    let mut rep0 = rep_offsets[0];
+    let mut rep1 = rep_offsets[1];
+    let mut rep2 = rep_offsets[2];
+
+    macro_rules! read_bits {
+        ($n:expr) => {{
+            let r = ((bs_container << (bs_consumed & 63)) >> 1 >> (63 - $n as u32)) as u32;
+            bs_consumed += $n as u32;
+            r
+        }};
+    }
+
+    macro_rules! refill_fast {
+        () => {{
+            let byte_shift = (bs_consumed >> 3) as usize;
+            bs_ptr = unsafe { bs_ptr.sub(byte_shift) };
+            bs_consumed -= (byte_shift as u32) * 8;
+            bs_container = unsafe { (bs_ptr as *const u64).read_unaligned() };
+        }};
+    }
+
+    macro_rules! compute_offset_inline {
+        ($offset_value:expr, $literal_length:expr) => {{
+            let ov = $offset_value;
+            if ov > 3 {
+                let offset = ov - 3;
+                rep2 = rep1;
+                rep1 = rep0;
+                rep0 = offset;
+                offset
+            } else {
+                let ll0 = ($literal_length == 0) as u32;
+                let rep_idx = ov - 1 + ll0;
+                let offset = if rep_idx == 0 {
+                    rep0
+                } else if rep_idx == 1 {
+                    rep1
+                } else if rep_idx == 2 {
+                    rep2
+                } else {
+                    rep0.wrapping_sub(1)
+                };
+                if rep_idx >= 2 {
+                    rep2 = rep1;
+                }
+                if rep_idx >= 1 {
+                    rep1 = rep0;
+                }
+                rep0 = offset;
+                offset
+            }
+        }};
+    }
+
+    macro_rules! decode_and_update {
+        () => {{
+            refill_fast!();
+
+            let of_e = unsafe { *of_tbl.add(of_state as usize & of_mask) };
+            let ml_e = unsafe { *ml_tbl.add(ml_state as usize & ml_mask) };
+            let ll_e = unsafe { *ll_tbl.add(ll_state as usize & ll_mask) };
+
+            let offset_value = of_e.baseline_value + read_bits!(of_e.extra_bits);
+            let match_length = ml_e.baseline_value + read_bits!(ml_e.extra_bits);
+            let literal_length = ll_e.baseline_value + read_bits!(ll_e.extra_bits);
+
+            let offset = compute_offset_inline!(offset_value, literal_length);
+
+            refill_fast!();
+            ll_state = ll_e.base_line as u32 + read_bits!(ll_e.num_bits);
+            ml_state = ml_e.base_line as u32 + read_bits!(ml_e.num_bits);
+            of_state = of_e.base_line as u32 + read_bits!(of_e.num_bits);
+
+            (literal_length, match_length, offset)
+        }};
+    }
+
+    macro_rules! execute_seq {
+        ($literal_length:expr, $match_length:expr, $offset:expr) => {{
+            let ll = $literal_length as usize;
+            let ml = $match_length as usize;
+            if unlikely(unsafe { op.add(ll + ml) } > op_limit) {
+                return Err(DecompressError::CorruptSequences);
+            }
+            let lit_remaining = unsafe { lit_end.offset_from(lit_pos) } as usize;
+            if unlikely(ll > lit_remaining) {
+                return Err(DecompressError::CorruptSequences);
+            }
+            unsafe {
+                if lit_remaining >= 16 {
+                    let chunk = v128_load(lit_pos as *const v128);
+                    v128_store(op as *mut v128, chunk);
+                    if ll > 16 {
+                        core::ptr::copy_nonoverlapping(lit_pos.add(16), op.add(16), ll - 16);
+                    }
+                } else if ll > 0 {
+                    core::ptr::copy_nonoverlapping(lit_pos, op, ll);
+                }
+                op = op.add(ll);
+                lit_pos = lit_pos.add(ll);
+            }
+
+            let offset = $offset;
+            if unlikely(offset == 0) {
+                return Err(DecompressError::InvalidOffset);
+            }
+            let off = offset as usize;
+            let out_pos = unsafe { op.offset_from(out_base) } as usize;
+            if unlikely(off > out_pos + hist_len) {
+                return Err(DecompressError::InvalidOffset);
+            }
+            if unlikely(ml == 0) {
+                return Err(DecompressError::CorruptSequences);
+            }
+            unsafe {
+                if !HAS_HISTORY || likely(off <= out_pos) {
+                    if off >= 16 {
+                        let mut s = op.sub(off);
+                        let mut d = op;
+                        let end = op.add(ml);
+                        loop {
+                            let chunk = v128_load(s as *const v128);
+                            v128_store(d as *mut v128, chunk);
+                            s = s.add(16);
+                            d = d.add(16);
+                            if d >= end {
+                                break;
+                            }
+                        }
+                    } else if off >= 8 {
+                        let s = op.sub(off);
+                        (op as *mut u64).write_unaligned((s as *const u64).read_unaligned());
+                        (op.add(8) as *mut u64)
+                            .write_unaligned((s.add(8) as *const u64).read_unaligned());
+                        if ml > 16 {
+                            let mut cs = s.add(16);
+                            let mut cd = op.add(16);
+                            let end = op.add(ml);
+                            while cd < end {
+                                (cd as *mut u64)
+                                    .write_unaligned((cs as *const u64).read_unaligned());
+                                cs = cs.add(8);
+                                cd = cd.add(8);
+                            }
+                        }
+                    } else {
+                        zrip_core::simd::scalar::copy_match(op, off, ml);
+                    }
+                } else {
+                    copy_match_from_history(op, out_base, history, off, out_pos, ml);
+                }
+                op = op.add(ml);
+            }
+        }};
+    }
+
+    let mut remaining = last_seq;
+    while remaining > 0 && unsafe { bs_ptr.offset_from(seq_base) } as usize >= bs_fast_limit_off {
+        let (ll, ml, off) = decode_and_update!();
+        execute_seq!(ll, ml, off);
+        remaining -= 1;
+    }
+
+    // Slow path: restore ReverseBitReader for checked refills
+    rev_reader.container = bs_container;
+    rev_reader.bits_consumed = bs_consumed;
+    rev_reader.ptr = unsafe { bs_ptr.offset_from(seq_data.as_ptr()) } as usize;
+
+    while remaining > 0 {
+        rev_reader.refill();
+
+        let of_e = unsafe { *of_tbl.add(of_state as usize & of_mask) };
+        let ml_e = unsafe { *ml_tbl.add(ml_state as usize & ml_mask) };
+        let ll_e = unsafe { *ll_tbl.add(ll_state as usize & ll_mask) };
+
+        let of_extra = rev_reader.read_bits_branchless(of_e.extra_bits);
+        let offset_value = of_e.baseline_value + of_extra;
+        let ml_extra = rev_reader.read_bits_branchless(ml_e.extra_bits);
+        let match_length = ml_e.baseline_value + ml_extra;
+        let ll_extra = rev_reader.read_bits_branchless(ll_e.extra_bits);
+        let literal_length = ll_e.baseline_value + ll_extra;
+        let offset = compute_offset_inline!(offset_value, literal_length);
+
+        rev_reader.refill();
+        ll_state = ll_e.base_line as u32 + rev_reader.read_bits_branchless(ll_e.num_bits);
+        ml_state = ml_e.base_line as u32 + rev_reader.read_bits_branchless(ml_e.num_bits);
+        of_state = of_e.base_line as u32 + rev_reader.read_bits_branchless(of_e.num_bits);
+
+        execute_seq!(literal_length, match_length, offset);
+        remaining -= 1;
+    }
+
+    // Last sequence: no FSE state update
+    if num_sequences > 0 {
+        rev_reader.refill();
+        let of_e = unsafe { *of_tbl.add(of_state as usize & of_mask) };
+        let ml_e = unsafe { *ml_tbl.add(ml_state as usize & ml_mask) };
+        let ll_e = unsafe { *ll_tbl.add(ll_state as usize & ll_mask) };
+        let offset_value = of_e.baseline_value + rev_reader.read_bits_branchless(of_e.extra_bits);
+        let match_length = ml_e.baseline_value + rev_reader.read_bits_branchless(ml_e.extra_bits);
+        let literal_length = ll_e.baseline_value + rev_reader.read_bits_branchless(ll_e.extra_bits);
+        let offset = compute_offset_inline!(offset_value, literal_length);
+        execute_seq!(literal_length, match_length, offset);
+    }
+
+    if rev_reader.bits_remaining() != 0 {
+        return Err(DecompressError::CorruptSequences);
+    }
+
+    rep_offsets[0] = rep0;
+    rep_offsets[1] = rep1;
+    rep_offsets[2] = rep2;
+
+    // Trailing literals
+    if lit_pos < lit_end {
+        let remaining = unsafe { lit_end.offset_from(lit_pos) } as usize;
+        if unsafe { op.add(remaining) } > unsafe { out_base.add(output.capacity()) } {
+            return Err(DecompressError::CorruptSequences);
+        }
+        unsafe {
+            core::ptr::copy_nonoverlapping(lit_pos, op, remaining);
+            op = op.add(remaining);
+        }
+    }
+
+    let new_len = unsafe { op.offset_from(out_base) } as usize;
+    if new_len > output.capacity() {
+        return Err(DecompressError::CorruptSequences);
+    }
+    unsafe {
+        output.set_len(new_len);
+    }
+
+    Ok(())
+}
+
+/// Fused sequence decode + execute with WASM SIMD128 wildcopy.
+///
+/// # Safety
+/// Must be called on wasm32 with simd128 target feature enabled.
+#[target_feature(enable = "simd128")]
+pub unsafe fn decode_execute_wasm32(
+    seq_data: &[u8],
+    num_sequences: u32,
+    tables: &SequenceDecodeTables,
+    rep_offsets: &mut [u32; 3],
+    literals: &[u8],
+    output: &mut Vec<u8>,
+    history: &[u8],
+) -> Result<(), DecompressError> {
+    if history.is_empty() {
+        unsafe {
+            decode_execute_wasm32_inner::<false>(
+                seq_data,
+                num_sequences,
+                tables,
+                rep_offsets,
+                literals,
+                output,
+                history,
+            )
+        }
+    } else {
+        unsafe {
+            decode_execute_wasm32_with_history(
+                seq_data,
+                num_sequences,
+                tables,
+                rep_offsets,
+                literals,
+                output,
+                history,
+            )
+        }
+    }
+}
+
+#[inline(never)]
+#[target_feature(enable = "simd128")]
+unsafe fn decode_execute_wasm32_with_history(
+    seq_data: &[u8],
+    num_sequences: u32,
+    tables: &SequenceDecodeTables,
+    rep_offsets: &mut [u32; 3],
+    literals: &[u8],
+    output: &mut Vec<u8>,
+    history: &[u8],
+) -> Result<(), DecompressError> {
+    unsafe {
+        decode_execute_wasm32_inner::<true>(
+            seq_data,
+            num_sequences,
+            tables,
+            rep_offsets,
+            literals,
+            output,
+            history,
+        )
+    }
+}
+
+pub(crate) fn decode_execute_wasm32_safe(
+    seq_data: &[u8],
+    num_sequences: u32,
+    tables: &SequenceDecodeTables,
+    rep_offsets: &mut [u32; 3],
+    literals: &[u8],
+    output: &mut Vec<u8>,
+    history: &[u8],
+) -> Result<(), DecompressError> {
+    unsafe {
+        decode_execute_wasm32(
+            seq_data,
+            num_sequences,
+            tables,
+            rep_offsets,
+            literals,
+            output,
+            history,
+        )
+    }
+}
+
+#[inline(always)]
+fn init_state(
+    _table: &[FseSeqDecodeEntry],
+    accuracy_log: u8,
+    reader: &mut ReverseBitReader,
+) -> Result<u32, DecompressError> {
+    reader.read_bits(accuracy_log)
+}
+
+#[inline]
+#[target_feature(enable = "simd128")]
+unsafe fn copy_match_from_history(
+    op: *mut u8,
+    _out_base: *const u8,
+    history: &[u8],
+    offset: usize,
+    out_pos: usize,
+    match_length: usize,
+) {
+    let history_reach = offset - out_pos;
+    let history_start = history.len() - history_reach;
+    let from_history = history_reach.min(match_length);
+    unsafe {
+        core::ptr::copy_nonoverlapping(history.as_ptr().add(history_start), op, from_history);
+    }
+    let remaining = match_length - from_history;
+    if remaining > 0 {
+        let dst = unsafe { op.add(from_history) };
+        unsafe {
+            if offset >= 16 {
+                let mut s = dst.sub(offset);
+                let mut d = dst;
+                let end = dst.add(remaining);
+                loop {
+                    let chunk = v128_load(s as *const v128);
+                    v128_store(d as *mut v128, chunk);
+                    s = s.add(16);
+                    d = d.add(16);
+                    if d >= end {
+                        break;
+                    }
+                }
+            } else {
+                zrip_core::simd::scalar::copy_match(dst, offset, remaining);
+            }
+        }
+    }
+}

--- a/crates/decode/src/simd_decode/wasm32/mod.rs
+++ b/crates/decode/src/simd_decode/wasm32/mod.rs
@@ -1,0 +1,2 @@
+#[cfg(feature = "alloc")]
+pub mod decode;

--- a/crates/decode/src/streaming.rs
+++ b/crates/decode/src/streaming.rs
@@ -16,7 +16,11 @@ use zrip_core::fse::{promote_ll_table, promote_ml_table, promote_of_table};
 use zrip_core::xxhash::Xxh64State;
 
 #[cfg(all(
-    any(target_arch = "x86_64", target_arch = "aarch64"),
+    any(
+        target_arch = "x86_64",
+        target_arch = "aarch64",
+        target_arch = "wasm32"
+    ),
     not(feature = "paranoid")
 ))]
 use zrip_core::simd::CpuTier;
@@ -443,6 +447,30 @@ impl<R: Read> FrameDecoder<R> {
             if zrip_core::simd::cpu_tier() >= CpuTier::Neon {
                 let before = self.output_buf.len();
                 crate::simd_decode::aarch64::decode::decode_execute_neon_safe(
+                    seq_data,
+                    num_sequences,
+                    &self.seq_tables,
+                    &mut self.rep_offsets,
+                    &self.ws.literal_buf,
+                    &mut self.output_buf,
+                    dict_history,
+                )
+                .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
+                if self.output_buf.len() - before > MAX_BLOCK_SIZE {
+                    return Err(io::Error::new(
+                        io::ErrorKind::InvalidData,
+                        DecompressError::BlockTooLarge,
+                    ));
+                }
+                return Ok(());
+            }
+        }
+
+        #[cfg(all(target_arch = "wasm32", not(feature = "paranoid")))]
+        {
+            if zrip_core::simd::cpu_tier() >= CpuTier::Wasm32Simd128 {
+                let before = self.output_buf.len();
+                crate::simd_decode::wasm32::decode::decode_execute_wasm32_safe(
                     seq_data,
                     num_sequences,
                     &self.seq_tables,


### PR DESCRIPTION
- Add wasm32 SIMD128 fused decode loop mirroring the aarch64 NEON path (both 128-bit), dispatched via `CpuTier::Wasm32Simd128` with compile-time detection, gated by `not(feature = "paranoid")`
- Add core SIMD primitives (`wildcopy`, `copy_match`, `common_prefix_len`) in `crates/core/src/simd/wasm32/simd128.rs`
- Fix pre-existing 32-bit overflow in `parse_compressed_header` format-3 branch (`literals.rs:78`): `(data[4] as usize) << 28` overflows on wasm32 where `usize` is 32 bits, causing `BadHuffmanStream` on any block with a 5-byte literals header
- Add `bench/wasm/` crate for WASM encode+decode benchmarking via wasmtime, with optional C zstd comparison (`--features czstd`)

WASM decode throughput (wasmtime, MB/s):

| File | Scalar | SIMD128 | C zstd | SIMD/Scalar | SIMD vs C |
|------|--------|---------|--------|-------------|-----------|
| dickens | 132 | 329 | 261 | 2.49x | +28% |
| mozilla | 222 | 483 | 469 | 2.17x | +3% |
| nci | 431 | 714 | 684 | 1.66x | +4% |
| sao | 363 | 826 | 624 | 2.28x | +33% |
| webster | 172 | 410 | 335 | 2.38x | +22% |
| x-ray | 375 | 814 | 640 | 2.17x | +27% |
| hdfs.json | 719 | 1158 | 1056 | 1.61x | +10% |

WASM encode throughput (wasmtime, L1, MB/s):

| File | zrip | C zstd | zrip/C |
|------|------|--------|--------|
| dickens | 109 | 122 | 0.89x |
| mozilla | 175 | 178 | 0.98x |
| nci | 341 | 385 | 0.89x |
| sao | 186 | 122 | 1.52x |
| webster | 130 | 122 | 1.06x |
| x-ray | 146 | 310 | 0.47x |
| hdfs.json | 523 | 575 | 0.91x |