### PR TITLE
Post-0.7.0 cleanup: exclude jsr/ from crate, bump jsr to 0.4.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ exclude = ["fuzz", "bench", "jsr"]
 
 [package]
 name = "zrip"
-version = "0.7.0"
+version = "0.7.1"
 edition = "2024"
 rust-version = "1.88"
 description = "Fast, memory-safe Rust implementation of Zstandard compression (levels -7..4)"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ license = "MIT"
 repository = "https://github.com/paddor/zrip"
 categories = ["compression"]
 keywords = ["zstd", "zstandard", "compression", "decompression"]
-include = ["src/**/*", "README.md", "LICENSE", "CHANGELOG.md", "DESIGN.md", "SAFETY.md", "SECURITY.md"]
+include = ["src/**/*", "README.md", "LICENSE", "CHANGELOG.md", "DESIGN.md", "SAFETY.md", "SECURITY.md", "!jsr/**"]
 
 [features]
 default = ["std", "frame", "ldm", "simd"]

--- a/jsr/deno.json
+++ b/jsr/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@paddor/zrip",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "license": "MIT",
   "description": "Pure Rust zstd codec compiled to WebAssembly. Fast compression levels -7..4 with SIMD auto-detection.",
   "exports": "./src/mod.ts",


### PR DESCRIPTION
- Exclude `jsr/` from published zrip crate package (`jsr/README.md` was leaking in)
- Bump jsr package `@paddor/zrip` from 0.3.0 to 0.4.0