### PR TITLE
Release 0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,31 @@
 
 ## [Unreleased]
 
+## [0.8.0]
+
+### Added
+
+- Level -8 (zrip-only): same parameters as old L-7 but with
+  `force_raw_literals`, extending the level range from [-7, 4] to [-8, 4].
+  Old L-7 now gets Huffman-compressed literals while L-8 trades ratio for
+  maximum encode throughput.
+- 3-tier dictionary setup in `CompressContext` adapts hash table
+  initialization to input size: micro inputs use a linear-scan attached
+  match finder with raw literals, small inputs add Huffman from dict
+  tables, large inputs copy the full hash snapshot.
+- Decode-side dictionary FSE/Huffman caching: pre-promotes dict tables at
+  construction time so each frame clones promoted tables instead of
+  rebuilding from raw dictionary entries.
+### Changed
+
+- L2 `hash_log` raised from 16 (256 KB) to 17 (512 KB) for better ratio.
+- `huf_worth_trying` minimum gain threshold raised from n/256 (~0.4%) to
+  n/32 (~3%) to skip Huffman table builds on marginally compressible
+  blocks.
+- Per-level raw literals size ramp skips Huffman for tiny blocks.
+- Decode doctests changed to `no_run` so Miri does not attempt
+  `fearless_simd::dispatch!` AVX2 paths it cannot emulate.
+
 ## [0.7.3]
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,10 +4,10 @@ exclude = ["fuzz", "bench", "jsr"]
 
 [package]
 name = "zrip"
-version = "0.7.3"
+version = "0.8.0"
 edition = "2024"
 rust-version = "1.88"
-description = "Fast, memory-safe Rust implementation of Zstandard compression (levels -7..4)"
+description = "Fast, memory-safe Rust implementation of Zstandard compression (levels -8..4)"
 license = "MIT"
 repository = "https://github.com/paddor/zrip"
 categories = ["compression"]
@@ -26,9 +26,9 @@ nightly = ["zrip-core/nightly", "zrip-encode/nightly", "zrip-decode/nightly"]
 paranoid = ["zrip-core/paranoid", "zrip-encode/paranoid", "zrip-decode/paranoid"]
 
 [dependencies]
-zrip-core = { version = "0.7.1", path = "crates/core", default-features = false }
-zrip-encode = { version = "0.7.1", path = "crates/encode", default-features = false }
-zrip-decode = { version = "0.7.1", path = "crates/decode", default-features = false }
+zrip-core = { version = "0.8.0", path = "crates/core", default-features = false }
+zrip-encode = { version = "0.8.0", path = "crates/encode", default-features = false }
+zrip-decode = { version = "0.8.0", path = "crates/decode", default-features = false }
 
 [lints]
 workspace = true

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -68,13 +68,13 @@ Negative levels trade ratio for throughput by increasing `target_length`
 (skip acceleration). Higher `target_length` means more positions are skipped
 on consecutive match-finding misses.
 
-**L-7** skips Huffman table construction and always emits raw literal blocks
+**L-8** skips Huffman table construction and always emits raw literal blocks
 with predefined FSE tables. This eliminates the most expensive part of the
 encode pipeline (Huffman tree build, stream encoding, custom FSE table
 estimation) at the cost of compression ratio. The result is a valid zstd
 frame that any decoder handles, but with LZ4-class encode throughput.
 
-**L-6 through L2** use the full encode pipeline: Huffman-compressed literals
+**L-7 through L2** use the full encode pipeline: Huffman-compressed literals
 (with treeless reuse across blocks) and predefined or custom FSE tables for
 sequences, whichever produces smaller output.
 

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zrip-core"
-version = "0.7.1"
+version = "0.8.0"
 edition = "2024"
 rust-version = "1.88"
 description = "Shared types and codecs for zrip (internal crate)"

--- a/crates/decode/Cargo.toml
+++ b/crates/decode/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zrip-decode"
-version = "0.7.1"
+version = "0.8.0"
 edition = "2024"
 rust-version = "1.88"
 description = "zstd decoder for zrip (internal crate)"
@@ -21,7 +21,7 @@ nightly = ["zrip-core/nightly"]
 paranoid = ["zrip-core/paranoid"]
 
 [dependencies]
-zrip-core = { version = "0.7.1", path = "../core", default-features = false }
+zrip-core = { version = "0.8.0", path = "../core", default-features = false }
 fearless_simd = { version = "0.5", optional = true }
 
 [dev-dependencies]

--- a/crates/decode/src/context.rs
+++ b/crates/decode/src/context.rs
@@ -14,7 +14,7 @@ use zrip_core::error::DecompressError;
 /// Holds internal buffers (output, Huffman/FSE workspace) across calls.
 /// Useful when decompressing many small frames in a loop.
 ///
-/// ```
+/// ```no_run
 /// let data = b"repeated decompression".repeat(100);
 /// let compressed = zrip::compress(&data, 1).unwrap();
 ///

--- a/crates/decode/src/streaming.rs
+++ b/crates/decode/src/streaming.rs
@@ -32,7 +32,7 @@ enum State {
 /// Wraps a reader of compressed data and yields decompressed bytes.
 /// Supports multi-frame streams and skippable frames.
 ///
-/// ```
+/// ```no_run
 /// use std::io::Read;
 ///
 /// let data = b"hello, streaming world!".repeat(100);

--- a/crates/encode/Cargo.toml
+++ b/crates/encode/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zrip-encode"
-version = "0.7.1"
+version = "0.8.0"
 edition = "2024"
 rust-version = "1.88"
 description = "zstd encoder for zrip (internal crate)"
@@ -21,7 +21,7 @@ nightly = ["zrip-core/nightly"]
 paranoid = ["zrip-core/paranoid"]
 
 [dependencies]
-zrip-core = { version = "0.7.1", path = "../core", default-features = false }
+zrip-core = { version = "0.8.0", path = "../core", default-features = false }
 
 [dev-dependencies]
 zrip = { path = "../.." }

--- a/jsr/deno.json
+++ b/jsr/deno.json
@@ -1,8 +1,8 @@
 {
   "name": "@paddor/zrip",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "license": "MIT",
-  "description": "Pure Rust zstd codec compiled to WebAssembly. Fast compression levels -7..4 with SIMD auto-detection.",
+  "description": "Pure Rust zstd codec compiled to WebAssembly. Fast compression levels -8..4 with SIMD auto-detection.",
   "exports": "./src/mod.ts",
   "publish": {
     "include": ["src/", "deno.json", "LICENSE", "README.md"],


### PR DESCRIPTION
- Fix decode doctests for Miri (no_run to avoid fearless_simd AVX2 dispatch)
- Fix DESIGN.md: L-8 skips Huffman, not L-7
- Bump all crates to 0.8.0, JSR to 0.5.0, level range now -8..4