### PR TITLE
Prepare 0.8.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 ## [Unreleased]
 
+## [0.8.1]
+
+### Changed
+
+- Reused Huffman decode tables and `MaybeUninit` FSE sequence table storage
+  to remove per-block decode allocations.
+- Specialized decoder no-history execution and sequence table reads to
+  reduce decode hot-loop work.
+- Specialized DFast MLS4, Fast L1 hash-log, and rare Fast MLS7 encode hot
+  paths.
+- Preserved copied `MaybeUninit` sequence entries for the default path while
+  borrowing sequence table entries in `paranoid` builds, recovering
+  `paranoid` decode throughput.
+- Refreshed x86_64 benchmark charts after rebenchmarking `zrip` and
+  `zrip paranoid` with performance governor and turbo off.
+- JSR package `@paddor/zrip` bumped to 0.5.1 for the current Rust codec.
+
 ## [0.8.0]
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ exclude = ["fuzz", "bench", "jsr"]
 
 [package]
 name = "zrip"
-version = "0.8.0"
+version = "0.8.1"
 edition = "2024"
 rust-version = "1.88"
 description = "Fast, memory-safe Rust implementation of Zstandard compression (levels -8..4)"
@@ -26,9 +26,9 @@ nightly = ["zrip-core/nightly", "zrip-encode/nightly", "zrip-decode/nightly"]
 paranoid = ["zrip-core/paranoid", "zrip-encode/paranoid", "zrip-decode/paranoid"]
 
 [dependencies]
-zrip-core = { version = "0.8.0", path = "crates/core", default-features = false }
-zrip-encode = { version = "0.8.0", path = "crates/encode", default-features = false }
-zrip-decode = { version = "0.8.0", path = "crates/decode", default-features = false }
+zrip-core = { version = "0.8.1", path = "crates/core", default-features = false }
+zrip-encode = { version = "0.8.1", path = "crates/encode", default-features = false }
+zrip-decode = { version = "0.8.1", path = "crates/decode", default-features = false }
 
 [lints]
 workspace = true

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zrip-core"
-version = "0.8.0"
+version = "0.8.1"
 edition = "2024"
 rust-version = "1.88"
 description = "Shared types and codecs for zrip (internal crate)"

--- a/crates/decode/Cargo.toml
+++ b/crates/decode/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zrip-decode"
-version = "0.8.0"
+version = "0.8.1"
 edition = "2024"
 rust-version = "1.88"
 description = "zstd decoder for zrip (internal crate)"
@@ -21,7 +21,7 @@ nightly = ["zrip-core/nightly"]
 paranoid = ["zrip-core/paranoid"]
 
 [dependencies]
-zrip-core = { version = "0.8.0", path = "../core", default-features = false }
+zrip-core = { version = "0.8.1", path = "../core", default-features = false }
 fearless_simd = { version = "0.5", optional = true }
 
 [dev-dependencies]

--- a/crates/encode/Cargo.toml
+++ b/crates/encode/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zrip-encode"
-version = "0.8.0"
+version = "0.8.1"
 edition = "2024"
 rust-version = "1.88"
 description = "zstd encoder for zrip (internal crate)"
@@ -21,7 +21,7 @@ nightly = ["zrip-core/nightly"]
 paranoid = ["zrip-core/paranoid"]
 
 [dependencies]
-zrip-core = { version = "0.8.0", path = "../core", default-features = false }
+zrip-core = { version = "0.8.1", path = "../core", default-features = false }
 
 [dev-dependencies]
 zrip = { path = "../.." }

--- a/jsr/deno.json
+++ b/jsr/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@paddor/zrip",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "license": "MIT",
   "description": "Pure Rust zstd codec compiled to WebAssembly. Fast compression levels -8..4 with SIMD auto-detection.",
   "exports": "./src/mod.ts",


### PR DESCRIPTION
- Bumps Rust crates to `0.8.1` and updates internal crate dependency versions.
- Bumps JSR package `@paddor/zrip` to `0.5.1`.
- Adds `CHANGELOG.md` release notes for the decode allocation, codec hot-path, paranoid perf, and chart updates.
