### PR TITLE
Release 0.7.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 ## [Unreleased]
 
+## [0.7.2]
+
+### Fixed
+
+- README: corrected "Safe decoder" claim. The decode crate has unsafe in
+  `fast_vec.rs`; only the `paranoid` feature makes it fully safe.
+- Regenerated small-input benchmark chart with structured-zstd 0.0.45.
+
+## [0.7.1]
+
+### Fixed
+
+- Excluded `jsr/` directory from the published crate package.
+
 ## [0.7.0]
 
 ### Changed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ exclude = ["fuzz", "bench", "jsr"]
 
 [package]
 name = "zrip"
-version = "0.7.1"
+version = "0.7.2"
 edition = "2024"
 rust-version = "1.88"
 description = "Fast, memory-safe Rust implementation of Zstandard compression (levels -7..4)"

--- a/README.md
+++ b/README.md
@@ -13,15 +13,16 @@ See the [benchmarks below](#performance).
 **Negative levels (-7 through -1).** Unlocks zstd's fastest compression tiers,
 useful when throughput matters more than ratio.
 
-**Safe decoder.** The entire decode crate is `#![forbid(unsafe_code)]` with zero
-`unsafe` blocks. Platform dispatch uses `fearless_simd` for safe runtime
-multiversioning. Encoder unsafe is confined to small, auditable `primitives.rs`
-with `debug_assert!` guards. The `paranoid` feature eliminates all remaining
-unsafe. See [SAFETY.md](SAFETY.md).
+**Memory safety.** Unsafe is minimized and confined to small, auditable
+primitives modules. The `paranoid` feature eliminates all remaining unsafe.
+See [SAFETY.md](SAFETY.md).
 
 **Small codebase.** ~12k lines of Rust. Levels above 4 add complexity for
 compression ratios that only matter in archival storage, not transfer
 pipelines.
+
+**Dictionary compression.** COVER and FastCOVER training built in for
+small-message workloads (log lines, JSON records, RPC payloads).
 
 **`no_std` + `alloc`.** Works in embedded and kernel contexts with the `alloc`
 feature; `frame` requires `std`.
@@ -29,9 +30,6 @@ feature; `frame` requires `std`.
 **WebAssembly.** Available as [`@paddor/zrip`](https://jsr.io/@paddor/zrip)
 on JSR. Auto-detects WASM SIMD support. 15% faster encode than C zstd compiled
 to WASM.
-
-**Dictionary compression.** COVER and FastCOVER training built in for
-small-message workloads (log lines, JSON records, RPC payloads).
 
 ## Performance
 

--- a/doc/charts/x86_64/small.svg
+++ b/doc/charts/x86_64/small.svg
@@ -12,87 +12,39 @@
   <text x="235.0" y="469" text-anchor="middle" fill="#7d8590" font-size="9">32K</text>
   <line x1="300.1" y1="55" x2="300.1" y2="455" stroke="#21262d" stroke-width="1"/>
   <text x="300.1" y="469" text-anchor="middle" fill="#7d8590" font-size="9">128K</text>
-  <line x1="90" y1="397.8" x2="320" y2="397.8" stroke="#21262d" stroke-width="1"/>
-  <text x="82" y="397.8" text-anchor="end" dominant-baseline="middle" fill="#7d8590" font-size="9">100</text>
-  <line x1="90" y1="340.5" x2="320" y2="340.5" stroke="#21262d" stroke-width="1"/>
-  <text x="82" y="340.5" text-anchor="end" dominant-baseline="middle" fill="#7d8590" font-size="9">200</text>
-  <line x1="90" y1="283.3" x2="320" y2="283.3" stroke="#21262d" stroke-width="1"/>
-  <text x="82" y="283.3" text-anchor="end" dominant-baseline="middle" fill="#7d8590" font-size="9">300</text>
-  <line x1="90" y1="226.0" x2="320" y2="226.0" stroke="#21262d" stroke-width="1"/>
-  <text x="82" y="226.0" text-anchor="end" dominant-baseline="middle" fill="#7d8590" font-size="9">400</text>
-  <line x1="90" y1="168.8" x2="320" y2="168.8" stroke="#21262d" stroke-width="1"/>
-  <text x="82" y="168.8" text-anchor="end" dominant-baseline="middle" fill="#7d8590" font-size="9">500</text>
-  <line x1="90" y1="111.5" x2="320" y2="111.5" stroke="#21262d" stroke-width="1"/>
-  <text x="82" y="111.5" text-anchor="end" dominant-baseline="middle" fill="#7d8590" font-size="9">600</text>
-  <path d="M104.6,179.6L169.8,107.2L235.0,234.9L300.1,285.5L300.1,386.3L235.0,383.3L169.8,413.0L104.6,408.0Z" fill="#60a5fa" fill-opacity="0.15"/>
-  <path d="M104.6,199.8L169.8,142.1L235.0,252.5L300.1,294.3" fill="none" stroke="#60a5fa" stroke-width="0.7" stroke-opacity="0.35"/>
-  <path d="M104.6,218.7L169.8,174.6L235.0,273.8L300.1,305.9" fill="none" stroke="#60a5fa" stroke-width="0.7" stroke-opacity="0.35"/>
-  <path d="M104.6,241.2L169.8,209.4L235.0,292.6L300.1,316.2" fill="none" stroke="#60a5fa" stroke-width="0.7" stroke-opacity="0.35"/>
-  <path d="M104.6,256.1L169.8,236.7L235.0,308.9L300.1,325.8" fill="none" stroke="#60a5fa" stroke-width="0.7" stroke-opacity="0.35"/>
-  <path d="M104.6,295.8L169.8,269.1L235.0,322.4L300.1,334.5" fill="none" stroke="#60a5fa" stroke-width="0.7" stroke-opacity="0.35"/>
-  <path d="M104.6,316.5L169.8,302.0L235.0,334.4L300.1,343.4" fill="none" stroke="#60a5fa" stroke-width="0.7" stroke-opacity="0.35"/>
-  <text x="306.1" y="346.4" text-anchor="start" fill="#60a5fa" font-size="7" font-weight="600" fill-opacity="0.5">L−1</text>
-  <path d="M104.6,358.5L169.8,330.8L235.0,329.5L300.1,339.1" fill="none" stroke="#60a5fa" stroke-width="0.7" stroke-opacity="0.35"/>
-  <path d="M104.6,364.2L169.8,345.5L235.0,352.6L300.1,358.3" fill="none" stroke="#60a5fa" stroke-width="0.7" stroke-opacity="0.35"/>
-  <path d="M104.6,380.5L169.8,366.9L235.0,375.4L300.1,379.1" fill="none" stroke="#60a5fa" stroke-width="0.7" stroke-opacity="0.35"/>
-  <path d="M104.6,179.6L169.8,107.2L235.0,234.9L300.1,285.5" fill="none" stroke="#60a5fa" stroke-width="1.5"/>
-  <circle cx="104.6" cy="179.6" r="2.5" fill="#60a5fa" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="169.8" cy="107.2" r="2.5" fill="#60a5fa" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="235.0" cy="234.9" r="2.5" fill="#60a5fa" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="300.1" cy="285.5" r="2.5" fill="#60a5fa" stroke="#0d1117" stroke-width="0.8"/>
-  <text x="306.1" y="288.5" text-anchor="start" fill="#60a5fa" font-size="7" font-weight="600">L−7</text>
-  <path d="M104.6,408.0L169.8,413.0L235.0,383.3L300.1,386.3" fill="none" stroke="#60a5fa" stroke-width="1.5" stroke-dasharray="4,3"/>
-  <circle cx="104.6" cy="408.0" r="2.5" fill="#60a5fa" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="169.8" cy="413.0" r="2.5" fill="#60a5fa" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="235.0" cy="383.3" r="2.5" fill="#60a5fa" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="300.1" cy="386.3" r="2.5" fill="#60a5fa" stroke="#0d1117" stroke-width="0.8"/>
-  <text x="306.1" y="389.3" text-anchor="start" fill="#60a5fa" font-size="7" font-weight="600">L4</text>
-  <path d="M104.6,174.3L169.8,135.4L235.0,276.3L300.1,327.5L300.1,400.8L235.0,397.4L169.8,387.0L104.6,409.5Z" fill="#f87171" fill-opacity="0.15"/>
-  <path d="M104.6,365.8L169.8,295.5L235.0,327.3L300.1,342.8" fill="none" stroke="#f87171" stroke-width="0.7" stroke-opacity="0.35"/>
-  <path d="M104.6,366.7L169.8,312.9L235.0,335.6L300.1,348.4" fill="none" stroke="#f87171" stroke-width="0.7" stroke-opacity="0.35"/>
-  <path d="M104.6,368.7L169.8,318.9L235.0,343.7L300.1,353.9" fill="none" stroke="#f87171" stroke-width="0.7" stroke-opacity="0.35"/>
-  <path d="M104.6,370.0L169.8,326.1L235.0,350.0L300.1,358.6" fill="none" stroke="#f87171" stroke-width="0.7" stroke-opacity="0.35"/>
-  <path d="M104.6,398.0L169.8,337.1L235.0,356.8L300.1,363.6" fill="none" stroke="#f87171" stroke-width="0.7" stroke-opacity="0.35"/>
-  <path d="M104.6,397.3L169.8,350.4L235.0,363.3L300.1,367.5" fill="none" stroke="#f87171" stroke-width="0.7" stroke-opacity="0.35"/>
-  <text x="306.1" y="370.5" text-anchor="start" fill="#f87171" font-size="7" font-weight="600" fill-opacity="0.5">L−1</text>
-  <path d="M104.6,401.9L169.8,383.3L235.0,378.9L300.1,373.7" fill="none" stroke="#f87171" stroke-width="0.7" stroke-opacity="0.35"/>
-  <path d="M104.6,402.2L169.8,383.1L235.0,380.6L300.1,378.8" fill="none" stroke="#f87171" stroke-width="0.7" stroke-opacity="0.35"/>
-  <path d="M104.6,409.0L169.8,386.6L235.0,397.2L300.1,400.7" fill="none" stroke="#f87171" stroke-width="0.7" stroke-opacity="0.35"/>
-  <path d="M104.6,174.3L169.8,135.4L235.0,276.3L300.1,327.5" fill="none" stroke="#f87171" stroke-width="1.5"/>
-  <circle cx="104.6" cy="174.3" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="169.8" cy="135.4" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="235.0" cy="276.3" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="300.1" cy="327.5" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
-  <text x="306.1" y="330.5" text-anchor="start" fill="#f87171" font-size="7" font-weight="600">L−7</text>
-  <path d="M104.6,409.5L169.8,387.0L235.0,397.4L300.1,400.8" fill="none" stroke="#f87171" stroke-width="1.5" stroke-dasharray="4,3"/>
-  <circle cx="104.6" cy="409.5" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="169.8" cy="387.0" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="235.0" cy="397.4" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="300.1" cy="400.8" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
-  <text x="306.1" y="403.8" text-anchor="start" fill="#f87171" font-size="7" font-weight="600">L4</text>
-  <path d="M104.6,373.0L169.8,315.8L235.0,343.1L300.1,344.4L300.1,421.1L235.0,421.9L169.8,423.8L104.6,426.4Z" fill="#f59e0b" fill-opacity="0.15"/>
-  <path d="M104.6,374.8L169.8,329.3L235.0,352.6L300.1,365.7" fill="none" stroke="#f59e0b" stroke-width="0.7" stroke-opacity="0.35"/>
-  <path d="M104.6,384.8L169.8,333.5L235.0,361.0L300.1,355.5" fill="none" stroke="#f59e0b" stroke-width="0.7" stroke-opacity="0.35"/>
-  <path d="M104.6,379.4L169.8,337.7L235.0,367.8L300.1,375.3" fill="none" stroke="#f59e0b" stroke-width="0.7" stroke-opacity="0.35"/>
-  <path d="M104.6,380.7L169.8,345.7L235.0,374.9L300.1,379.7" fill="none" stroke="#f59e0b" stroke-width="0.7" stroke-opacity="0.35"/>
-  <path d="M104.6,390.1L169.8,358.5L235.0,382.2L300.1,384.3" fill="none" stroke="#f59e0b" stroke-width="0.7" stroke-opacity="0.35"/>
-  <path d="M104.6,395.0L169.8,378.9L235.0,388.9L300.1,388.9" fill="none" stroke="#f59e0b" stroke-width="0.7" stroke-opacity="0.35"/>
-  <text x="306.1" y="391.9" text-anchor="start" fill="#f59e0b" font-size="7" font-weight="600" fill-opacity="0.5">L−1</text>
-  <path d="M104.6,405.1L169.8,393.2L235.0,396.0L300.1,392.0" fill="none" stroke="#f59e0b" stroke-width="0.7" stroke-opacity="0.35"/>
-  <path d="M104.6,413.6L169.8,405.3L235.0,398.7L300.1,397.6" fill="none" stroke="#f59e0b" stroke-width="0.7" stroke-opacity="0.35"/>
-  <path d="M104.6,426.4L169.8,423.8L235.0,421.9L300.1,421.1" fill="none" stroke="#f59e0b" stroke-width="0.7" stroke-opacity="0.35"/>
-  <path d="M104.6,373.0L169.8,315.8L235.0,343.1L300.1,344.4" fill="none" stroke="#f59e0b" stroke-width="1.5"/>
-  <circle cx="104.6" cy="373.0" r="2.5" fill="#f59e0b" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="169.8" cy="315.8" r="2.5" fill="#f59e0b" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="235.0" cy="343.1" r="2.5" fill="#f59e0b" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="300.1" cy="344.4" r="2.5" fill="#f59e0b" stroke="#0d1117" stroke-width="0.8"/>
-  <text x="306.1" y="347.4" text-anchor="start" fill="#f59e0b" font-size="7" font-weight="600">L−7</text>
-  <path d="M104.6,426.4L169.8,423.8L235.0,421.9L300.1,421.1" fill="none" stroke="#f59e0b" stroke-width="1.5" stroke-dasharray="4,3"/>
-  <circle cx="104.6" cy="426.4" r="2.5" fill="#f59e0b" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="169.8" cy="423.8" r="2.5" fill="#f59e0b" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="235.0" cy="421.9" r="2.5" fill="#f59e0b" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="300.1" cy="421.1" r="2.5" fill="#f59e0b" stroke="#0d1117" stroke-width="0.8"/>
-  <text x="306.1" y="424.1" text-anchor="start" fill="#f59e0b" font-size="7" font-weight="600">L4</text>
+  <line x1="90" y1="384.2" x2="320" y2="384.2" stroke="#21262d" stroke-width="1"/>
+  <text x="82" y="384.2" text-anchor="end" dominant-baseline="middle" fill="#7d8590" font-size="9">50</text>
+  <line x1="90" y1="313.4" x2="320" y2="313.4" stroke="#21262d" stroke-width="1"/>
+  <text x="82" y="313.4" text-anchor="end" dominant-baseline="middle" fill="#7d8590" font-size="9">100</text>
+  <line x1="90" y1="242.6" x2="320" y2="242.6" stroke="#21262d" stroke-width="1"/>
+  <text x="82" y="242.6" text-anchor="end" dominant-baseline="middle" fill="#7d8590" font-size="9">150</text>
+  <line x1="90" y1="171.8" x2="320" y2="171.8" stroke="#21262d" stroke-width="1"/>
+  <text x="82" y="171.8" text-anchor="end" dominant-baseline="middle" fill="#7d8590" font-size="9">200</text>
+  <line x1="90" y1="101.0" x2="320" y2="101.0" stroke="#21262d" stroke-width="1"/>
+  <text x="82" y="101.0" text-anchor="end" dominant-baseline="middle" fill="#7d8590" font-size="9">250</text>
+  <path d="M104.6,252.4L169.8,107.2L235.0,175.1L300.1,230.0L300.1,370.3L235.0,370.6L169.8,398.4L104.6,401.7Z" fill="#f59e0b" fill-opacity="0.15"/>
+  <path d="M104.6,253.4L169.8,140.0L235.0,198.9L300.1,238.1" fill="none" stroke="#f59e0b" stroke-width="0.7" stroke-opacity="0.35"/>
+  <path d="M104.6,276.6L169.8,152.4L235.0,220.9L300.1,250.3" fill="none" stroke="#f59e0b" stroke-width="0.7" stroke-opacity="0.35"/>
+  <path d="M104.6,264.1L169.8,161.3L235.0,236.5L300.1,260.8" fill="none" stroke="#f59e0b" stroke-width="0.7" stroke-opacity="0.35"/>
+  <path d="M104.6,267.1L169.8,178.3L235.0,253.9L300.1,271.0" fill="none" stroke="#f59e0b" stroke-width="0.7" stroke-opacity="0.35"/>
+  <path d="M104.6,289.2L169.8,210.7L235.0,272.1L300.1,282.1" fill="none" stroke="#f59e0b" stroke-width="0.7" stroke-opacity="0.35"/>
+  <path d="M104.6,301.9L169.8,257.7L235.0,288.0L300.1,292.8" fill="none" stroke="#f59e0b" stroke-width="0.7" stroke-opacity="0.35"/>
+  <text x="306.1" y="295.8" text-anchor="start" fill="#f59e0b" font-size="7" font-weight="600" fill-opacity="0.5">L−1</text>
+  <path d="M104.6,330.6L169.8,301.2L235.0,305.7L300.1,289.0" fill="none" stroke="#f59e0b" stroke-width="0.7" stroke-opacity="0.35"/>
+  <path d="M104.6,351.6L169.8,330.7L235.0,320.3L300.1,314.9" fill="none" stroke="#f59e0b" stroke-width="0.7" stroke-opacity="0.35"/>
+  <path d="M104.6,369.1L169.8,370.9L235.0,370.6L300.1,369.6" fill="none" stroke="#f59e0b" stroke-width="0.7" stroke-opacity="0.35"/>
+  <path d="M104.6,252.4L169.8,107.2L235.0,175.1L300.1,230.0" fill="none" stroke="#f59e0b" stroke-width="1.5"/>
+  <circle cx="104.6" cy="252.4" r="2.5" fill="#f59e0b" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="169.8" cy="107.2" r="2.5" fill="#f59e0b" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="235.0" cy="175.1" r="2.5" fill="#f59e0b" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="300.1" cy="230.0" r="2.5" fill="#f59e0b" stroke="#0d1117" stroke-width="0.8"/>
+  <text x="306.1" y="233.0" text-anchor="start" fill="#f59e0b" font-size="7" font-weight="600">L−7</text>
+  <path d="M104.6,401.7L169.8,398.4L235.0,370.6L300.1,370.3" fill="none" stroke="#f59e0b" stroke-width="1.5" stroke-dasharray="4,3"/>
+  <circle cx="104.6" cy="401.7" r="2.5" fill="#f59e0b" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="169.8" cy="398.4" r="2.5" fill="#f59e0b" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="235.0" cy="370.6" r="2.5" fill="#f59e0b" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="300.1" cy="370.3" r="2.5" fill="#f59e0b" stroke="#0d1117" stroke-width="0.8"/>
+  <text x="306.1" y="373.3" text-anchor="start" fill="#f59e0b" font-size="7" font-weight="600">L4</text>
   <rect x="390" y="55" width="230" height="400" fill="#161b22" rx="4"/>
   <text x="505.0" y="47" text-anchor="middle" fill="#e6edf3" font-size="12" font-weight="600">hdfs</text>
   <line x1="404.6" y1="55" x2="404.6" y2="455" stroke="#21262d" stroke-width="1"/>
@@ -103,81 +55,41 @@
   <text x="535.0" y="469" text-anchor="middle" fill="#7d8590" font-size="9">32K</text>
   <line x1="600.1" y1="55" x2="600.1" y2="455" stroke="#21262d" stroke-width="1"/>
   <text x="600.1" y="469" text-anchor="middle" fill="#7d8590" font-size="9">128K</text>
-  <line x1="390" y1="341.6" x2="620" y2="341.6" stroke="#21262d" stroke-width="1"/>
-  <text x="382" y="341.6" text-anchor="end" dominant-baseline="middle" fill="#7d8590" font-size="9">500</text>
-  <line x1="390" y1="228.2" x2="620" y2="228.2" stroke="#21262d" stroke-width="1"/>
-  <text x="382" y="228.2" text-anchor="end" dominant-baseline="middle" fill="#7d8590" font-size="9">1000</text>
-  <line x1="390" y1="114.8" x2="620" y2="114.8" stroke="#21262d" stroke-width="1"/>
-  <text x="382" y="114.8" text-anchor="end" dominant-baseline="middle" fill="#7d8590" font-size="9">1500</text>
-  <path d="M404.6,324.3L469.8,204.7L535.0,107.2L600.1,114.1L600.1,284.8L535.0,272.8L469.8,393.1L404.6,422.4Z" fill="#60a5fa" fill-opacity="0.15"/>
-  <path d="M404.6,334.0L469.8,209.9L535.0,117.5L600.1,146.1" fill="none" stroke="#60a5fa" stroke-width="0.7" stroke-opacity="0.35"/>
-  <path d="M404.6,331.4L469.8,218.0L535.0,128.4L600.1,151.1" fill="none" stroke="#60a5fa" stroke-width="0.7" stroke-opacity="0.35"/>
-  <path d="M404.6,330.6L469.8,220.4L535.0,135.3L600.1,156.4" fill="none" stroke="#60a5fa" stroke-width="0.7" stroke-opacity="0.35"/>
-  <path d="M404.6,334.4L469.8,229.6L535.0,145.0L600.1,160.2" fill="none" stroke="#60a5fa" stroke-width="0.7" stroke-opacity="0.35"/>
-  <path d="M404.6,340.8L469.8,236.2L535.0,159.7L600.1,171.6" fill="none" stroke="#60a5fa" stroke-width="0.7" stroke-opacity="0.35"/>
-  <path d="M404.6,350.8L469.8,253.8L535.0,172.9L600.1,185.8" fill="none" stroke="#60a5fa" stroke-width="0.7" stroke-opacity="0.35"/>
-  <text x="606.1" y="188.8" text-anchor="start" fill="#60a5fa" font-size="7" font-weight="600" fill-opacity="0.5">L−1</text>
-  <path d="M404.6,392.1L469.8,306.8L535.0,211.8L600.1,198.8" fill="none" stroke="#60a5fa" stroke-width="0.7" stroke-opacity="0.35"/>
-  <path d="M404.6,394.3L469.8,310.4L535.0,221.6L600.1,216.2" fill="none" stroke="#60a5fa" stroke-width="0.7" stroke-opacity="0.35"/>
-  <path d="M404.6,402.2L469.8,332.5L535.0,267.5L600.1,268.9" fill="none" stroke="#60a5fa" stroke-width="0.7" stroke-opacity="0.35"/>
-  <path d="M404.6,324.3L469.8,204.7L535.0,107.2L600.1,114.1" fill="none" stroke="#60a5fa" stroke-width="1.5"/>
-  <circle cx="404.6" cy="324.3" r="2.5" fill="#60a5fa" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="469.8" cy="204.7" r="2.5" fill="#60a5fa" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="535.0" cy="107.2" r="2.5" fill="#60a5fa" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="600.1" cy="114.1" r="2.5" fill="#60a5fa" stroke="#0d1117" stroke-width="0.8"/>
-  <text x="606.1" y="117.1" text-anchor="start" fill="#60a5fa" font-size="7" font-weight="600">L−7</text>
-  <path d="M404.6,422.4L469.8,393.1L535.0,272.8L600.1,284.8" fill="none" stroke="#60a5fa" stroke-width="1.5" stroke-dasharray="4,3"/>
-  <circle cx="404.6" cy="422.4" r="2.5" fill="#60a5fa" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="469.8" cy="393.1" r="2.5" fill="#60a5fa" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="535.0" cy="272.8" r="2.5" fill="#60a5fa" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="600.1" cy="284.8" r="2.5" fill="#60a5fa" stroke="#0d1117" stroke-width="0.8"/>
-  <text x="606.1" y="287.8" text-anchor="start" fill="#60a5fa" font-size="7" font-weight="600">L4</text>
-  <path d="M404.6,308.1L469.8,199.0L535.0,116.0L600.1,158.3L600.1,334.0L535.0,336.7L469.8,382.6L404.6,413.8Z" fill="#f87171" fill-opacity="0.15"/>
-  <path d="M404.6,404.8L469.8,368.1L535.0,248.7L600.1,236.0" fill="none" stroke="#f87171" stroke-width="0.7" stroke-opacity="0.35"/>
-  <path d="M404.6,406.7L469.8,372.6L535.0,269.5L600.1,259.0" fill="none" stroke="#f87171" stroke-width="0.7" stroke-opacity="0.35"/>
-  <path d="M404.6,405.2L469.8,368.9L535.0,268.8L600.1,262.3" fill="none" stroke="#f87171" stroke-width="0.7" stroke-opacity="0.35"/>
-  <path d="M404.6,405.3L469.8,369.9L535.0,295.7L600.1,263.4" fill="none" stroke="#f87171" stroke-width="0.7" stroke-opacity="0.35"/>
-  <path d="M404.6,405.1L469.8,369.6L535.0,292.9L600.1,261.1" fill="none" stroke="#f87171" stroke-width="0.7" stroke-opacity="0.35"/>
-  <path d="M404.6,406.0L469.8,370.9L535.0,294.9L600.1,267.2" fill="none" stroke="#f87171" stroke-width="0.7" stroke-opacity="0.35"/>
-  <text x="606.1" y="270.2" text-anchor="start" fill="#f87171" font-size="7" font-weight="600" fill-opacity="0.5">L−1</text>
-  <path d="M404.6,408.7L469.8,373.7L535.0,301.8L600.1,293.9" fill="none" stroke="#f87171" stroke-width="0.7" stroke-opacity="0.35"/>
-  <path d="M404.6,408.7L469.8,372.7L535.0,307.6L600.1,303.8" fill="none" stroke="#f87171" stroke-width="0.7" stroke-opacity="0.35"/>
-  <path d="M404.6,412.8L469.8,381.1L535.0,334.0L600.1,333.2" fill="none" stroke="#f87171" stroke-width="0.7" stroke-opacity="0.35"/>
-  <path d="M404.6,308.1L469.8,199.0L535.0,116.0L600.1,158.3" fill="none" stroke="#f87171" stroke-width="1.5"/>
-  <circle cx="404.6" cy="308.1" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="469.8" cy="199.0" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="535.0" cy="116.0" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="600.1" cy="158.3" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
-  <text x="606.1" y="161.3" text-anchor="start" fill="#f87171" font-size="7" font-weight="600">L−7</text>
-  <path d="M404.6,413.8L469.8,382.6L535.0,336.7L600.1,334.0" fill="none" stroke="#f87171" stroke-width="1.5" stroke-dasharray="4,3"/>
-  <circle cx="404.6" cy="413.8" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="469.8" cy="382.6" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="535.0" cy="336.7" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="600.1" cy="334.0" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
-  <text x="606.1" y="337.0" text-anchor="start" fill="#f87171" font-size="7" font-weight="600">L4</text>
-  <path d="M404.6,421.6L469.8,376.9L535.0,329.4L600.1,321.4L600.1,386.4L535.0,392.4L469.8,406.7L404.6,434.1Z" fill="#f59e0b" fill-opacity="0.15"/>
-  <path d="M404.6,421.9L469.8,376.9L535.0,333.5L600.1,329.0" fill="none" stroke="#f59e0b" stroke-width="0.7" stroke-opacity="0.35"/>
-  <path d="M404.6,421.6L469.8,378.2L535.0,333.2L600.1,330.0" fill="none" stroke="#f59e0b" stroke-width="0.7" stroke-opacity="0.35"/>
-  <path d="M404.6,421.8L469.8,376.9L535.0,333.1L600.1,330.2" fill="none" stroke="#f59e0b" stroke-width="0.7" stroke-opacity="0.35"/>
-  <path d="M404.6,422.6L469.8,377.9L535.0,335.1L600.1,332.4" fill="none" stroke="#f59e0b" stroke-width="0.7" stroke-opacity="0.35"/>
-  <path d="M404.6,422.7L469.8,379.1L535.0,341.8L600.1,337.8" fill="none" stroke="#f59e0b" stroke-width="0.7" stroke-opacity="0.35"/>
-  <path d="M404.6,423.6L469.8,380.6L535.0,346.1L600.1,347.6" fill="none" stroke="#f59e0b" stroke-width="0.7" stroke-opacity="0.35"/>
-  <text x="606.1" y="350.6" text-anchor="start" fill="#f59e0b" font-size="7" font-weight="600" fill-opacity="0.5">L−1</text>
-  <path d="M404.6,423.8L469.8,383.5L535.0,345.6L600.1,345.8" fill="none" stroke="#f59e0b" stroke-width="0.7" stroke-opacity="0.35"/>
-  <path d="M404.6,424.6L469.8,384.4L535.0,348.8L600.1,345.9" fill="none" stroke="#f59e0b" stroke-width="0.7" stroke-opacity="0.35"/>
-  <path d="M404.6,434.1L469.8,406.7L535.0,392.4L600.1,384.7" fill="none" stroke="#f59e0b" stroke-width="0.7" stroke-opacity="0.35"/>
-  <path d="M404.6,421.6L469.8,376.9L535.0,329.4L600.1,321.4" fill="none" stroke="#f59e0b" stroke-width="1.5"/>
-  <circle cx="404.6" cy="421.6" r="2.5" fill="#f59e0b" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="469.8" cy="376.9" r="2.5" fill="#f59e0b" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="535.0" cy="329.4" r="2.5" fill="#f59e0b" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="600.1" cy="321.4" r="2.5" fill="#f59e0b" stroke="#0d1117" stroke-width="0.8"/>
-  <text x="606.1" y="324.4" text-anchor="start" fill="#f59e0b" font-size="7" font-weight="600">L−7</text>
-  <path d="M404.6,434.1L469.8,406.7L535.0,392.4L600.1,386.4" fill="none" stroke="#f59e0b" stroke-width="1.5" stroke-dasharray="4,3"/>
-  <circle cx="404.6" cy="434.1" r="2.5" fill="#f59e0b" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="469.8" cy="406.7" r="2.5" fill="#f59e0b" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="535.0" cy="392.4" r="2.5" fill="#f59e0b" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="600.1" cy="386.4" r="2.5" fill="#f59e0b" stroke="#0d1117" stroke-width="0.8"/>
-  <text x="606.1" y="389.4" text-anchor="start" fill="#f59e0b" font-size="7" font-weight="600">L4</text>
+  <line x1="390" y1="396.4" x2="620" y2="396.4" stroke="#21262d" stroke-width="1"/>
+  <text x="382" y="396.4" text-anchor="end" dominant-baseline="middle" fill="#7d8590" font-size="9">100</text>
+  <line x1="390" y1="337.9" x2="620" y2="337.9" stroke="#21262d" stroke-width="1"/>
+  <text x="382" y="337.9" text-anchor="end" dominant-baseline="middle" fill="#7d8590" font-size="9">200</text>
+  <line x1="390" y1="279.3" x2="620" y2="279.3" stroke="#21262d" stroke-width="1"/>
+  <text x="382" y="279.3" text-anchor="end" dominant-baseline="middle" fill="#7d8590" font-size="9">300</text>
+  <line x1="390" y1="220.8" x2="620" y2="220.8" stroke="#21262d" stroke-width="1"/>
+  <text x="382" y="220.8" text-anchor="end" dominant-baseline="middle" fill="#7d8590" font-size="9">400</text>
+  <line x1="390" y1="162.2" x2="620" y2="162.2" stroke="#21262d" stroke-width="1"/>
+  <text x="382" y="162.2" text-anchor="end" dominant-baseline="middle" fill="#7d8590" font-size="9">500</text>
+  <line x1="390" y1="103.7" x2="620" y2="103.7" stroke="#21262d" stroke-width="1"/>
+  <text x="382" y="103.7" text-anchor="end" dominant-baseline="middle" fill="#7d8590" font-size="9">600</text>
+  <path d="M404.6,367.4L469.8,250.0L535.0,128.5L600.1,107.2L600.1,264.3L535.0,266.7L469.8,369.9L404.6,409.8Z" fill="#f59e0b" fill-opacity="0.15"/>
+  <path d="M404.6,367.8L469.8,250.9L535.0,140.7L600.1,128.6" fill="none" stroke="#f59e0b" stroke-width="0.7" stroke-opacity="0.35"/>
+  <path d="M404.6,367.4L469.8,253.7L535.0,143.1L600.1,129.9" fill="none" stroke="#f59e0b" stroke-width="0.7" stroke-opacity="0.35"/>
+  <path d="M404.6,368.2L469.8,250.0L535.0,139.6L600.1,131.3" fill="none" stroke="#f59e0b" stroke-width="0.7" stroke-opacity="0.35"/>
+  <path d="M404.6,368.7L469.8,252.0L535.0,148.1L600.1,136.3" fill="none" stroke="#f59e0b" stroke-width="0.7" stroke-opacity="0.35"/>
+  <path d="M404.6,370.1L469.8,255.5L535.0,159.4L600.1,150.7" fill="none" stroke="#f59e0b" stroke-width="0.7" stroke-opacity="0.35"/>
+  <path d="M404.6,371.4L469.8,259.1L535.0,170.3L600.1,175.3" fill="none" stroke="#f59e0b" stroke-width="0.7" stroke-opacity="0.35"/>
+  <text x="606.1" y="178.3" text-anchor="start" fill="#f59e0b" font-size="7" font-weight="600" fill-opacity="0.5">L−1</text>
+  <path d="M404.6,372.7L469.8,269.1L535.0,170.8L600.1,180.7" fill="none" stroke="#f59e0b" stroke-width="0.7" stroke-opacity="0.35"/>
+  <path d="M404.6,374.9L469.8,272.2L535.0,180.2L600.1,175.9" fill="none" stroke="#f59e0b" stroke-width="0.7" stroke-opacity="0.35"/>
+  <path d="M404.6,389.0L469.8,314.0L535.0,266.3L600.1,256.9" fill="none" stroke="#f59e0b" stroke-width="0.7" stroke-opacity="0.35"/>
+  <path d="M404.6,367.4L469.8,250.0L535.0,128.5L600.1,107.2" fill="none" stroke="#f59e0b" stroke-width="1.5"/>
+  <circle cx="404.6" cy="367.4" r="2.5" fill="#f59e0b" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="469.8" cy="250.0" r="2.5" fill="#f59e0b" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="535.0" cy="128.5" r="2.5" fill="#f59e0b" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="600.1" cy="107.2" r="2.5" fill="#f59e0b" stroke="#0d1117" stroke-width="0.8"/>
+  <text x="606.1" y="110.2" text-anchor="start" fill="#f59e0b" font-size="7" font-weight="600">L−7</text>
+  <path d="M404.6,409.8L469.8,369.9L535.0,266.7L600.1,264.3" fill="none" stroke="#f59e0b" stroke-width="1.5" stroke-dasharray="4,3"/>
+  <circle cx="404.6" cy="409.8" r="2.5" fill="#f59e0b" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="469.8" cy="369.9" r="2.5" fill="#f59e0b" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="535.0" cy="266.7" r="2.5" fill="#f59e0b" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="600.1" cy="264.3" r="2.5" fill="#f59e0b" stroke="#0d1117" stroke-width="0.8"/>
+  <text x="606.1" y="267.3" text-anchor="start" fill="#f59e0b" font-size="7" font-weight="600">L4</text>
   <rect x="690" y="55" width="230" height="400" fill="#161b22" rx="4"/>
   <text x="805.0" y="47" text-anchor="middle" fill="#e6edf3" font-size="12" font-weight="600">xml collection</text>
   <line x1="704.6" y1="55" x2="704.6" y2="455" stroke="#21262d" stroke-width="1"/>
@@ -188,92 +100,48 @@
   <text x="835.0" y="469" text-anchor="middle" fill="#7d8590" font-size="9">32K</text>
   <line x1="900.1" y1="55" x2="900.1" y2="455" stroke="#21262d" stroke-width="1"/>
   <text x="900.1" y="469" text-anchor="middle" fill="#7d8590" font-size="9">128K</text>
-  <line x1="690" y1="386.8" x2="920" y2="386.8" stroke="#21262d" stroke-width="1"/>
-  <text x="682" y="386.8" text-anchor="end" dominant-baseline="middle" fill="#7d8590" font-size="9">200</text>
-  <line x1="690" y1="318.6" x2="920" y2="318.6" stroke="#21262d" stroke-width="1"/>
-  <text x="682" y="318.6" text-anchor="end" dominant-baseline="middle" fill="#7d8590" font-size="9">400</text>
-  <line x1="690" y1="250.4" x2="920" y2="250.4" stroke="#21262d" stroke-width="1"/>
-  <text x="682" y="250.4" text-anchor="end" dominant-baseline="middle" fill="#7d8590" font-size="9">600</text>
-  <line x1="690" y1="182.3" x2="920" y2="182.3" stroke="#21262d" stroke-width="1"/>
-  <text x="682" y="182.3" text-anchor="end" dominant-baseline="middle" fill="#7d8590" font-size="9">800</text>
-  <line x1="690" y1="114.1" x2="920" y2="114.1" stroke="#21262d" stroke-width="1"/>
-  <text x="682" y="114.1" text-anchor="end" dominant-baseline="middle" fill="#7d8590" font-size="9">1000</text>
-  <path d="M704.6,346.1L769.8,303.4L835.0,206.1L900.1,107.2L900.1,148.7L835.0,264.4L769.8,405.1L704.6,413.9Z" fill="#60a5fa" fill-opacity="0.15"/>
-  <path d="M704.6,349.6L769.8,305.2L835.0,211.2L900.1,136.2" fill="none" stroke="#60a5fa" stroke-width="0.7" stroke-opacity="0.35"/>
-  <path d="M704.6,354.9L769.8,315.0L835.0,229.9L900.1,145.6" fill="none" stroke="#60a5fa" stroke-width="0.7" stroke-opacity="0.35"/>
-  <path d="M704.6,354.6L769.8,314.5L835.0,221.2L900.1,135.9" fill="none" stroke="#60a5fa" stroke-width="0.7" stroke-opacity="0.35"/>
-  <path d="M704.6,357.9L769.8,317.1L835.0,223.9L900.1,127.1" fill="none" stroke="#60a5fa" stroke-width="0.7" stroke-opacity="0.35"/>
-  <path d="M704.6,361.9L769.8,324.4L835.0,228.9L900.1,128.0" fill="none" stroke="#60a5fa" stroke-width="0.7" stroke-opacity="0.35"/>
-  <path d="M704.6,366.8L769.8,334.5L835.0,244.9L900.1,133.6" fill="none" stroke="#60a5fa" stroke-width="0.7" stroke-opacity="0.35"/>
-  <text x="906.1" y="136.6" text-anchor="start" fill="#60a5fa" font-size="7" font-weight="600" fill-opacity="0.5">L−1</text>
-  <path d="M704.6,389.5L769.8,351.0L835.0,233.2L900.1,107.2" fill="none" stroke="#60a5fa" stroke-width="0.7" stroke-opacity="0.35"/>
-  <path d="M704.6,392.0L769.8,356.4L835.0,264.4L900.1,148.7" fill="none" stroke="#60a5fa" stroke-width="0.7" stroke-opacity="0.35"/>
-  <path d="M704.6,394.7L769.8,359.5L835.0,258.8L900.1,133.7" fill="none" stroke="#60a5fa" stroke-width="0.7" stroke-opacity="0.35"/>
-  <path d="M704.6,346.1L769.8,303.4L835.0,206.1L900.1,107.2" fill="none" stroke="#60a5fa" stroke-width="1.5"/>
-  <circle cx="704.6" cy="346.1" r="2.5" fill="#60a5fa" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="769.8" cy="303.4" r="2.5" fill="#60a5fa" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="835.0" cy="206.1" r="2.5" fill="#60a5fa" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="900.1" cy="107.2" r="2.5" fill="#60a5fa" stroke="#0d1117" stroke-width="0.8"/>
-  <text x="906.1" y="110.2" text-anchor="start" fill="#60a5fa" font-size="7" font-weight="600">L−7</text>
-  <path d="M704.6,413.9L769.8,405.1L835.0,264.4L900.1,148.7" fill="none" stroke="#60a5fa" stroke-width="1.5" stroke-dasharray="4,3"/>
-  <circle cx="704.6" cy="413.9" r="2.5" fill="#60a5fa" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="769.8" cy="405.1" r="2.5" fill="#60a5fa" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="835.0" cy="264.4" r="2.5" fill="#60a5fa" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="900.1" cy="148.7" r="2.5" fill="#60a5fa" stroke="#0d1117" stroke-width="0.8"/>
-  <text x="906.1" y="151.7" text-anchor="start" fill="#60a5fa" font-size="7" font-weight="600">L4</text>
-  <path d="M704.6,334.9L769.8,309.6L835.0,221.4L900.1,151.9L900.1,259.1L835.0,346.5L769.8,397.2L704.6,421.0Z" fill="#f87171" fill-opacity="0.15"/>
-  <path d="M704.6,417.3L769.8,387.9L835.0,301.3L900.1,207.0" fill="none" stroke="#f87171" stroke-width="0.7" stroke-opacity="0.35"/>
-  <path d="M704.6,415.4L769.8,387.7L835.0,309.2L900.1,215.5" fill="none" stroke="#f87171" stroke-width="0.7" stroke-opacity="0.35"/>
-  <path d="M704.6,415.9L769.8,386.6L835.0,328.0L900.1,216.9" fill="none" stroke="#f87171" stroke-width="0.7" stroke-opacity="0.35"/>
-  <path d="M704.6,416.4L769.8,385.4L835.0,326.3L900.1,216.0" fill="none" stroke="#f87171" stroke-width="0.7" stroke-opacity="0.35"/>
-  <path d="M704.6,415.5L769.8,385.4L835.0,325.3L900.1,214.8" fill="none" stroke="#f87171" stroke-width="0.7" stroke-opacity="0.35"/>
-  <path d="M704.6,415.8L769.8,386.0L835.0,323.1L900.1,224.5" fill="none" stroke="#f87171" stroke-width="0.7" stroke-opacity="0.35"/>
-  <text x="906.1" y="227.5" text-anchor="start" fill="#f87171" font-size="7" font-weight="600" fill-opacity="0.5">L−1</text>
-  <path d="M704.6,417.7L769.8,389.1L835.0,330.8L900.1,231.7" fill="none" stroke="#f87171" stroke-width="0.7" stroke-opacity="0.35"/>
-  <path d="M704.6,417.5L769.8,388.8L835.0,333.2L900.1,240.3" fill="none" stroke="#f87171" stroke-width="0.7" stroke-opacity="0.35"/>
-  <path d="M704.6,420.8L769.8,397.2L835.0,346.5L900.1,258.9" fill="none" stroke="#f87171" stroke-width="0.7" stroke-opacity="0.35"/>
-  <path d="M704.6,334.9L769.8,309.6L835.0,221.4L900.1,151.9" fill="none" stroke="#f87171" stroke-width="1.5"/>
-  <circle cx="704.6" cy="334.9" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="769.8" cy="309.6" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="835.0" cy="221.4" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="900.1" cy="151.9" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
-  <text x="906.1" y="154.9" text-anchor="start" fill="#f87171" font-size="7" font-weight="600">L−7</text>
-  <path d="M704.6,421.0L769.8,397.2L835.0,346.5L900.1,259.1" fill="none" stroke="#f87171" stroke-width="1.5" stroke-dasharray="4,3"/>
-  <circle cx="704.6" cy="421.0" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="769.8" cy="397.2" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="835.0" cy="346.5" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="900.1" cy="259.1" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
-  <text x="906.1" y="262.1" text-anchor="start" fill="#f87171" font-size="7" font-weight="600">L4</text>
-  <path d="M704.6,418.7L769.8,392.9L835.0,336.8L900.1,253.5L900.1,322.3L835.0,383.5L769.8,422.7L704.6,434.4Z" fill="#f59e0b" fill-opacity="0.15"/>
-  <path d="M704.6,418.7L769.8,393.1L835.0,337.9L900.1,256.2" fill="none" stroke="#f59e0b" stroke-width="0.7" stroke-opacity="0.35"/>
-  <path d="M704.6,422.7L769.8,393.9L835.0,342.4L900.1,256.3" fill="none" stroke="#f59e0b" stroke-width="0.7" stroke-opacity="0.35"/>
-  <path d="M704.6,422.7L769.8,394.5L835.0,342.2L900.1,259.5" fill="none" stroke="#f59e0b" stroke-width="0.7" stroke-opacity="0.35"/>
-  <path d="M704.6,423.7L769.8,395.5L835.0,344.4L900.1,257.8" fill="none" stroke="#f59e0b" stroke-width="0.7" stroke-opacity="0.35"/>
-  <path d="M704.6,423.5L769.8,397.3L835.0,343.5L900.1,259.8" fill="none" stroke="#f59e0b" stroke-width="0.7" stroke-opacity="0.35"/>
-  <path d="M704.6,423.9L769.8,399.4L835.0,346.7L900.1,263.9" fill="none" stroke="#f59e0b" stroke-width="0.7" stroke-opacity="0.35"/>
-  <text x="906.1" y="266.9" text-anchor="start" fill="#f59e0b" font-size="7" font-weight="600" fill-opacity="0.5">L−1</text>
-  <path d="M704.6,425.1L769.8,404.8L835.0,357.7L900.1,280.2" fill="none" stroke="#f59e0b" stroke-width="0.7" stroke-opacity="0.35"/>
-  <path d="M704.6,426.8L769.8,409.5L835.0,365.7L900.1,294.5" fill="none" stroke="#f59e0b" stroke-width="0.7" stroke-opacity="0.35"/>
-  <path d="M704.6,434.4L769.8,422.7L835.0,383.5L900.1,317.2" fill="none" stroke="#f59e0b" stroke-width="0.7" stroke-opacity="0.35"/>
-  <path d="M704.6,418.7L769.8,392.9L835.0,336.8L900.1,253.5" fill="none" stroke="#f59e0b" stroke-width="1.5"/>
-  <circle cx="704.6" cy="418.7" r="2.5" fill="#f59e0b" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="769.8" cy="392.9" r="2.5" fill="#f59e0b" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="835.0" cy="336.8" r="2.5" fill="#f59e0b" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="900.1" cy="253.5" r="2.5" fill="#f59e0b" stroke="#0d1117" stroke-width="0.8"/>
-  <text x="906.1" y="256.5" text-anchor="start" fill="#f59e0b" font-size="7" font-weight="600">L−7</text>
-  <path d="M704.6,434.4L769.8,422.7L835.0,383.5L900.1,322.3" fill="none" stroke="#f59e0b" stroke-width="1.5" stroke-dasharray="4,3"/>
-  <circle cx="704.6" cy="434.4" r="2.5" fill="#f59e0b" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="769.8" cy="422.7" r="2.5" fill="#f59e0b" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="835.0" cy="383.5" r="2.5" fill="#f59e0b" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="900.1" cy="322.3" r="2.5" fill="#f59e0b" stroke="#0d1117" stroke-width="0.8"/>
-  <text x="906.1" y="325.3" text-anchor="start" fill="#f59e0b" font-size="7" font-weight="600">L4</text>
+  <line x1="690" y1="395.9" x2="920" y2="395.9" stroke="#21262d" stroke-width="1"/>
+  <text x="682" y="395.9" text-anchor="end" dominant-baseline="middle" fill="#7d8590" font-size="9">100</text>
+  <line x1="690" y1="336.8" x2="920" y2="336.8" stroke="#21262d" stroke-width="1"/>
+  <text x="682" y="336.8" text-anchor="end" dominant-baseline="middle" fill="#7d8590" font-size="9">200</text>
+  <line x1="690" y1="277.7" x2="920" y2="277.7" stroke="#21262d" stroke-width="1"/>
+  <text x="682" y="277.7" text-anchor="end" dominant-baseline="middle" fill="#7d8590" font-size="9">300</text>
+  <line x1="690" y1="218.6" x2="920" y2="218.6" stroke="#21262d" stroke-width="1"/>
+  <text x="682" y="218.6" text-anchor="end" dominant-baseline="middle" fill="#7d8590" font-size="9">400</text>
+  <line x1="690" y1="159.5" x2="920" y2="159.5" stroke="#21262d" stroke-width="1"/>
+  <text x="682" y="159.5" text-anchor="end" dominant-baseline="middle" fill="#7d8590" font-size="9">500</text>
+  <line x1="690" y1="100.4" x2="920" y2="100.4" stroke="#21262d" stroke-width="1"/>
+  <text x="682" y="100.4" text-anchor="end" dominant-baseline="middle" fill="#7d8590" font-size="9">600</text>
+  <path d="M704.6,390.9L769.8,345.7L835.0,247.2L900.1,107.2L900.1,214.1L835.0,318.9L769.8,416.3L704.6,424.2Z" fill="#f59e0b" fill-opacity="0.15"/>
+  <path d="M704.6,390.9L769.8,346.4L835.0,249.5L900.1,112.9" fill="none" stroke="#f59e0b" stroke-width="0.7" stroke-opacity="0.35"/>
+  <path d="M704.6,398.1L769.8,347.1L835.0,255.2L900.1,113.4" fill="none" stroke="#f59e0b" stroke-width="0.7" stroke-opacity="0.35"/>
+  <path d="M704.6,398.8L769.8,347.0L835.0,253.3L900.1,118.7" fill="none" stroke="#f59e0b" stroke-width="0.7" stroke-opacity="0.35"/>
+  <path d="M704.6,400.1L769.8,349.2L835.0,259.1L900.1,115.2" fill="none" stroke="#f59e0b" stroke-width="0.7" stroke-opacity="0.35"/>
+  <path d="M704.6,399.7L769.8,352.5L835.0,257.8L900.1,118.7" fill="none" stroke="#f59e0b" stroke-width="0.7" stroke-opacity="0.35"/>
+  <path d="M704.6,400.5L769.8,355.0L835.0,262.9L900.1,124.8" fill="none" stroke="#f59e0b" stroke-width="0.7" stroke-opacity="0.35"/>
+  <text x="906.1" y="127.8" text-anchor="start" fill="#f59e0b" font-size="7" font-weight="600" fill-opacity="0.5">L−1</text>
+  <path d="M704.6,403.5L769.8,368.9L835.0,287.5L900.1,162.7" fill="none" stroke="#f59e0b" stroke-width="0.7" stroke-opacity="0.35"/>
+  <path d="M704.6,405.9L769.8,374.5L835.0,298.8L900.1,180.6" fill="none" stroke="#f59e0b" stroke-width="0.7" stroke-opacity="0.35"/>
+  <path d="M704.6,413.3L769.8,390.8L835.0,318.9L900.1,203.3" fill="none" stroke="#f59e0b" stroke-width="0.7" stroke-opacity="0.35"/>
+  <path d="M704.6,390.9L769.8,345.7L835.0,247.2L900.1,107.2" fill="none" stroke="#f59e0b" stroke-width="1.5"/>
+  <circle cx="704.6" cy="390.9" r="2.5" fill="#f59e0b" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="769.8" cy="345.7" r="2.5" fill="#f59e0b" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="835.0" cy="247.2" r="2.5" fill="#f59e0b" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="900.1" cy="107.2" r="2.5" fill="#f59e0b" stroke="#0d1117" stroke-width="0.8"/>
+  <text x="906.1" y="110.2" text-anchor="start" fill="#f59e0b" font-size="7" font-weight="600">L−7</text>
+  <path d="M704.6,424.2L769.8,416.3L835.0,318.9L900.1,214.1" fill="none" stroke="#f59e0b" stroke-width="1.5" stroke-dasharray="4,3"/>
+  <circle cx="704.6" cy="424.2" r="2.5" fill="#f59e0b" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="769.8" cy="416.3" r="2.5" fill="#f59e0b" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="835.0" cy="318.9" r="2.5" fill="#f59e0b" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="900.1" cy="214.1" r="2.5" fill="#f59e0b" stroke="#0d1117" stroke-width="0.8"/>
+  <text x="906.1" y="217.1" text-anchor="start" fill="#f59e0b" font-size="7" font-weight="600">L4</text>
   <text x="20" y="255.0" text-anchor="middle" fill="#e6edf3" font-size="11" font-weight="600" transform="rotate(-90,20,255.0)">encode MB/s</text>
   <circle cx="96" cy="495" r="4" fill="#60a5fa"/>
   <text x="104" y="498.5" fill="#e6edf3" font-size="10" font-weight="500">C zstd (libzstd)</text>
   <circle cx="231" cy="495" r="4" fill="#f87171"/>
   <text x="239" y="498.5" fill="#e6edf3" font-size="10" font-weight="500">zrip (Rust)</text>
   <circle cx="335" cy="495" r="4" fill="#f59e0b"/>
-  <text x="343" y="498.5" fill="#e6edf3" font-size="10" font-weight="500">structured-zstd 0.0.42 (Rust)</text>
+  <text x="343" y="498.5" fill="#e6edf3" font-size="10" font-weight="500">structured-zstd 0.0.45 (Rust)</text>
   <rect x="546" y="490" width="14" height="10" fill="#7d8590" fill-opacity="0.25" rx="2"/>
   <text x="564" y="498.5" fill="#7d8590" font-size="10">L−7..L4 range</text>
   <line x1="663" y1="495" x2="677" y2="495" stroke="#7d8590" stroke-width="1.5"/>

--- a/scripts/plot_small.py
+++ b/scripts/plot_small.py
@@ -29,7 +29,7 @@ COLORS = {
 LABELS = {
     "C zstd":          "C zstd (libzstd)",
     "zrip":            "zrip (Rust)",
-    "structured-zstd": "structured-zstd 0.0.44 (Rust)",
+    "structured-zstd": "structured-zstd 0.0.45 (Rust)",
 }
 
 SMALL_PREFIXES = ["dickens", "hdfs", "xml_collection"]


### PR DESCRIPTION
- Fix incorrect "Safe decoder" claim in README; replaced with accurate "Memory safety" blurb
- Rebench structured-zstd 0.0.45 and regenerate small-input chart
- Add missing 0.7.1 changelog entry
- Bump zrip crate to 0.7.2