### PR TITLE
Bump zrip to 0.7.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 ## [Unreleased]
 
+## [0.7.3]
+
+### Fixed
+
+- Three UB vulnerabilities found by miri:
+  - `ReverseBitReader::refill_fast` could underflow `ptr` and read out of
+    bounds on short streams. Now returns early instead of relying on
+    `debug_assert!`.
+  - Huffman decode functions trusted `table_log` without checking that the
+    table had enough entries, allowing out-of-bounds `get_unchecked`.
+    All entry points now validate `table.len() >= 1 << table_log`.
+  - Sequence execution did not check trailing-literal length against the
+    block-size limit, allowing `fast_extend_from_slice` to write past the
+    reserved capacity.
+- `compress_with_params` and `level_params_for_size` now clamp `hash_log`
+  and `chain_log` to [6, 30], preventing out-of-bounds hash table access
+  when callers supply extreme values.
+
 ## [0.7.2]
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ exclude = ["fuzz", "bench", "jsr"]
 
 [package]
 name = "zrip"
-version = "0.7.2"
+version = "0.7.3"
 edition = "2024"
 rust-version = "1.88"
 description = "Fast, memory-safe Rust implementation of Zstandard compression (levels -7..4)"
@@ -26,9 +26,9 @@ nightly = ["zrip-core/nightly", "zrip-encode/nightly", "zrip-decode/nightly"]
 paranoid = ["zrip-core/paranoid", "zrip-encode/paranoid", "zrip-decode/paranoid"]
 
 [dependencies]
-zrip-core = { version = "0.7.0", path = "crates/core", default-features = false }
-zrip-encode = { version = "0.7.0", path = "crates/encode", default-features = false }
-zrip-decode = { version = "0.7.0", path = "crates/decode", default-features = false }
+zrip-core = { version = "0.7.1", path = "crates/core", default-features = false }
+zrip-encode = { version = "0.7.1", path = "crates/encode", default-features = false }
+zrip-decode = { version = "0.7.1", path = "crates/decode", default-features = false }
 
 [lints]
 workspace = true

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zrip-core"
-version = "0.7.0"
+version = "0.7.1"
 edition = "2024"
 rust-version = "1.88"
 description = "Shared types and codecs for zrip (internal crate)"

--- a/crates/decode/Cargo.toml
+++ b/crates/decode/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zrip-decode"
-version = "0.7.0"
+version = "0.7.1"
 edition = "2024"
 rust-version = "1.88"
 description = "zstd decoder for zrip (internal crate)"
@@ -21,7 +21,7 @@ nightly = ["zrip-core/nightly"]
 paranoid = ["zrip-core/paranoid"]
 
 [dependencies]
-zrip-core = { version = "0.7.0", path = "../core", default-features = false }
+zrip-core = { version = "0.7.1", path = "../core", default-features = false }
 fearless_simd = { version = "0.5", optional = true }
 
 [dev-dependencies]

--- a/crates/encode/Cargo.toml
+++ b/crates/encode/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zrip-encode"
-version = "0.7.0"
+version = "0.7.1"
 edition = "2024"
 rust-version = "1.88"
 description = "zstd encoder for zrip (internal crate)"
@@ -21,7 +21,7 @@ nightly = ["zrip-core/nightly"]
 paranoid = ["zrip-core/paranoid"]
 
 [dependencies]
-zrip-core = { version = "0.7.0", path = "../core", default-features = false }
+zrip-core = { version = "0.7.1", path = "../core", default-features = false }
 
 [dev-dependencies]
 zrip = { path = "../.." }

--- a/jsr/deno.json
+++ b/jsr/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@paddor/zrip",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "license": "MIT",
   "description": "Pure Rust zstd codec compiled to WebAssembly. Fast compression levels -7..4 with SIMD auto-detection.",
   "exports": "./src/mod.ts",


### PR DESCRIPTION
- Bump zrip 0.7.2 → 0.7.3, subcrates (core/encode/decode) 0.7.0 → 0.7.1, JSR 0.4.0 → 0.4.1
- Add CHANGELOG entry for three miri UB fixes and hash_log/chain_log clamping