### PR TITLE
Release 0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,49 @@
 
 ## [Unreleased]
 
+## [0.6.0]
+
+### Added
+
+- WASM SIMD128 decode path: fused FSE decode+execute loop
+  (`simd_decode/wasm32/decode.rs`) and core SIMD primitives (wildcopy,
+  copy_match, common_prefix_len) in `simd/wasm32/simd128.rs`. Dispatched
+  via `CpuTier::Wasm32Simd128` at compile time when
+  `target_feature = "simd128"` is enabled.
+- Long distance matching (LDM) encoder (`ldm.rs`): gear hash scan with
+  gap fill via Fast/DFast strategy. Controlled via `Options::ldm(true)`
+  and `Options::window_log(n)`. Enabled by default via the `ldm` feature
+  flag, with zero runtime cost when not activated.
+- Cross-block match references in streaming encoder: matches can now
+  reference data from prior blocks within the window, improving
+  compression ratio on multi-block inputs.
+- `Options` API for configuring `window_log` and `ldm` on
+  `compress_opts()` and `FrameEncoder::with_options()`.
+- wasm32 benchmark charts (`doc/charts/wasm32/`) comparing zrip
+  (SIMD128), zrip paranoid (no SIMD), C zstd (libzstd via wasi-sdk),
+  and structured-zstd.
+- `--profile` flag for plot scripts (`scripts/profiles.py`) enabling
+  per-target chart generation with consistent codec colors and labels.
+- Streaming, LDM, and cross-block matching tests in
+  `tests/streaming.rs`.
+
+### Fixed
+
+- 32-bit overflow in `parse_compressed_header` format-3 branch
+  (`literals.rs`): `(data[4] as usize) << 28` overflows on wasm32
+  where usize is 32 bits. Fixed by accumulating into u64.
+- `cpu_tier()` now returns `Scalar` under Miri to avoid UB from CPUID
+  intrinsics.
+- Unused variable warning on targets without prefetch support.
+
+### Changed
+
+- Bench cache layout restructured to per-target directories
+  (`~/.cache/zrip/{arch}/L{level}/{codec}.jsonl`).
+- Corpus paths resolved via `CARGO_MANIFEST_DIR` so bench downloads
+  land in `bench/corpus/` regardless of working directory.
+- JSR package `@paddor/zrip` bumped to 0.3.0.
+
 ## [0.5.1]
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ exclude = ["fuzz", "bench", "jsr"]
 
 [package]
 name = "zrip"
-version = "0.5.1"
+version = "0.6.0"
 edition = "2024"
 rust-version = "1.85"
 description = "Fast, memory-safe Rust implementation of Zstandard compression (levels -7..4)"
@@ -25,9 +25,9 @@ nightly = ["zrip-core/nightly", "zrip-encode/nightly", "zrip-decode/nightly"]
 paranoid = ["zrip-core/paranoid", "zrip-encode/paranoid", "zrip-decode/paranoid"]
 
 [dependencies]
-zrip-core = { version = "0.5.1", path = "crates/core", default-features = false }
-zrip-encode = { version = "0.5.1", path = "crates/encode", default-features = false }
-zrip-decode = { version = "0.5.1", path = "crates/decode", default-features = false }
+zrip-core = { version = "0.6.0", path = "crates/core", default-features = false }
+zrip-encode = { version = "0.6.0", path = "crates/encode", default-features = false }
+zrip-decode = { version = "0.6.0", path = "crates/decode", default-features = false }
 
 [lints]
 workspace = true

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zrip-core"
-version = "0.5.1"
+version = "0.6.0"
 edition = "2024"
 rust-version = "1.85"
 description = "Shared types and codecs for zrip (internal crate)"

--- a/crates/decode/Cargo.toml
+++ b/crates/decode/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zrip-decode"
-version = "0.5.1"
+version = "0.6.0"
 edition = "2024"
 rust-version = "1.85"
 description = "zstd decoder for zrip (internal crate)"
@@ -20,7 +20,7 @@ nightly = ["zrip-core/nightly"]
 paranoid = ["zrip-core/paranoid"]
 
 [dependencies]
-zrip-core = { version = "0.5.1", path = "../core", default-features = false }
+zrip-core = { version = "0.6.0", path = "../core", default-features = false }
 
 [dev-dependencies]
 zrip = { path = "../.." }

--- a/crates/encode/Cargo.toml
+++ b/crates/encode/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zrip-encode"
-version = "0.5.1"
+version = "0.6.0"
 edition = "2024"
 rust-version = "1.85"
 description = "zstd encoder for zrip (internal crate)"
@@ -21,7 +21,7 @@ nightly = ["zrip-core/nightly"]
 paranoid = ["zrip-core/paranoid"]
 
 [dependencies]
-zrip-core = { version = "0.5.1", path = "../core", default-features = false }
+zrip-core = { version = "0.6.0", path = "../core", default-features = false }
 
 [dev-dependencies]
 zrip = { path = "../.." }

--- a/jsr/deno.json
+++ b/jsr/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@paddor/zrip",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "license": "MIT",
   "description": "Pure Rust zstd codec compiled to WebAssembly. Fast compression levels -7..4 with SIMD auto-detection.",
   "exports": "./src/mod.ts",


### PR DESCRIPTION
- Bump zrip, zrip-core, zrip-encode, zrip-decode from 0.5.1 to 0.6.0
- Bump JSR `@paddor/zrip` from 0.2.0 to 0.3.0
- Add 0.6.0 changelog section (WASM SIMD128, LDM, cross-block streaming, 32-bit overflow fix)