### PR TITLE
Fix four UB vulnerabilities found by miri

### DIFF
--- a/crates/core/src/bitstream/reader_reverse.rs
+++ b/crates/core/src/bitstream/reader_reverse.rs
@@ -138,9 +138,9 @@ impl<'a> ReverseBitReader<'a> {
     #[inline(always)]
     pub fn refill_fast(&mut self) {
         let byte_shift = (self.bits_consumed >> 3) as usize;
-        debug_assert!(self.ptr >= self.limit_ptr);
-        debug_assert!(byte_shift <= self.ptr);
-        debug_assert!(self.ptr - byte_shift + 8 <= self.data.len());
+        if byte_shift > self.ptr || self.ptr - byte_shift + 8 > self.data.len() {
+            return;
+        }
         self.ptr -= byte_shift;
         self.bits_consumed -= (byte_shift as u32) * 8;
         self.container = primitives::read_u64_le_unaligned(self.data, self.ptr);

--- a/crates/core/src/bitstream/reader_reverse.rs
+++ b/crates/core/src/bitstream/reader_reverse.rs
@@ -229,3 +229,20 @@ mod tests {
         assert_eq!(r.read_bits(8).unwrap(), 0xFF);
     }
 }
+
+#[cfg(all(test, miri, not(feature = "paranoid")))]
+mod ub_tests {
+    use super::*;
+
+    #[test]
+    fn public_refill_fast_underflows_on_short_stream() {
+        // Issue: refill_fast is a safe public method, but its requirements
+        // (enough consumed bits and at least eight readable bytes after the new
+        // pointer) are enforced only with debug_asserts. On this one-byte stream,
+        // byte_shift is 8 and ptr is 0, so release builds wrap the subtraction
+        // and miri reports the resulting out-of-bounds read_u64_le_unaligned.
+        let data = [0b0000_0001];
+        let mut reader = ReverseBitReader::new(&data).unwrap();
+        reader.refill_fast();
+    }
+}

--- a/crates/core/src/huffman/decode.rs
+++ b/crates/core/src/huffman/decode.rs
@@ -16,6 +16,9 @@ pub fn decode_single_stream(
     data: &[u8],
     output_size: usize,
 ) -> Result<Vec<u8>, DecompressError> {
+    if table.len() < (1usize << table_log) {
+        return Err(DecompressError::BadHuffmanStream);
+    }
     let mut reader = ReverseBitReader::new(data).map_err(|_| DecompressError::BadHuffmanStream)?;
 
     let mut output = Vec::with_capacity(output_size);
@@ -62,6 +65,9 @@ pub fn decode_single_stream_into(
     data: &[u8],
     output: &mut [u8],
 ) -> Result<(), DecompressError> {
+    if table.len() < (1usize << table_log) {
+        return Err(DecompressError::BadHuffmanStream);
+    }
     let mut reader = ReverseBitReader::new(data).map_err(|_| DecompressError::BadHuffmanStream)?;
     decode_stream_tail(table, table_log, &mut reader, output)
 }
@@ -73,6 +79,9 @@ pub fn decode_single_stream_vec(
     output_size: usize,
     output: &mut Vec<u8>,
 ) -> Result<(), DecompressError> {
+    if table.len() < (1usize << table_log) {
+        return Err(DecompressError::BadHuffmanStream);
+    }
     output.clear();
     output.reserve(output_size);
     primitives::set_vec_len(output, output_size);
@@ -101,6 +110,9 @@ pub fn decode_4_streams(
     data: &[u8],
     output_size: usize,
 ) -> Result<Vec<u8>, DecompressError> {
+    if table.len() < (1usize << table_log) {
+        return Err(DecompressError::BadHuffmanStream);
+    }
     let mut output = vec![0u8; output_size];
     decode_4_streams_core_safe(table, table_log, data, output_size, &mut output)?;
     Ok(output)
@@ -113,6 +125,9 @@ pub fn decode_4_streams_into(
     output_size: usize,
     output: &mut Vec<u8>,
 ) -> Result<(), DecompressError> {
+    if table.len() < (1usize << table_log) {
+        return Err(DecompressError::BadHuffmanStream);
+    }
     output.clear();
     output.reserve(output_size);
     primitives::set_vec_len(output, output_size);

--- a/crates/core/src/huffman/decode.rs
+++ b/crates/core/src/huffman/decode.rs
@@ -196,3 +196,26 @@ pub(super) fn decode_stream_tail(
 
     Ok(())
 }
+
+#[cfg(all(test, miri, not(feature = "paranoid")))]
+mod ub_tests {
+    use super::*;
+    use crate::bitstream::writer::BitWriter;
+
+    #[test]
+    fn public_decode_single_stream_trusts_huffman_table_len() {
+        // Issue: decode_single_stream is a safe public API, but huf_table_lookup
+        // uses get_unchecked and only debug-asserts that the caller supplied at
+        // least 1 << table_log entries. This one-bit stream decodes index 1 from
+        // a one-entry table, so miri reports an out-of-bounds read.
+        let table = [HuffmanDecodeEntry {
+            symbol: 0,
+            num_bits: 1,
+        }];
+        let mut data = BitWriter::new();
+        data.write_bits(1, 1);
+        data.close_reverse_stream();
+
+        let _ = decode_single_stream(&table, 1, &data.into_bytes(), 1);
+    }
+}

--- a/crates/decode/src/exec.rs
+++ b/crates/decode/src/exec.rs
@@ -39,7 +39,8 @@ pub(crate) fn decode_execute_sequences(
     output.reserve(zrip_core::frame::MAX_BLOCK_SIZE + WILDCOPY_OVERLENGTH);
 
     let mut op = output.len();
-    let op_limit = output.capacity() - WILDCOPY_OVERLENGTH;
+    let output_start = op;
+    let op_limit = output_start + zrip_core::frame::MAX_BLOCK_SIZE;
     let mut lit_off: usize = 0;
     macro_rules! execute_seq {
         ($literal_length:expr, $match_length:expr, $offset:expr) => {{
@@ -163,7 +164,7 @@ pub(crate) fn decode_execute_sequences(
 
     if lit_off < literals.len() {
         let remaining = literals.len() - lit_off;
-        if output.len() + remaining + 16 > output.capacity() {
+        if op + remaining > op_limit {
             return Err(DecompressError::CorruptSequences);
         }
         fast_extend_from_slice(output, &literals[lit_off..]);

--- a/crates/decode/src/lib.rs
+++ b/crates/decode/src/lib.rs
@@ -421,3 +421,61 @@ pub(crate) fn decode_sequences_dispatch(
         history,
     )
 }
+
+#[cfg(all(test, miri, not(feature = "paranoid")))]
+mod ub_tests {
+    use super::*;
+    use alloc::vec::Vec;
+    use zrip_core::bitstream::writer::BitWriter;
+    use zrip_core::frame::{MAX_BLOCK_SIZE, ZSTD_MAGIC};
+
+    fn push_block_header(out: &mut Vec<u8>, last: bool, block_type: u32, block_size: usize) {
+        let raw = ((block_size as u32) << 3) | (block_type << 1) | u32::from(last);
+        out.push(raw as u8);
+        out.push((raw >> 8) as u8);
+        out.push((raw >> 16) as u8);
+    }
+
+    fn frame_with_oversized_compressed_block_output() -> Vec<u8> {
+        let mut frame = Vec::new();
+        frame.extend_from_slice(&ZSTD_MAGIC.to_le_bytes());
+        frame.push(0x00);
+        frame.push(0x00);
+
+        push_block_header(&mut frame, false, 0, 1);
+        frame.push(b'A');
+
+        let mut block = Vec::new();
+        let trailing_literals = 65usize;
+        block.push(0x04 | (((trailing_literals & 0x0f) as u8) << 4));
+        block.push((trailing_literals >> 4) as u8);
+        block.extend(core::iter::repeat_n(b'B', trailing_literals));
+
+        block.push(1);
+        block.push(0x54);
+        block.extend_from_slice(&[0, 2, 52]);
+
+        let mut seq_bits = BitWriter::new();
+        let ml_extra = MAX_BLOCK_SIZE as u32 - 65_539;
+        seq_bits.write_bits(ml_extra, 16);
+        seq_bits.write_bits(0, 2);
+        seq_bits.close_reverse_stream();
+        block.extend_from_slice(&seq_bits.into_bytes());
+
+        push_block_header(&mut frame, true, 2, block.len());
+        frame.extend_from_slice(&block);
+        frame
+    }
+
+    #[test]
+    fn compressed_block_trailing_literals_overrun_wildcopy_headroom() {
+        // Issue: sequence execution reserves one block plus 64 bytes of wild-copy
+        // headroom and checks each sequence against that limit, but the final
+        // trailing literals are appended afterward without a matching capacity or
+        // block-size check. This safe frame seeds one prior byte, emits a 128 KiB
+        // match at offset 1, then appends 65 literals; miri reports the resulting
+        // out-of-bounds write in fast_extend_from_slice.
+        let frame = frame_with_oversized_compressed_block_output();
+        let _ = decompress(&frame);
+    }
+}

--- a/crates/encode/src/lib.rs
+++ b/crates/encode/src/lib.rs
@@ -96,10 +96,16 @@ pub(crate) fn block_looks_incompressible(data: &[u8]) -> bool {
 }
 
 pub(crate) fn clamp_params_to_src_size(params: &mut strategy::LevelParams, src_len: usize) {
+    params.hash_log = params
+        .hash_log
+        .clamp(strategy::HASH_LOG_MIN, strategy::HASH_LOG_MAX);
+    params.chain_log = params
+        .chain_log
+        .clamp(strategy::HASH_LOG_MIN, strategy::HASH_LOG_MAX);
     if src_len >= 2 {
         let src_log = 32 - ((src_len as u32) - 1).leading_zeros();
-        params.hash_log = params.hash_log.min(src_log);
-        params.chain_log = params.chain_log.min(src_log);
+        params.hash_log = params.hash_log.min(src_log).max(strategy::HASH_LOG_MIN);
+        params.chain_log = params.chain_log.min(src_log).max(strategy::HASH_LOG_MIN);
         params.window_log = params.window_log.min(src_log);
     }
 }

--- a/crates/encode/src/lib.rs
+++ b/crates/encode/src/lib.rs
@@ -455,3 +455,21 @@ pub fn compress_into(input: &[u8], output: &mut [u8], level: i32) -> Result<usiz
     output[..buf.len()].copy_from_slice(&buf);
     Ok(buf.len())
 }
+
+#[cfg(all(test, miri, not(feature = "paranoid")))]
+mod ub_tests {
+    use super::*;
+
+    #[test]
+    fn public_compress_with_params_accepts_zero_hash_log() {
+        // Issue: LevelParams is public and compress_with_params only clamps log
+        // values downward for the input size. A caller can pass hash_log = 0,
+        // which allocates a one-entry hash table, while release-mode hash shifts
+        // produce indexes derived from the input bytes. The first hash_load then
+        // reaches get_unchecked with an out-of-bounds index.
+        let mut params = strategy::level_params(1).unwrap();
+        params.hash_log = 0;
+        params.chain_log = 0;
+        let _ = compress_with_params(b"abcdefghijklmnop", &params);
+    }
+}

--- a/crates/encode/src/strategy.rs
+++ b/crates/encode/src/strategy.rs
@@ -84,14 +84,19 @@ pub fn level_params(level: i32) -> Option<LevelParams> {
 /// Level 0 is treated as "library default" and maps to level 1.
 pub fn level_params_for_size(level: i32, src_len: usize) -> Option<LevelParams> {
     let mut params = level_params_inner(level)?;
+    params.hash_log = params.hash_log.clamp(HASH_LOG_MIN, HASH_LOG_MAX);
+    params.chain_log = params.chain_log.clamp(HASH_LOG_MIN, HASH_LOG_MAX);
     if (2..usize::MAX).contains(&src_len) {
         let src_log = 32 - ((src_len as u32) - 1).leading_zeros();
-        params.hash_log = params.hash_log.min(src_log);
-        params.chain_log = params.chain_log.min(src_log);
+        params.hash_log = params.hash_log.min(src_log).max(HASH_LOG_MIN);
+        params.chain_log = params.chain_log.min(src_log).max(HASH_LOG_MIN);
         params.window_log = params.window_log.min(src_log);
     }
     Some(params)
 }
+
+pub const HASH_LOG_MIN: u32 = 6;
+pub const HASH_LOG_MAX: u32 = 30;
 
 /// Returns the maximum hash_log for a given level.
 /// Used by CompressContext to pre-allocate hash tables.

--- a/tests/roundtrip.rs
+++ b/tests/roundtrip.rs
@@ -647,6 +647,30 @@ fn compress_with_params_dfast() {
     assert_eq!(decompressed, data);
 }
 
+#[cfg(not(miri))]
+#[test]
+fn compress_with_params_clamps_degenerate_hash_log() {
+    let data = b"abcdefghijklmnop".repeat(100);
+    let mut params = zrip::encode::strategy::level_params(1).unwrap();
+    params.hash_log = 0;
+    params.chain_log = 0;
+    let compressed = zrip::compress_with_params(&data, &params).unwrap();
+    let decompressed = zrip::decompress(&compressed).unwrap();
+    assert_eq!(decompressed, data);
+}
+
+#[cfg(not(miri))]
+#[test]
+fn compress_with_params_clamps_excessive_hash_log() {
+    let data = b"abcdefghijklmnop".repeat(100);
+    let mut params = zrip::encode::strategy::level_params(1).unwrap();
+    params.hash_log = 40;
+    params.chain_log = 40;
+    let compressed = zrip::compress_with_params(&data, &params).unwrap();
+    let decompressed = zrip::decompress(&compressed).unwrap();
+    assert_eq!(decompressed, data);
+}
+
 // ===== Skippable frames =====
 
 #[test]


### PR DESCRIPTION
- Clamp `hash_log`/`chain_log` to `[6, 30]` in `compress_with_params` and `level_params_for_size` — `hash_log=0` created a 1-entry table while hash functions shifted by `(32 - 0)`, wrapping in release mode and producing OOB indices for `get_unchecked`; values above 30 risk allocation DoS
- Add runtime bounds checks to `ReverseBitReader::refill_fast` — on short streams (< 8 bytes), `byte_shift` could exceed `ptr`, wrapping the subtraction and causing OOB `read_u64_le_unaligned`
- Validate `table.len() >= 1 << table_log` at all public Huffman decode entry points (`decode_single_stream`, `decode_single_stream_into`, `decode_single_stream_vec`, `decode_4_streams`, `decode_4_streams_into`) — `huf_table_lookup` uses `get_unchecked`, so an undersized table causes OOB read
- Derive `op_limit` in sequence execution from `MAX_BLOCK_SIZE` instead of `Vec::capacity()` — allocator over-allocation could let sequences + trailing literals exceed `MAX_BLOCK_SIZE`, overrunning the reserved wildcopy headroom in `fast_extend_from_slice`
- Include miri UB PoC tests by Shnatsel (GPT-5.5) covering all four vulnerabilities
- Full audit of all remaining unsafe surfaces (encoder primitives, decoder fast_vec, core bitstream/huffman/fse/xxhash, streaming/dict) found no additional reachable UB