### PR TITLE
Improve OpenZL zstd decode paths

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .DS_Store
 __pycache__/
 /info/
+/tmp/
 target/
 corpus/
 /fuzz/artifacts/

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,6 +60,10 @@ name = "profile_decode_corpus"
 required-features = ["std"]
 
 [[example]]
+name = "profile_openzl_decode"
+required-features = ["std"]
+
+[[example]]
 name = "profile_encode"
 required-features = ["std"]
 

--- a/crates/core/src/frame/header.rs
+++ b/crates/core/src/frame/header.rs
@@ -24,11 +24,18 @@ pub fn parse_frame_header(data: &[u8]) -> Result<FrameHeader, DecompressError> {
         return Err(DecompressError::BadMagic);
     }
 
-    if data.len() < 5 {
+    parse_frame_header_after_magic(&data[4..], 4)
+}
+
+pub fn parse_frame_header_after_magic(
+    data: &[u8],
+    magic_size: usize,
+) -> Result<FrameHeader, DecompressError> {
+    if data.is_empty() {
         return Err(DecompressError::BadFrameHeader);
     }
 
-    let descriptor = data[4];
+    let descriptor = data[0];
     let dict_id_flag = descriptor & 0x03;
     let content_checksum = (descriptor & 0x04) != 0;
     let single_segment = (descriptor & 0x20) != 0;
@@ -43,7 +50,7 @@ pub fn parse_frame_header(data: &[u8]) -> Result<FrameHeader, DecompressError> {
         return Err(DecompressError::BadFrameHeader);
     }
 
-    let mut offset = 5;
+    let mut offset = 1;
 
     let window_size = if single_segment {
         0
@@ -146,7 +153,7 @@ pub fn parse_frame_header(data: &[u8]) -> Result<FrameHeader, DecompressError> {
         dict_id,
         content_checksum,
         single_segment,
-        header_size: offset,
+        header_size: offset + magic_size,
     })
 }
 
@@ -171,5 +178,14 @@ mod tests {
             parse_frame_header(&data),
             Err(DecompressError::BadMagic)
         ));
+    }
+
+    #[test]
+    fn parse_header_after_magic() {
+        let data = [0x20, 0x00];
+        let hdr = parse_frame_header_after_magic(&data, 0).unwrap();
+        assert!(hdr.single_segment);
+        assert_eq!(hdr.frame_content_size, Some(0));
+        assert_eq!(hdr.header_size, 2);
     }
 }

--- a/crates/core/src/huffman/weights.rs
+++ b/crates/core/src/huffman/weights.rs
@@ -237,16 +237,17 @@ pub fn build_huffman_decode_table(
         return Err(DecompressError::BadHuffmanWeights);
     }
 
-    let max_weight = *weights.iter().max().unwrap();
-    if max_weight > MAX_BITS + 1 {
-        return Err(DecompressError::BadHuffmanWeights);
-    }
-
     let mut weight_sum: u32 = 0;
+    let mut max_weight = 0u8;
     for &w in weights.iter() {
+        max_weight = max_weight.max(w);
         if w > 0 {
             weight_sum += 1u32 << (w - 1);
         }
+    }
+
+    if max_weight > MAX_BITS + 1 {
+        return Err(DecompressError::BadHuffmanWeights);
     }
 
     if weight_sum == 0 {
@@ -321,16 +322,17 @@ pub fn build_huffman_decode_table_into(
         return Err(DecompressError::BadHuffmanWeights);
     }
 
-    let max_weight = *weights.iter().max().unwrap();
-    if max_weight > MAX_BITS + 1 {
-        return Err(DecompressError::BadHuffmanWeights);
-    }
-
     let mut weight_sum: u32 = 0;
+    let mut max_weight = 0u8;
     for &w in weights.iter() {
+        max_weight = max_weight.max(w);
         if w > 0 {
             weight_sum += 1u32 << (w - 1);
         }
+    }
+
+    if max_weight > MAX_BITS + 1 {
+        return Err(DecompressError::BadHuffmanWeights);
     }
 
     if weight_sum == 0 {
@@ -362,7 +364,6 @@ pub fn build_huffman_decode_table_into(
     let max_w = table_log as u8 + 1;
 
     rank_count.resize(max_w as usize + 1, 0);
-    rank_count.truncate(max_w as usize + 1);
     rank_count.fill(0);
     for &w in all_weights.iter() {
         if w > 0 && w <= max_w {
@@ -371,7 +372,6 @@ pub fn build_huffman_decode_table_into(
     }
 
     rank_start.resize(max_w as usize + 1, 0);
-    rank_start.truncate(max_w as usize + 1);
     {
         let mut cumul = 0u32;
         for w in 1..=max_w {

--- a/crates/decode/src/context.rs
+++ b/crates/decode/src/context.rs
@@ -95,4 +95,77 @@ impl DecompressContext {
             Ok(Cow::Borrowed(&self.output))
         }
     }
+
+    /// Decompresses one zstd frame whose 4-byte magic number is stored out of band.
+    ///
+    /// OpenZL stores zstd payloads this way inside transform streams.
+    pub fn decompress_after_magic_with_limit(
+        &mut self,
+        input: &[u8],
+        max_output: usize,
+    ) -> Result<Cow<'_, [u8]>, DecompressError> {
+        self.output.clear();
+        super::decompress_frame_after_magic(
+            input,
+            &mut self.output,
+            max_output,
+            self.dict.as_ref(),
+            &mut self.ws,
+        )?;
+        if self.output.len() >= zrip_core::LARGE_OUTPUT_THRESHOLD {
+            Ok(Cow::Owned(core::mem::take(&mut self.output)))
+        } else {
+            Ok(Cow::Borrowed(&self.output))
+        }
+    }
+
+    /// Decompresses one zstd frame without its magic number into `output`.
+    ///
+    /// Appends to `output` and returns the number of bytes written.
+    pub fn decompress_after_magic_into(
+        &mut self,
+        input: &[u8],
+        output: &mut Vec<u8>,
+        max_output: usize,
+    ) -> Result<usize, DecompressError> {
+        let start = output.len();
+        super::decompress_frame_after_magic(
+            input,
+            output,
+            max_output,
+            self.dict.as_ref(),
+            &mut self.ws,
+        )?;
+        Ok(output.len() - start)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloc::vec::Vec;
+
+    fn push_block_header(out: &mut Vec<u8>, last: bool, block_type: u32, block_size: usize) {
+        let raw = ((block_size as u32) << 3) | (block_type << 1) | u32::from(last);
+        out.push(raw as u8);
+        out.push((raw >> 8) as u8);
+        out.push((raw >> 16) as u8);
+    }
+
+    #[test]
+    fn decompress_after_magic_into_appends_output() {
+        let mut frame = Vec::new();
+        frame.push(0x20);
+        frame.push(5);
+        push_block_header(&mut frame, true, 0, 5);
+        frame.extend_from_slice(b"hello");
+
+        let mut ctx = DecompressContext::new();
+        let mut output = b"prefix".to_vec();
+        let written = ctx
+            .decompress_after_magic_into(&frame, &mut output, usize::MAX)
+            .unwrap();
+        assert_eq!(written, 5);
+        assert_eq!(output, b"prefixhello");
+    }
 }

--- a/crates/decode/src/exec.rs
+++ b/crates/decode/src/exec.rs
@@ -123,6 +123,21 @@ pub(crate) fn decode_execute_sequences<const HAS_HISTORY: bool>(
     let last_seq = num_sequences - 1;
     let mut seq_idx: u32 = 0;
     let fast_limit = rev_reader.limit_ptr + 16;
+    while seq_idx + 4 <= last_seq && rev_reader.ptr >= fast_limit {
+        rev_reader.refill_fast();
+        decode_and_execute_update!(rev_reader, offsets);
+
+        rev_reader.refill_fast();
+        decode_and_execute_update!(rev_reader, offsets);
+
+        rev_reader.refill_fast();
+        decode_and_execute_update!(rev_reader, offsets);
+
+        rev_reader.refill_fast();
+        decode_and_execute_update!(rev_reader, offsets);
+
+        seq_idx += 4;
+    }
     while seq_idx + 2 <= last_seq && rev_reader.ptr >= fast_limit {
         rev_reader.refill_fast();
         decode_and_execute_update!(rev_reader, offsets);

--- a/crates/decode/src/exec.rs
+++ b/crates/decode/src/exec.rs
@@ -3,7 +3,7 @@
 #[cfg(feature = "alloc")]
 use alloc::vec::Vec;
 
-use crate::fast_vec::{fast_extend_from_slice, wild_copy_match};
+use crate::fast_vec::{fast_extend_from_slice, wild_copy_match, wild_copy_match_single};
 use crate::sequences::{SequenceDecodeTables, compute_offset};
 use zrip_core::bitstream::reader_reverse::ReverseBitReader;
 use zrip_core::error::DecompressError;
@@ -188,6 +188,104 @@ pub(crate) fn decode_execute_sequences<const HAS_HISTORY: bool>(
             return Err(DecompressError::CorruptSequences);
         }
         fast_extend_from_slice(output, &literals[lit_off..]);
+    }
+
+    Ok(())
+}
+
+#[inline(always)]
+pub(crate) fn decode_execute_single_sequence<const HAS_HISTORY: bool>(
+    data: &[u8],
+    tables: &SequenceDecodeTables,
+    offsets: &mut [u32; 3],
+    literals: &[u8],
+    output: &mut Vec<u8>,
+    history: &[u8],
+) -> Result<(), DecompressError> {
+    if data.is_empty() {
+        return Err(DecompressError::CorruptSequences);
+    }
+
+    let mut rev_reader =
+        ReverseBitReader::new(data).map_err(|_| DecompressError::CorruptSequences)?;
+    let ll_state = rev_reader.read_bits(tables.ll_accuracy)?;
+    let of_state = rev_reader.read_bits(tables.of_accuracy)?;
+    let ml_state = rev_reader.read_bits(tables.ml_accuracy)?;
+
+    const WILDCOPY_OVERLENGTH: usize = 64;
+    output.reserve(zrip_core::frame::MAX_BLOCK_SIZE + WILDCOPY_OVERLENGTH);
+
+    macro_rules! table_entry {
+        ($table:expr, $state:expr) => {{
+            let idx = ($state & FSE_SEQ_TABLE_MASK) as usize;
+            #[cfg(feature = "paranoid")]
+            {
+                $table.get_ref(idx)
+            }
+            #[cfg(not(feature = "paranoid"))]
+            {
+                $table.get(idx)
+            }
+        }};
+    }
+
+    rev_reader.refill();
+    let of_e = table_entry!(tables.of_table, of_state);
+    let ml_e = table_entry!(tables.ml_table, ml_state);
+    let ll_e = table_entry!(tables.ll_table, ll_state);
+
+    let of_extra = rev_reader.read_bits_branchless(of_e.extra_bits);
+    let offset_value = of_e.baseline_value + of_extra;
+    let ml_extra = rev_reader.read_bits_branchless(ml_e.extra_bits);
+    let match_length = ml_e.baseline_value + ml_extra;
+    let ll_extra = rev_reader.read_bits_branchless(ll_e.extra_bits);
+    let literal_length = ll_e.baseline_value + ll_extra;
+    let offset = compute_offset(offset_value, literal_length, offsets);
+
+    let ll = literal_length as usize;
+    let ml = match_length as usize;
+    let output_start = output.len();
+    let op_limit = output_start + zrip_core::frame::MAX_BLOCK_SIZE;
+    if unlikely(output_start + ll + ml > op_limit) {
+        return Err(DecompressError::CorruptSequences);
+    }
+    if unlikely(ll > literals.len()) {
+        return Err(DecompressError::CorruptLiterals);
+    }
+
+    fast_extend_from_slice(output, &literals[..ll]);
+
+    let off = offset as usize;
+    if unlikely(off == 0) {
+        return Err(DecompressError::InvalidOffset);
+    }
+    let out_pos = output.len();
+    if HAS_HISTORY {
+        if unlikely(off > out_pos + history.len()) {
+            return Err(DecompressError::InvalidOffset);
+        }
+        if likely(off <= out_pos) {
+            wild_copy_match_single(output, off, ml);
+        } else {
+            copy_match_from_history(output, history, off, out_pos, ml);
+        }
+    } else {
+        if unlikely(off > out_pos) {
+            return Err(DecompressError::InvalidOffset);
+        }
+        wild_copy_match_single(output, off, ml);
+    }
+
+    if rev_reader.bits_remaining() != 0 {
+        return Err(DecompressError::CorruptSequences);
+    }
+
+    if ll < literals.len() {
+        let remaining = literals.len() - ll;
+        if output.len() + remaining > op_limit {
+            return Err(DecompressError::CorruptSequences);
+        }
+        fast_extend_from_slice(output, &literals[ll..]);
     }
 
     Ok(())

--- a/crates/decode/src/fast_vec.rs
+++ b/crates/decode/src/fast_vec.rs
@@ -25,6 +25,26 @@ fn copy_8(src: *const u8, dst: *mut u8) {
     }
 }
 
+#[cfg(not(feature = "paranoid"))]
+#[inline(always)]
+fn copy_32(src: *const u8, dst: *mut u8) {
+    unsafe {
+        copy_16(src, dst);
+        copy_16(src.add(16), dst.add(16));
+    }
+}
+
+#[cfg(not(feature = "paranoid"))]
+#[inline(always)]
+fn copy_64(src: *const u8, dst: *mut u8) {
+    unsafe {
+        copy_16(src, dst);
+        copy_16(src.add(16), dst.add(16));
+        copy_16(src.add(32), dst.add(32));
+        copy_16(src.add(48), dst.add(48));
+    }
+}
+
 /// Copy `src` into the end of `vec` using 16-byte chunk copies.
 ///
 /// All reads stay within `src` bounds (no wild over-read).
@@ -179,6 +199,51 @@ pub(crate) fn wild_copy_match(vec: &mut Vec<u8>, offset: usize, len: usize) {
     }
 }
 
+/// Variant for one-sequence tiny frames. The caller reserves 64 bytes of
+/// headroom, so non-overlapping copies can use wider chunks without changing
+/// the generic multi-sequence path.
+#[cfg(not(feature = "paranoid"))]
+#[inline(always)]
+pub(crate) fn wild_copy_match_single(vec: &mut Vec<u8>, offset: usize, len: usize) {
+    debug_assert!(offset > 0 && offset <= vec.len());
+    debug_assert!(vec.len() + len + 64 <= vec.capacity());
+    unsafe {
+        let ptr = vec.as_mut_ptr();
+        let op = ptr.add(vec.len());
+        let src = op.sub(offset);
+
+        if offset >= 64 {
+            let mut off = 0usize;
+            loop {
+                copy_64(src.add(off), op.add(off));
+                off += 64;
+                if off >= len {
+                    break;
+                }
+            }
+        } else if offset >= 32 {
+            let mut off = 0usize;
+            loop {
+                copy_32(src.add(off), op.add(off));
+                off += 32;
+                if off >= len {
+                    break;
+                }
+            }
+        } else {
+            wild_copy_match(vec, offset, len);
+            return;
+        }
+        vec.set_len(vec.len() + len);
+    }
+}
+
+#[cfg(feature = "paranoid")]
+#[inline(always)]
+pub(crate) fn wild_copy_match_single(vec: &mut Vec<u8>, offset: usize, len: usize) {
+    wild_copy_match(vec, offset, len);
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -206,6 +271,28 @@ mod tests {
                     expected.push(expected[start + i % offset]);
                 }
                 wild_copy_match(&mut v, offset, len);
+                assert_eq!(
+                    &v[..offset + len],
+                    &expected[..offset + len],
+                    "offset={offset} len={len}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn wild_copy_match_single_all_offsets() {
+        for offset in 1..=128 {
+            for len in 1..=256 {
+                let mut v = Vec::with_capacity(offset + len + 64);
+                let seed: Vec<u8> = (0..offset).map(|i| (i as u8).wrapping_mul(37)).collect();
+                v.extend_from_slice(&seed);
+                let mut expected = v.clone();
+                let start = expected.len() - offset;
+                for i in 0..len {
+                    expected.push(expected[start + i % offset]);
+                }
+                wild_copy_match_single(&mut v, offset, len);
                 assert_eq!(
                     &v[..offset + len],
                     &expected[..offset + len],

--- a/crates/decode/src/lib.rs
+++ b/crates/decode/src/lib.rs
@@ -28,7 +28,9 @@ use crate::sequences::{SequenceDecodeTables, parse_sequence_count, parse_sequenc
 use zrip_core::block::{BlockType, parse_block_header};
 use zrip_core::error::DecompressError;
 use zrip_core::frame::MAX_WINDOW_SIZE;
-use zrip_core::frame::header::{FrameHeader, parse_frame_header, parse_frame_header_after_magic};
+#[cfg(feature = "std")]
+use zrip_core::frame::header::parse_frame_header_after_magic;
+use zrip_core::frame::header::{FrameHeader, parse_frame_header};
 use zrip_core::huffman::HuffmanDecodeEntry;
 use zrip_core::xxhash::Xxh64State;
 
@@ -198,6 +200,7 @@ pub(crate) fn decompress_frame(
     decompress_frame_with_header(input, output, max_output, dict, ws, header)
 }
 
+#[cfg(feature = "std")]
 pub(crate) fn decompress_frame_after_magic(
     input: &[u8],
     output: &mut Vec<u8>,
@@ -391,16 +394,19 @@ fn initial_sequence_state(
         if let Some((t, l)) = d.of_table() {
             st.of_table = crate::seq_table::SeqTable::promote_of(t);
             st.of_accuracy = l;
+            st.of_kind = crate::sequences::SequenceTableKind::Other;
             st.of_set = true;
         }
         if let Some((t, l)) = d.ml_table() {
             st.ml_table = crate::seq_table::SeqTable::promote_ml(t);
             st.ml_accuracy = l;
+            st.ml_kind = crate::sequences::SequenceTableKind::Other;
             st.ml_set = true;
         }
         if let Some((t, l)) = d.ll_table() {
             st.ll_table = crate::seq_table::SeqTable::promote_ll(t);
             st.ll_accuracy = l;
+            st.ll_kind = crate::sequences::SequenceTableKind::Other;
             st.ll_set = true;
         }
         (st, *d.rep_offsets())

--- a/crates/decode/src/lib.rs
+++ b/crates/decode/src/lib.rs
@@ -79,7 +79,6 @@ impl BlockDecodeWorkspace {
 
     pub(crate) fn reset_huffman_state(&mut self) {
         self.huf_valid = false;
-        self.huf_last_weights_valid = false;
     }
 
     #[cfg(feature = "std")]
@@ -263,6 +262,7 @@ fn decompress_frame_with_header(
         ws.huf_table.extend_from_slice(t);
         ws.huf_table_log = l;
         ws.huf_valid = true;
+        ws.huf_last_weights_valid = false;
     } else if let Some(d) = dict
         && let Some((t, l)) = d.huf_table()
     {
@@ -270,6 +270,7 @@ fn decompress_frame_with_header(
         ws.huf_table.extend_from_slice(t);
         ws.huf_table_log = l;
         ws.huf_valid = true;
+        ws.huf_last_weights_valid = false;
     }
 
     let mut hasher = if header.content_checksum {
@@ -596,6 +597,20 @@ mod tests {
             decompress_frame_after_magic(&frame, &mut output, usize::MAX, None, &mut ws).unwrap();
         assert_eq!(consumed, frame.len());
         assert_eq!(output, b"hello");
+    }
+
+    #[test]
+    fn frame_reset_keeps_explicit_huffman_cache() {
+        let mut ws = BlockDecodeWorkspace::new();
+        ws.huf_valid = true;
+        ws.huf_last_weights_valid = true;
+        ws.huf_last_weights.extend_from_slice(&[1, 2, 3]);
+
+        ws.reset_huffman_state();
+
+        assert!(!ws.huf_valid);
+        assert!(ws.huf_last_weights_valid);
+        assert_eq!(ws.huf_last_weights, [1, 2, 3]);
     }
 }
 

--- a/crates/decode/src/lib.rs
+++ b/crates/decode/src/lib.rs
@@ -22,7 +22,7 @@ use alloc::boxed::Box;
 #[cfg(feature = "alloc")]
 use alloc::vec::Vec;
 
-use crate::exec::decode_execute_sequences;
+use crate::exec::{decode_execute_sequences, decode_execute_single_sequence};
 use crate::literals::decode_literals_ws;
 use crate::sequences::{SequenceDecodeTables, parse_sequence_count, parse_sequence_tables_ws};
 use zrip_core::block::{BlockType, parse_block_header};
@@ -48,6 +48,7 @@ pub(crate) struct BlockDecodeWorkspace {
     pub fse_dist: Vec<i16>,
     pub fse_symbol_next: Vec<u16>,
     pub fse_build_buf: Vec<zrip_core::fse::FseDecodeEntry>,
+    pub seq_tables: Option<SequenceDecodeTables>,
     pub cached_dict_tables: Option<SequenceDecodeTables>,
     pub cached_dict_rep: [u32; 3],
     pub cached_dict_huf: Option<(Vec<HuffmanDecodeEntry>, u8)>,
@@ -69,6 +70,7 @@ impl BlockDecodeWorkspace {
             fse_dist: Vec::new(),
             fse_symbol_next: Vec::new(),
             fse_build_buf: Vec::new(),
+            seq_tables: Some(SequenceDecodeTables::new_default()),
             cached_dict_tables: None,
             cached_dict_rep: [1, 4, 8],
             cached_dict_huf: None,
@@ -322,7 +324,11 @@ fn decompress_frame_with_header(
                     return Err(DecompressError::InputExhausted);
                 }
                 if seq_tables.is_none() {
-                    let (initial_tables, initial_rep_offsets) = initial_sequence_state(ws, dict);
+                    let mut initial_tables = ws
+                        .seq_tables
+                        .take()
+                        .unwrap_or_else(SequenceDecodeTables::new_default);
+                    let initial_rep_offsets = initial_sequence_state(&mut initial_tables, ws, dict);
                     seq_tables = Some(initial_tables);
                     rep_offsets = initial_rep_offsets;
                 }
@@ -349,6 +355,10 @@ fn decompress_frame_with_header(
         if block_header.last_block {
             break;
         }
+    }
+
+    if let Some(tables) = seq_tables.take() {
+        ws.seq_tables = Some(tables);
     }
 
     if let Some(ref mut hasher) = hasher {
@@ -384,34 +394,37 @@ fn decompress_frame_with_header(
 }
 
 fn initial_sequence_state(
+    tables: &mut SequenceDecodeTables,
     ws: &BlockDecodeWorkspace,
     dict: Option<&zrip_core::dict::Dictionary>,
-) -> (SequenceDecodeTables, [u32; 3]) {
+) -> [u32; 3] {
     if let Some(ref cached) = ws.cached_dict_tables {
-        (cached.clone(), ws.cached_dict_rep)
+        *tables = cached.clone();
+        ws.cached_dict_rep
     } else if let Some(d) = dict {
-        let mut st = SequenceDecodeTables::new_default();
+        tables.reset_default();
         if let Some((t, l)) = d.of_table() {
-            st.of_table = crate::seq_table::SeqTable::promote_of(t);
-            st.of_accuracy = l;
-            st.of_kind = crate::sequences::SequenceTableKind::Other;
-            st.of_set = true;
+            tables.of_table = crate::seq_table::SeqTable::promote_of(t);
+            tables.of_accuracy = l;
+            tables.of_kind = crate::sequences::SequenceTableKind::Other;
+            tables.of_set = true;
         }
         if let Some((t, l)) = d.ml_table() {
-            st.ml_table = crate::seq_table::SeqTable::promote_ml(t);
-            st.ml_accuracy = l;
-            st.ml_kind = crate::sequences::SequenceTableKind::Other;
-            st.ml_set = true;
+            tables.ml_table = crate::seq_table::SeqTable::promote_ml(t);
+            tables.ml_accuracy = l;
+            tables.ml_kind = crate::sequences::SequenceTableKind::Other;
+            tables.ml_set = true;
         }
         if let Some((t, l)) = d.ll_table() {
-            st.ll_table = crate::seq_table::SeqTable::promote_ll(t);
-            st.ll_accuracy = l;
-            st.ll_kind = crate::sequences::SequenceTableKind::Other;
-            st.ll_set = true;
+            tables.ll_table = crate::seq_table::SeqTable::promote_ll(t);
+            tables.ll_accuracy = l;
+            tables.ll_kind = crate::sequences::SequenceTableKind::Other;
+            tables.ll_set = true;
         }
-        (st, *d.rep_offsets())
+        *d.rep_offsets()
     } else {
-        (SequenceDecodeTables::new_default(), [1u32, 4, 8])
+        tables.reset_default();
+        [1u32, 4, 8]
     }
 }
 
@@ -482,6 +495,27 @@ pub(crate) fn decode_sequences_dispatch(
     output: &mut Vec<u8>,
     history: &[u8],
 ) -> Result<(), DecompressError> {
+    if num_sequences == 1 {
+        if history.is_empty() {
+            return decode_execute_single_sequence::<false>(
+                seq_data,
+                seq_tables,
+                rep_offsets,
+                literals,
+                output,
+                history,
+            );
+        }
+        return decode_execute_single_sequence::<true>(
+            seq_data,
+            seq_tables,
+            rep_offsets,
+            literals,
+            output,
+            history,
+        );
+    }
+
     #[cfg(all(feature = "std", feature = "simd"))]
     {
         use std::sync::OnceLock;

--- a/crates/decode/src/lib.rs
+++ b/crates/decode/src/lib.rs
@@ -28,7 +28,7 @@ use crate::sequences::{SequenceDecodeTables, parse_sequence_count, parse_sequenc
 use zrip_core::block::{BlockType, parse_block_header};
 use zrip_core::error::DecompressError;
 use zrip_core::frame::MAX_WINDOW_SIZE;
-use zrip_core::frame::header::parse_frame_header;
+use zrip_core::frame::header::{FrameHeader, parse_frame_header, parse_frame_header_after_magic};
 use zrip_core::huffman::HuffmanDecodeEntry;
 use zrip_core::xxhash::Xxh64State;
 
@@ -195,7 +195,28 @@ pub(crate) fn decompress_frame(
     ws: &mut BlockDecodeWorkspace,
 ) -> Result<usize, DecompressError> {
     let header = parse_frame_header(input)?;
+    decompress_frame_with_header(input, output, max_output, dict, ws, header)
+}
 
+pub(crate) fn decompress_frame_after_magic(
+    input: &[u8],
+    output: &mut Vec<u8>,
+    max_output: usize,
+    dict: Option<&zrip_core::dict::Dictionary>,
+    ws: &mut BlockDecodeWorkspace,
+) -> Result<usize, DecompressError> {
+    let header = parse_frame_header_after_magic(input, 0)?;
+    decompress_frame_with_header(input, output, max_output, dict, ws, header)
+}
+
+fn decompress_frame_with_header(
+    input: &[u8],
+    output: &mut Vec<u8>,
+    max_output: usize,
+    dict: Option<&zrip_core::dict::Dictionary>,
+    ws: &mut BlockDecodeWorkspace,
+    header: FrameHeader,
+) -> Result<usize, DecompressError> {
     if header.window_size > MAX_WINDOW_SIZE && !header.single_segment {
         return Err(DecompressError::WindowTooLarge {
             requested: header.window_size,
@@ -229,29 +250,8 @@ pub(crate) fn decompress_frame(
 
     let dict_history: &[u8] = if let Some(d) = dict { d.content() } else { &[] };
 
-    let (mut seq_tables, mut rep_offsets) = if let Some(ref cached) = ws.cached_dict_tables {
-        (cached.clone(), ws.cached_dict_rep)
-    } else if let Some(d) = dict {
-        let mut st = SequenceDecodeTables::new_default();
-        if let Some((t, l)) = d.of_table() {
-            st.of_table = crate::seq_table::SeqTable::promote_of(t);
-            st.of_accuracy = l;
-            st.of_set = true;
-        }
-        if let Some((t, l)) = d.ml_table() {
-            st.ml_table = crate::seq_table::SeqTable::promote_ml(t);
-            st.ml_accuracy = l;
-            st.ml_set = true;
-        }
-        if let Some((t, l)) = d.ll_table() {
-            st.ll_table = crate::seq_table::SeqTable::promote_ll(t);
-            st.ll_accuracy = l;
-            st.ll_set = true;
-        }
-        (st, *d.rep_offsets())
-    } else {
-        (SequenceDecodeTables::new_default(), [1u32, 4, 8])
-    };
+    let mut seq_tables = None;
+    let mut rep_offsets = [1u32, 4, 8];
     ws.reset_huffman_state();
     if let Some((ref t, l)) = ws.cached_dict_huf {
         ws.huf_table.clear();
@@ -318,13 +318,20 @@ pub(crate) fn decompress_frame(
                 if offset + block_size > input.len() {
                     return Err(DecompressError::InputExhausted);
                 }
+                if seq_tables.is_none() {
+                    let (initial_tables, initial_rep_offsets) = initial_sequence_state(ws, dict);
+                    seq_tables = Some(initial_tables);
+                    rep_offsets = initial_rep_offsets;
+                }
                 let block_data = &input[offset..offset + block_size];
                 decode_compressed_block(
                     block_data,
                     output,
                     output_start,
                     max_output,
-                    &mut seq_tables,
+                    seq_tables
+                        .as_mut()
+                        .expect("sequence tables are initialized before compressed blocks"),
                     &mut rep_offsets,
                     ws,
                     dict_history,
@@ -371,6 +378,35 @@ pub(crate) fn decompress_frame(
     }
 
     Ok(offset)
+}
+
+fn initial_sequence_state(
+    ws: &BlockDecodeWorkspace,
+    dict: Option<&zrip_core::dict::Dictionary>,
+) -> (SequenceDecodeTables, [u32; 3]) {
+    if let Some(ref cached) = ws.cached_dict_tables {
+        (cached.clone(), ws.cached_dict_rep)
+    } else if let Some(d) = dict {
+        let mut st = SequenceDecodeTables::new_default();
+        if let Some((t, l)) = d.of_table() {
+            st.of_table = crate::seq_table::SeqTable::promote_of(t);
+            st.of_accuracy = l;
+            st.of_set = true;
+        }
+        if let Some((t, l)) = d.ml_table() {
+            st.ml_table = crate::seq_table::SeqTable::promote_ml(t);
+            st.ml_accuracy = l;
+            st.ml_set = true;
+        }
+        if let Some((t, l)) = d.ll_table() {
+            st.ll_table = crate::seq_table::SeqTable::promote_ll(t);
+            st.ll_accuracy = l;
+            st.ll_set = true;
+        }
+        (st, *d.rep_offsets())
+    } else {
+        (SequenceDecodeTables::new_default(), [1u32, 4, 8])
+    }
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -491,6 +527,35 @@ pub(crate) fn decode_sequences_dispatch(
             output,
             history,
         )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloc::vec::Vec;
+
+    fn push_block_header(out: &mut Vec<u8>, last: bool, block_type: u32, block_size: usize) {
+        let raw = ((block_size as u32) << 3) | (block_type << 1) | u32::from(last);
+        out.push(raw as u8);
+        out.push((raw >> 8) as u8);
+        out.push((raw >> 16) as u8);
+    }
+
+    #[test]
+    fn decompresses_frame_after_magic() {
+        let mut frame = Vec::new();
+        frame.push(0x20);
+        frame.push(5);
+        push_block_header(&mut frame, true, 0, 5);
+        frame.extend_from_slice(b"hello");
+
+        let mut output = Vec::new();
+        let mut ws = BlockDecodeWorkspace::new();
+        let consumed =
+            decompress_frame_after_magic(&frame, &mut output, usize::MAX, None, &mut ws).unwrap();
+        assert_eq!(consumed, frame.len());
+        assert_eq!(output, b"hello");
     }
 }
 

--- a/crates/decode/src/literals.rs
+++ b/crates/decode/src/literals.rs
@@ -156,9 +156,7 @@ pub(crate) fn decode_literals_ws(
                     &mut ws.fse_symbol_next,
                     &mut ws.fse_dist,
                 )?;
-                let can_reuse = ws.huf_valid
-                    && ws.huf_last_weights_valid
-                    && ws.huf_weights == ws.huf_last_weights;
+                let can_reuse = ws.huf_last_weights_valid && ws.huf_weights == ws.huf_last_weights;
                 if !can_reuse {
                     ws.huf_table_log = build_huffman_decode_table_into(
                         &ws.huf_weights,

--- a/crates/decode/src/sequences.rs
+++ b/crates/decode/src/sequences.rs
@@ -81,6 +81,59 @@ impl SequenceDecodeTables {
             }
         }
     }
+
+    pub(crate) fn reset_default(&mut self) {
+        if self.ll_kind != SequenceTableKind::Predefined {
+            #[cfg(feature = "std")]
+            {
+                self.ll_table = LL_PREDEFINED.clone();
+            }
+            #[cfg(not(feature = "std"))]
+            {
+                self.ll_table = SeqTable::promote_ll(&build_decode_table_from_default(
+                    &LL_DEFAULT_DIST,
+                    LL_DEFAULT_ACCURACY,
+                ));
+            }
+            self.ll_kind = SequenceTableKind::Predefined;
+        }
+        self.ll_accuracy = LL_DEFAULT_ACCURACY;
+        self.ll_set = false;
+
+        if self.of_kind != SequenceTableKind::Predefined {
+            #[cfg(feature = "std")]
+            {
+                self.of_table = OF_PREDEFINED.clone();
+            }
+            #[cfg(not(feature = "std"))]
+            {
+                self.of_table = SeqTable::promote_of(&build_decode_table_from_default(
+                    &OF_DEFAULT_DIST,
+                    OF_DEFAULT_ACCURACY,
+                ));
+            }
+            self.of_kind = SequenceTableKind::Predefined;
+        }
+        self.of_accuracy = OF_DEFAULT_ACCURACY;
+        self.of_set = false;
+
+        if self.ml_kind != SequenceTableKind::Predefined {
+            #[cfg(feature = "std")]
+            {
+                self.ml_table = ML_PREDEFINED.clone();
+            }
+            #[cfg(not(feature = "std"))]
+            {
+                self.ml_table = SeqTable::promote_ml(&build_decode_table_from_default(
+                    &ML_DEFAULT_DIST,
+                    ML_DEFAULT_ACCURACY,
+                ));
+            }
+            self.ml_kind = SequenceTableKind::Predefined;
+        }
+        self.ml_accuracy = ML_DEFAULT_ACCURACY;
+        self.ml_set = false;
+    }
 }
 
 pub(crate) fn parse_sequence_count(data: &[u8]) -> Result<(u32, usize), DecompressError> {

--- a/crates/decode/src/sequences.rs
+++ b/crates/decode/src/sequences.rs
@@ -17,13 +17,22 @@ use zrip_core::fse::{
 pub(crate) struct SequenceDecodeTables {
     pub(crate) ll_table: SeqTable,
     pub(crate) ll_accuracy: u8,
+    pub(crate) ll_kind: SequenceTableKind,
     pub(crate) of_table: SeqTable,
     pub(crate) of_accuracy: u8,
+    pub(crate) of_kind: SequenceTableKind,
     pub(crate) ml_table: SeqTable,
     pub(crate) ml_accuracy: u8,
+    pub(crate) ml_kind: SequenceTableKind,
     pub(crate) ll_set: bool,
     pub(crate) of_set: bool,
     pub(crate) ml_set: bool,
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub(crate) enum SequenceTableKind {
+    Predefined,
+    Other,
 }
 
 impl SequenceDecodeTables {
@@ -33,10 +42,13 @@ impl SequenceDecodeTables {
             Self {
                 ll_table: LL_PREDEFINED.clone(),
                 ll_accuracy: LL_DEFAULT_ACCURACY,
+                ll_kind: SequenceTableKind::Predefined,
                 of_table: OF_PREDEFINED.clone(),
                 of_accuracy: OF_DEFAULT_ACCURACY,
+                of_kind: SequenceTableKind::Predefined,
                 ml_table: ML_PREDEFINED.clone(),
                 ml_accuracy: ML_DEFAULT_ACCURACY,
+                ml_kind: SequenceTableKind::Predefined,
                 ll_set: false,
                 of_set: false,
                 ml_set: false,
@@ -50,16 +62,19 @@ impl SequenceDecodeTables {
                     LL_DEFAULT_ACCURACY,
                 )),
                 ll_accuracy: LL_DEFAULT_ACCURACY,
+                ll_kind: SequenceTableKind::Predefined,
                 of_table: SeqTable::promote_of(&build_decode_table_from_default(
                     &OF_DEFAULT_DIST,
                     OF_DEFAULT_ACCURACY,
                 )),
                 of_accuracy: OF_DEFAULT_ACCURACY,
+                of_kind: SequenceTableKind::Predefined,
                 ml_table: SeqTable::promote_ml(&build_decode_table_from_default(
                     &ML_DEFAULT_DIST,
                     ML_DEFAULT_ACCURACY,
                 )),
                 ml_accuracy: ML_DEFAULT_ACCURACY,
+                ml_kind: SequenceTableKind::Predefined,
                 ll_set: false,
                 of_set: false,
                 ml_set: false,
@@ -166,16 +181,19 @@ pub(crate) fn parse_sequence_tables_ws(
 
     match ll_mode {
         0 => {
-            #[cfg(feature = "std")]
-            {
-                prev.ll_table = LL_PREDEFINED.clone();
-            }
-            #[cfg(not(feature = "std"))]
-            {
-                prev.ll_table = SeqTable::promote_ll(&build_decode_table_from_default(
-                    &LL_DEFAULT_DIST,
-                    LL_DEFAULT_ACCURACY,
-                ));
+            if prev.ll_kind != SequenceTableKind::Predefined {
+                #[cfg(feature = "std")]
+                {
+                    prev.ll_table = LL_PREDEFINED.clone();
+                }
+                #[cfg(not(feature = "std"))]
+                {
+                    prev.ll_table = SeqTable::promote_ll(&build_decode_table_from_default(
+                        &LL_DEFAULT_DIST,
+                        LL_DEFAULT_ACCURACY,
+                    ));
+                }
+                prev.ll_kind = SequenceTableKind::Predefined;
             }
             prev.ll_accuracy = LL_DEFAULT_ACCURACY;
             prev.ll_set = true;
@@ -195,6 +213,7 @@ pub(crate) fn parse_sequence_tables_ws(
                 },
             );
             prev.ll_accuracy = 0;
+            prev.ll_kind = SequenceTableKind::Other;
             prev.ll_set = true;
         }
         2 => {
@@ -210,6 +229,7 @@ pub(crate) fn parse_sequence_tables_ws(
             )?;
             prev.ll_table = SeqTable::promote_ll(&ws.fse_build_buf);
             prev.ll_accuracy = acc;
+            prev.ll_kind = SequenceTableKind::Other;
             prev.ll_set = true;
         }
         _ => {
@@ -221,16 +241,19 @@ pub(crate) fn parse_sequence_tables_ws(
 
     match of_mode {
         0 => {
-            #[cfg(feature = "std")]
-            {
-                prev.of_table = OF_PREDEFINED.clone();
-            }
-            #[cfg(not(feature = "std"))]
-            {
-                prev.of_table = SeqTable::promote_of(&build_decode_table_from_default(
-                    &OF_DEFAULT_DIST,
-                    OF_DEFAULT_ACCURACY,
-                ));
+            if prev.of_kind != SequenceTableKind::Predefined {
+                #[cfg(feature = "std")]
+                {
+                    prev.of_table = OF_PREDEFINED.clone();
+                }
+                #[cfg(not(feature = "std"))]
+                {
+                    prev.of_table = SeqTable::promote_of(&build_decode_table_from_default(
+                        &OF_DEFAULT_DIST,
+                        OF_DEFAULT_ACCURACY,
+                    ));
+                }
+                prev.of_kind = SequenceTableKind::Predefined;
             }
             prev.of_accuracy = OF_DEFAULT_ACCURACY;
             prev.of_set = true;
@@ -250,6 +273,7 @@ pub(crate) fn parse_sequence_tables_ws(
                 },
             );
             prev.of_accuracy = 0;
+            prev.of_kind = SequenceTableKind::Other;
             prev.of_set = true;
         }
         2 => {
@@ -265,6 +289,7 @@ pub(crate) fn parse_sequence_tables_ws(
             )?;
             prev.of_table = SeqTable::promote_of(&ws.fse_build_buf);
             prev.of_accuracy = acc;
+            prev.of_kind = SequenceTableKind::Other;
             prev.of_set = true;
         }
         _ => {
@@ -276,16 +301,19 @@ pub(crate) fn parse_sequence_tables_ws(
 
     match ml_mode {
         0 => {
-            #[cfg(feature = "std")]
-            {
-                prev.ml_table = ML_PREDEFINED.clone();
-            }
-            #[cfg(not(feature = "std"))]
-            {
-                prev.ml_table = SeqTable::promote_ml(&build_decode_table_from_default(
-                    &ML_DEFAULT_DIST,
-                    ML_DEFAULT_ACCURACY,
-                ));
+            if prev.ml_kind != SequenceTableKind::Predefined {
+                #[cfg(feature = "std")]
+                {
+                    prev.ml_table = ML_PREDEFINED.clone();
+                }
+                #[cfg(not(feature = "std"))]
+                {
+                    prev.ml_table = SeqTable::promote_ml(&build_decode_table_from_default(
+                        &ML_DEFAULT_DIST,
+                        ML_DEFAULT_ACCURACY,
+                    ));
+                }
+                prev.ml_kind = SequenceTableKind::Predefined;
             }
             prev.ml_accuracy = ML_DEFAULT_ACCURACY;
             prev.ml_set = true;
@@ -305,6 +333,7 @@ pub(crate) fn parse_sequence_tables_ws(
                 },
             );
             prev.ml_accuracy = 0;
+            prev.ml_kind = SequenceTableKind::Other;
             prev.ml_set = true;
         }
         2 => {
@@ -320,6 +349,7 @@ pub(crate) fn parse_sequence_tables_ws(
             )?;
             prev.ml_table = SeqTable::promote_ml(&ws.fse_build_buf);
             prev.ml_accuracy = acc;
+            prev.ml_kind = SequenceTableKind::Other;
             prev.ml_set = true;
         }
         _ => {

--- a/doc/charts/x86_64/small_decode.svg
+++ b/doc/charts/x86_64/small_decode.svg
@@ -22,63 +22,63 @@
   <text x="664.3" y="289" text-anchor="middle" fill="#7d8590" font-size="9">64K</text>
   <line x1="742.4" y1="55" x2="742.4" y2="275" stroke="#21262d" stroke-width="1"/>
   <text x="742.4" y="289" text-anchor="middle" fill="#7d8590" font-size="9">128K</text>
-  <line x1="90" y1="226.4" x2="790" y2="226.4" stroke="#21262d" stroke-width="1"/>
-  <text x="82" y="226.4" text-anchor="end" dominant-baseline="middle" fill="#7d8590" font-size="9">200</text>
-  <line x1="90" y1="177.7" x2="790" y2="177.7" stroke="#21262d" stroke-width="1"/>
-  <text x="82" y="177.7" text-anchor="end" dominant-baseline="middle" fill="#7d8590" font-size="9">400</text>
-  <line x1="90" y1="129.1" x2="790" y2="129.1" stroke="#21262d" stroke-width="1"/>
-  <text x="82" y="129.1" text-anchor="end" dominant-baseline="middle" fill="#7d8590" font-size="9">600</text>
-  <line x1="90" y1="80.4" x2="790" y2="80.4" stroke="#21262d" stroke-width="1"/>
-  <text x="82" y="80.4" text-anchor="end" dominant-baseline="middle" fill="#7d8590" font-size="9">800</text>
-  <path d="M117.8,228.1L195.9,200.9L274.0,187.8L352.0,159.3L430.1,139.4L508.2,132.9L586.3,103.7L664.3,89.8L742.4,83.7" fill="none" stroke="#60a5fa" stroke-width="1.8"/>
-  <circle cx="117.8" cy="228.1" r="2.5" fill="#60a5fa" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="195.9" cy="200.9" r="2.5" fill="#60a5fa" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="274.0" cy="187.8" r="2.5" fill="#60a5fa" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="352.0" cy="159.3" r="2.5" fill="#60a5fa" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="430.1" cy="139.4" r="2.5" fill="#60a5fa" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="508.2" cy="132.9" r="2.5" fill="#60a5fa" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="586.3" cy="103.7" r="2.5" fill="#60a5fa" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="664.3" cy="89.8" r="2.5" fill="#60a5fa" stroke="#0d1117" stroke-width="0.8"/>
+  <line x1="90" y1="226.3" x2="790" y2="226.3" stroke="#21262d" stroke-width="1"/>
+  <text x="82" y="226.3" text-anchor="end" dominant-baseline="middle" fill="#7d8590" font-size="9">200</text>
+  <line x1="90" y1="177.5" x2="790" y2="177.5" stroke="#21262d" stroke-width="1"/>
+  <text x="82" y="177.5" text-anchor="end" dominant-baseline="middle" fill="#7d8590" font-size="9">400</text>
+  <line x1="90" y1="128.8" x2="790" y2="128.8" stroke="#21262d" stroke-width="1"/>
+  <text x="82" y="128.8" text-anchor="end" dominant-baseline="middle" fill="#7d8590" font-size="9">600</text>
+  <line x1="90" y1="80.0" x2="790" y2="80.0" stroke="#21262d" stroke-width="1"/>
+  <text x="82" y="80.0" text-anchor="end" dominant-baseline="middle" fill="#7d8590" font-size="9">800</text>
+  <path d="M117.8,227.3L195.9,200.1L274.0,186.4L352.0,158.7L430.1,139.0L508.2,131.8L586.3,103.5L664.3,90.6L742.4,83.7" fill="none" stroke="#60a5fa" stroke-width="1.8"/>
+  <circle cx="117.8" cy="227.3" r="2.5" fill="#60a5fa" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="195.9" cy="200.1" r="2.5" fill="#60a5fa" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="274.0" cy="186.4" r="2.5" fill="#60a5fa" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="352.0" cy="158.7" r="2.5" fill="#60a5fa" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="430.1" cy="139.0" r="2.5" fill="#60a5fa" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="508.2" cy="131.8" r="2.5" fill="#60a5fa" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="586.3" cy="103.5" r="2.5" fill="#60a5fa" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="664.3" cy="90.6" r="2.5" fill="#60a5fa" stroke="#0d1117" stroke-width="0.8"/>
   <circle cx="742.4" cy="83.7" r="2.5" fill="#60a5fa" stroke="#0d1117" stroke-width="0.8"/>
-  <path d="M117.8,251.3L195.9,237.3L274.0,227.0L352.0,209.4L430.1,192.6L508.2,191.9L586.3,187.2L664.3,183.0L742.4,175.0" fill="none" stroke="#f87171" stroke-width="1.8"/>
-  <circle cx="117.8" cy="251.3" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="195.9" cy="237.3" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="274.0" cy="227.0" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="352.0" cy="209.4" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="430.1" cy="192.6" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="508.2" cy="191.9" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="586.3" cy="187.2" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="664.3" cy="183.0" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="742.4" cy="175.0" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
-  <path d="M117.8,251.5L195.9,238.6L274.0,230.1L352.0,215.5L430.1,205.0L508.2,209.8L586.3,205.6L664.3,204.0L742.4,200.8" fill="none" stroke="#f472b6" stroke-width="1.8"/>
-  <circle cx="117.8" cy="251.5" r="2.5" fill="#f472b6" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="195.9" cy="238.6" r="2.5" fill="#f472b6" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="274.0" cy="230.1" r="2.5" fill="#f472b6" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="352.0" cy="215.5" r="2.5" fill="#f472b6" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="430.1" cy="205.0" r="2.5" fill="#f472b6" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="508.2" cy="209.8" r="2.5" fill="#f472b6" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="586.3" cy="205.6" r="2.5" fill="#f472b6" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="664.3" cy="204.0" r="2.5" fill="#f472b6" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="742.4" cy="200.8" r="2.5" fill="#f472b6" stroke="#0d1117" stroke-width="0.8"/>
-  <path d="M117.8,250.6L195.9,233.7L274.0,226.0L352.0,207.5L430.1,195.4L508.2,192.4L586.3,174.1L664.3,168.9L742.4,165.6" fill="none" stroke="#f59e0b" stroke-width="1.8"/>
-  <circle cx="117.8" cy="250.6" r="2.5" fill="#f59e0b" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="195.9" cy="233.7" r="2.5" fill="#f59e0b" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="274.0" cy="226.0" r="2.5" fill="#f59e0b" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="352.0" cy="207.5" r="2.5" fill="#f59e0b" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="430.1" cy="195.4" r="2.5" fill="#f59e0b" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="508.2" cy="192.4" r="2.5" fill="#f59e0b" stroke="#0d1117" stroke-width="0.8"/>
+  <path d="M117.8,250.5L195.9,236.6L274.0,228.8L352.0,210.5L430.1,193.7L508.2,192.3L586.3,187.8L664.3,183.9L742.4,176.3" fill="none" stroke="#f87171" stroke-width="1.8"/>
+  <circle cx="117.8" cy="250.5" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="195.9" cy="236.6" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="274.0" cy="228.8" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="352.0" cy="210.5" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="430.1" cy="193.7" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="508.2" cy="192.3" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="586.3" cy="187.8" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="664.3" cy="183.9" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="742.4" cy="176.3" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
+  <path d="M117.8,250.4L195.9,238.2L274.0,231.3L352.0,217.5L430.1,210.6L508.2,212.2L586.3,206.0L664.3,204.7L742.4,201.2" fill="none" stroke="#f472b6" stroke-width="1.8"/>
+  <circle cx="117.8" cy="250.4" r="2.5" fill="#f472b6" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="195.9" cy="238.2" r="2.5" fill="#f472b6" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="274.0" cy="231.3" r="2.5" fill="#f472b6" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="352.0" cy="217.5" r="2.5" fill="#f472b6" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="430.1" cy="210.6" r="2.5" fill="#f472b6" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="508.2" cy="212.2" r="2.5" fill="#f472b6" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="586.3" cy="206.0" r="2.5" fill="#f472b6" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="664.3" cy="204.7" r="2.5" fill="#f472b6" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="742.4" cy="201.2" r="2.5" fill="#f472b6" stroke="#0d1117" stroke-width="0.8"/>
+  <path d="M117.8,251.5L195.9,235.3L274.0,226.6L352.0,208.5L430.1,196.0L508.2,192.7L586.3,174.1L664.3,168.5L742.4,165.3" fill="none" stroke="#f59e0b" stroke-width="1.8"/>
+  <circle cx="117.8" cy="251.5" r="2.5" fill="#f59e0b" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="195.9" cy="235.3" r="2.5" fill="#f59e0b" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="274.0" cy="226.6" r="2.5" fill="#f59e0b" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="352.0" cy="208.5" r="2.5" fill="#f59e0b" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="430.1" cy="196.0" r="2.5" fill="#f59e0b" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="508.2" cy="192.7" r="2.5" fill="#f59e0b" stroke="#0d1117" stroke-width="0.8"/>
   <circle cx="586.3" cy="174.1" r="2.5" fill="#f59e0b" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="664.3" cy="168.9" r="2.5" fill="#f59e0b" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="742.4" cy="165.6" r="2.5" fill="#f59e0b" stroke="#0d1117" stroke-width="0.8"/>
-  <path d="M117.8,259.4L195.9,252.3L274.0,249.5L352.0,246.5L430.1,245.2L508.2,245.8L586.3,241.4L664.3,240.4L742.4,239.3" fill="none" stroke="#4ade80" stroke-width="1.8"/>
+  <circle cx="664.3" cy="168.5" r="2.5" fill="#f59e0b" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="742.4" cy="165.3" r="2.5" fill="#f59e0b" stroke="#0d1117" stroke-width="0.8"/>
+  <path d="M117.8,259.4L195.9,252.2L274.0,249.5L352.0,246.5L430.1,245.2L508.2,245.8L586.3,241.4L664.3,240.3L742.4,239.3" fill="none" stroke="#4ade80" stroke-width="1.8"/>
   <circle cx="117.8" cy="259.4" r="2.5" fill="#4ade80" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="195.9" cy="252.3" r="2.5" fill="#4ade80" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="195.9" cy="252.2" r="2.5" fill="#4ade80" stroke="#0d1117" stroke-width="0.8"/>
   <circle cx="274.0" cy="249.5" r="2.5" fill="#4ade80" stroke="#0d1117" stroke-width="0.8"/>
   <circle cx="352.0" cy="246.5" r="2.5" fill="#4ade80" stroke="#0d1117" stroke-width="0.8"/>
   <circle cx="430.1" cy="245.2" r="2.5" fill="#4ade80" stroke="#0d1117" stroke-width="0.8"/>
   <circle cx="508.2" cy="245.8" r="2.5" fill="#4ade80" stroke="#0d1117" stroke-width="0.8"/>
   <circle cx="586.3" cy="241.4" r="2.5" fill="#4ade80" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="664.3" cy="240.4" r="2.5" fill="#4ade80" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="664.3" cy="240.3" r="2.5" fill="#4ade80" stroke="#0d1117" stroke-width="0.8"/>
   <circle cx="742.4" cy="239.3" r="2.5" fill="#4ade80" stroke="#0d1117" stroke-width="0.8"/>
   <rect x="90" y="325" width="700" height="220" fill="#161b22" rx="4"/>
   <text x="440.0" y="317" text-anchor="middle" fill="#e6edf3" font-size="12" font-weight="600">hdfs</text>
@@ -100,68 +100,68 @@
   <text x="664.3" y="559" text-anchor="middle" fill="#7d8590" font-size="9">64K</text>
   <line x1="742.4" y1="325" x2="742.4" y2="545" stroke="#21262d" stroke-width="1"/>
   <text x="742.4" y="559" text-anchor="middle" fill="#7d8590" font-size="9">128K</text>
-  <line x1="90" y1="512.4" x2="790" y2="512.4" stroke="#21262d" stroke-width="1"/>
-  <text x="82" y="512.4" text-anchor="end" dominant-baseline="middle" fill="#7d8590" font-size="9">500</text>
-  <line x1="90" y1="479.8" x2="790" y2="479.8" stroke="#21262d" stroke-width="1"/>
-  <text x="82" y="479.8" text-anchor="end" dominant-baseline="middle" fill="#7d8590" font-size="9">1000</text>
-  <line x1="90" y1="447.2" x2="790" y2="447.2" stroke="#21262d" stroke-width="1"/>
-  <text x="82" y="447.2" text-anchor="end" dominant-baseline="middle" fill="#7d8590" font-size="9">1500</text>
-  <line x1="90" y1="414.6" x2="790" y2="414.6" stroke="#21262d" stroke-width="1"/>
-  <text x="82" y="414.6" text-anchor="end" dominant-baseline="middle" fill="#7d8590" font-size="9">2000</text>
-  <line x1="90" y1="382.0" x2="790" y2="382.0" stroke="#21262d" stroke-width="1"/>
-  <text x="82" y="382.0" text-anchor="end" dominant-baseline="middle" fill="#7d8590" font-size="9">2500</text>
-  <line x1="90" y1="349.4" x2="790" y2="349.4" stroke="#21262d" stroke-width="1"/>
-  <text x="82" y="349.4" text-anchor="end" dominant-baseline="middle" fill="#7d8590" font-size="9">3000</text>
-  <path d="M117.8,532.0L195.9,520.1L274.0,502.0L352.0,487.5L430.1,451.2L508.2,406.1L586.3,364.6L664.3,353.7L742.4,372.9" fill="none" stroke="#60a5fa" stroke-width="1.8"/>
-  <circle cx="117.8" cy="532.0" r="2.5" fill="#60a5fa" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="195.9" cy="520.1" r="2.5" fill="#60a5fa" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="274.0" cy="502.0" r="2.5" fill="#60a5fa" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="352.0" cy="487.5" r="2.5" fill="#60a5fa" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="430.1" cy="451.2" r="2.5" fill="#60a5fa" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="508.2" cy="406.1" r="2.5" fill="#60a5fa" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="586.3" cy="364.6" r="2.5" fill="#60a5fa" stroke="#0d1117" stroke-width="0.8"/>
+  <line x1="90" y1="511.9" x2="790" y2="511.9" stroke="#21262d" stroke-width="1"/>
+  <text x="82" y="511.9" text-anchor="end" dominant-baseline="middle" fill="#7d8590" font-size="9">500</text>
+  <line x1="90" y1="478.7" x2="790" y2="478.7" stroke="#21262d" stroke-width="1"/>
+  <text x="82" y="478.7" text-anchor="end" dominant-baseline="middle" fill="#7d8590" font-size="9">1000</text>
+  <line x1="90" y1="445.6" x2="790" y2="445.6" stroke="#21262d" stroke-width="1"/>
+  <text x="82" y="445.6" text-anchor="end" dominant-baseline="middle" fill="#7d8590" font-size="9">1500</text>
+  <line x1="90" y1="412.4" x2="790" y2="412.4" stroke="#21262d" stroke-width="1"/>
+  <text x="82" y="412.4" text-anchor="end" dominant-baseline="middle" fill="#7d8590" font-size="9">2000</text>
+  <line x1="90" y1="379.3" x2="790" y2="379.3" stroke="#21262d" stroke-width="1"/>
+  <text x="82" y="379.3" text-anchor="end" dominant-baseline="middle" fill="#7d8590" font-size="9">2500</text>
+  <line x1="90" y1="346.2" x2="790" y2="346.2" stroke="#21262d" stroke-width="1"/>
+  <text x="82" y="346.2" text-anchor="end" dominant-baseline="middle" fill="#7d8590" font-size="9">3000</text>
+  <path d="M117.8,531.6L195.9,519.3L274.0,500.4L352.0,486.2L430.1,448.8L508.2,403.0L586.3,362.3L664.3,353.7L742.4,370.7" fill="none" stroke="#60a5fa" stroke-width="1.8"/>
+  <circle cx="117.8" cy="531.6" r="2.5" fill="#60a5fa" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="195.9" cy="519.3" r="2.5" fill="#60a5fa" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="274.0" cy="500.4" r="2.5" fill="#60a5fa" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="352.0" cy="486.2" r="2.5" fill="#60a5fa" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="430.1" cy="448.8" r="2.5" fill="#60a5fa" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="508.2" cy="403.0" r="2.5" fill="#60a5fa" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="586.3" cy="362.3" r="2.5" fill="#60a5fa" stroke="#0d1117" stroke-width="0.8"/>
   <circle cx="664.3" cy="353.7" r="2.5" fill="#60a5fa" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="742.4" cy="372.9" r="2.5" fill="#60a5fa" stroke="#0d1117" stroke-width="0.8"/>
-  <path d="M117.8,538.4L195.9,532.8L274.0,523.6L352.0,513.8L430.1,492.4L508.2,464.0L586.3,435.1L664.3,430.0L742.4,435.2" fill="none" stroke="#f87171" stroke-width="1.8"/>
-  <circle cx="117.8" cy="538.4" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="195.9" cy="532.8" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="274.0" cy="523.6" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="352.0" cy="513.8" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="430.1" cy="492.4" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="508.2" cy="464.0" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="586.3" cy="435.1" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="664.3" cy="430.0" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="742.4" cy="435.2" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
-  <path d="M117.8,538.5L195.9,533.0L274.0,524.2L352.0,515.5L430.1,495.8L508.2,470.2L586.3,446.2L664.3,436.3L742.4,446.4" fill="none" stroke="#f472b6" stroke-width="1.8"/>
-  <circle cx="117.8" cy="538.5" r="2.5" fill="#f472b6" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="195.9" cy="533.0" r="2.5" fill="#f472b6" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="274.0" cy="524.2" r="2.5" fill="#f472b6" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="352.0" cy="515.5" r="2.5" fill="#f472b6" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="430.1" cy="495.8" r="2.5" fill="#f472b6" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="508.2" cy="470.2" r="2.5" fill="#f472b6" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="586.3" cy="446.2" r="2.5" fill="#f472b6" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="664.3" cy="436.3" r="2.5" fill="#f472b6" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="742.4" cy="446.4" r="2.5" fill="#f472b6" stroke="#0d1117" stroke-width="0.8"/>
-  <path d="M117.8,538.1L195.9,531.9L274.0,522.2L352.0,514.0L430.1,491.6L508.2,465.6L586.3,440.7L664.3,433.7L742.4,437.6" fill="none" stroke="#f59e0b" stroke-width="1.8"/>
-  <circle cx="117.8" cy="538.1" r="2.5" fill="#f59e0b" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="195.9" cy="531.9" r="2.5" fill="#f59e0b" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="274.0" cy="522.2" r="2.5" fill="#f59e0b" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="352.0" cy="514.0" r="2.5" fill="#f59e0b" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="430.1" cy="491.6" r="2.5" fill="#f59e0b" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="508.2" cy="465.6" r="2.5" fill="#f59e0b" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="586.3" cy="440.7" r="2.5" fill="#f59e0b" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="664.3" cy="433.7" r="2.5" fill="#f59e0b" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="742.4" cy="437.6" r="2.5" fill="#f59e0b" stroke="#0d1117" stroke-width="0.8"/>
-  <path d="M117.8,540.5L195.9,537.0L274.0,531.3L352.0,525.8L430.1,517.4L508.2,510.1L586.3,506.2L664.3,507.2L742.4,507.3" fill="none" stroke="#4ade80" stroke-width="1.8"/>
-  <circle cx="117.8" cy="540.5" r="2.5" fill="#4ade80" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="195.9" cy="537.0" r="2.5" fill="#4ade80" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="274.0" cy="531.3" r="2.5" fill="#4ade80" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="352.0" cy="525.8" r="2.5" fill="#4ade80" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="430.1" cy="517.4" r="2.5" fill="#4ade80" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="508.2" cy="510.1" r="2.5" fill="#4ade80" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="586.3" cy="506.2" r="2.5" fill="#4ade80" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="664.3" cy="507.2" r="2.5" fill="#4ade80" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="742.4" cy="507.3" r="2.5" fill="#4ade80" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="742.4" cy="370.7" r="2.5" fill="#60a5fa" stroke="#0d1117" stroke-width="0.8"/>
+  <path d="M117.8,538.0L195.9,532.0L274.0,524.0L352.0,514.5L430.1,493.6L508.2,465.1L586.3,436.2L664.3,428.7L742.4,434.7" fill="none" stroke="#f87171" stroke-width="1.8"/>
+  <circle cx="117.8" cy="538.0" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="195.9" cy="532.0" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="274.0" cy="524.0" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="352.0" cy="514.5" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="430.1" cy="493.6" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="508.2" cy="465.1" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="586.3" cy="436.2" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="664.3" cy="428.7" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="742.4" cy="434.7" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
+  <path d="M117.8,538.0L195.9,532.2L274.0,523.8L352.0,516.6L430.1,496.6L508.2,472.2L586.3,448.3L664.3,440.6L742.4,446.5" fill="none" stroke="#f472b6" stroke-width="1.8"/>
+  <circle cx="117.8" cy="538.0" r="2.5" fill="#f472b6" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="195.9" cy="532.2" r="2.5" fill="#f472b6" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="274.0" cy="523.8" r="2.5" fill="#f472b6" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="352.0" cy="516.6" r="2.5" fill="#f472b6" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="430.1" cy="496.6" r="2.5" fill="#f472b6" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="508.2" cy="472.2" r="2.5" fill="#f472b6" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="586.3" cy="448.3" r="2.5" fill="#f472b6" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="664.3" cy="440.6" r="2.5" fill="#f472b6" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="742.4" cy="446.5" r="2.5" fill="#f472b6" stroke="#0d1117" stroke-width="0.8"/>
+  <path d="M117.8,538.2L195.9,532.5L274.0,522.3L352.0,513.6L430.1,491.8L508.2,465.2L586.3,440.3L664.3,434.6L742.4,435.6" fill="none" stroke="#f59e0b" stroke-width="1.8"/>
+  <circle cx="117.8" cy="538.2" r="2.5" fill="#f59e0b" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="195.9" cy="532.5" r="2.5" fill="#f59e0b" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="274.0" cy="522.3" r="2.5" fill="#f59e0b" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="352.0" cy="513.6" r="2.5" fill="#f59e0b" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="430.1" cy="491.8" r="2.5" fill="#f59e0b" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="508.2" cy="465.2" r="2.5" fill="#f59e0b" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="586.3" cy="440.3" r="2.5" fill="#f59e0b" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="664.3" cy="434.6" r="2.5" fill="#f59e0b" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="742.4" cy="435.6" r="2.5" fill="#f59e0b" stroke="#0d1117" stroke-width="0.8"/>
+  <path d="M117.8,540.4L195.9,536.9L274.0,531.1L352.0,525.4L430.1,516.9L508.2,509.5L586.3,505.5L664.3,506.6L742.4,506.7" fill="none" stroke="#4ade80" stroke-width="1.8"/>
+  <circle cx="117.8" cy="540.4" r="2.5" fill="#4ade80" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="195.9" cy="536.9" r="2.5" fill="#4ade80" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="274.0" cy="531.1" r="2.5" fill="#4ade80" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="352.0" cy="525.4" r="2.5" fill="#4ade80" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="430.1" cy="516.9" r="2.5" fill="#4ade80" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="508.2" cy="509.5" r="2.5" fill="#4ade80" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="586.3" cy="505.5" r="2.5" fill="#4ade80" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="664.3" cy="506.6" r="2.5" fill="#4ade80" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="742.4" cy="506.7" r="2.5" fill="#4ade80" stroke="#0d1117" stroke-width="0.8"/>
   <rect x="90" y="595" width="700" height="220" fill="#161b22" rx="4"/>
   <text x="440.0" y="587" text-anchor="middle" fill="#e6edf3" font-size="12" font-weight="600">xml collection</text>
   <line x1="117.8" y1="595" x2="117.8" y2="815" stroke="#21262d" stroke-width="1"/>
@@ -182,53 +182,53 @@
   <text x="664.3" y="829" text-anchor="middle" fill="#7d8590" font-size="9">64K</text>
   <line x1="742.4" y1="595" x2="742.4" y2="815" stroke="#21262d" stroke-width="1"/>
   <text x="742.4" y="829" text-anchor="middle" fill="#7d8590" font-size="9">128K</text>
-  <line x1="90" y1="756.3" x2="790" y2="756.3" stroke="#21262d" stroke-width="1"/>
-  <text x="82" y="756.3" text-anchor="end" dominant-baseline="middle" fill="#7d8590" font-size="9">1000</text>
-  <line x1="90" y1="697.7" x2="790" y2="697.7" stroke="#21262d" stroke-width="1"/>
-  <text x="82" y="697.7" text-anchor="end" dominant-baseline="middle" fill="#7d8590" font-size="9">2000</text>
-  <line x1="90" y1="639.0" x2="790" y2="639.0" stroke="#21262d" stroke-width="1"/>
-  <text x="82" y="639.0" text-anchor="end" dominant-baseline="middle" fill="#7d8590" font-size="9">3000</text>
-  <path d="M117.8,805.8L195.9,800.2L274.0,791.5L352.0,780.6L430.1,770.5L508.2,745.9L586.3,703.4L664.3,654.5L742.4,623.7" fill="none" stroke="#60a5fa" stroke-width="1.8"/>
+  <line x1="90" y1="756.2" x2="790" y2="756.2" stroke="#21262d" stroke-width="1"/>
+  <text x="82" y="756.2" text-anchor="end" dominant-baseline="middle" fill="#7d8590" font-size="9">1000</text>
+  <line x1="90" y1="697.5" x2="790" y2="697.5" stroke="#21262d" stroke-width="1"/>
+  <text x="82" y="697.5" text-anchor="end" dominant-baseline="middle" fill="#7d8590" font-size="9">2000</text>
+  <line x1="90" y1="638.7" x2="790" y2="638.7" stroke="#21262d" stroke-width="1"/>
+  <text x="82" y="638.7" text-anchor="end" dominant-baseline="middle" fill="#7d8590" font-size="9">3000</text>
+  <path d="M117.8,805.8L195.9,800.0L274.0,791.4L352.0,780.3L430.1,770.2L508.2,745.0L586.3,704.2L664.3,654.5L742.4,623.7" fill="none" stroke="#60a5fa" stroke-width="1.8"/>
   <circle cx="117.8" cy="805.8" r="2.5" fill="#60a5fa" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="195.9" cy="800.2" r="2.5" fill="#60a5fa" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="274.0" cy="791.5" r="2.5" fill="#60a5fa" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="352.0" cy="780.6" r="2.5" fill="#60a5fa" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="430.1" cy="770.5" r="2.5" fill="#60a5fa" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="508.2" cy="745.9" r="2.5" fill="#60a5fa" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="586.3" cy="703.4" r="2.5" fill="#60a5fa" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="195.9" cy="800.0" r="2.5" fill="#60a5fa" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="274.0" cy="791.4" r="2.5" fill="#60a5fa" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="352.0" cy="780.3" r="2.5" fill="#60a5fa" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="430.1" cy="770.2" r="2.5" fill="#60a5fa" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="508.2" cy="745.0" r="2.5" fill="#60a5fa" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="586.3" cy="704.2" r="2.5" fill="#60a5fa" stroke="#0d1117" stroke-width="0.8"/>
   <circle cx="664.3" cy="654.5" r="2.5" fill="#60a5fa" stroke="#0d1117" stroke-width="0.8"/>
   <circle cx="742.4" cy="623.7" r="2.5" fill="#60a5fa" stroke="#0d1117" stroke-width="0.8"/>
-  <path d="M117.8,809.7L195.9,806.7L274.0,801.5L352.0,793.9L430.1,786.3L508.2,768.8L586.3,740.2L664.3,713.5L742.4,690.9" fill="none" stroke="#f87171" stroke-width="1.8"/>
-  <circle cx="117.8" cy="809.7" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="195.9" cy="806.7" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="274.0" cy="801.5" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="352.0" cy="793.9" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="430.1" cy="786.3" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="508.2" cy="768.8" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="586.3" cy="740.2" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
+  <path d="M117.8,809.6L195.9,807.1L274.0,801.9L352.0,794.5L430.1,786.8L508.2,769.8L586.3,741.5L664.3,713.5L742.4,692.4" fill="none" stroke="#f87171" stroke-width="1.8"/>
+  <circle cx="117.8" cy="809.6" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="195.9" cy="807.1" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="274.0" cy="801.9" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="352.0" cy="794.5" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="430.1" cy="786.8" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="508.2" cy="769.8" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="586.3" cy="741.5" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
   <circle cx="664.3" cy="713.5" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="742.4" cy="690.9" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
-  <path d="M117.8,809.9L195.9,807.2L274.0,802.5L352.0,795.9L430.1,789.7L508.2,775.3L586.3,751.0L664.3,723.6L742.4,702.9" fill="none" stroke="#f472b6" stroke-width="1.8"/>
+  <circle cx="742.4" cy="692.4" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
+  <path d="M117.8,809.9L195.9,807.6L274.0,803.0L352.0,796.6L430.1,790.5L508.2,777.0L586.3,753.4L664.3,726.8L742.4,705.0" fill="none" stroke="#f472b6" stroke-width="1.8"/>
   <circle cx="117.8" cy="809.9" r="2.5" fill="#f472b6" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="195.9" cy="807.2" r="2.5" fill="#f472b6" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="274.0" cy="802.5" r="2.5" fill="#f472b6" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="352.0" cy="795.9" r="2.5" fill="#f472b6" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="430.1" cy="789.7" r="2.5" fill="#f472b6" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="508.2" cy="775.3" r="2.5" fill="#f472b6" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="586.3" cy="751.0" r="2.5" fill="#f472b6" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="664.3" cy="723.6" r="2.5" fill="#f472b6" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="742.4" cy="702.9" r="2.5" fill="#f472b6" stroke="#0d1117" stroke-width="0.8"/>
-  <path d="M117.8,809.8L195.9,807.1L274.0,802.2L352.0,795.9L430.1,789.4L508.2,774.5L586.3,750.2L664.3,720.6L742.4,693.3" fill="none" stroke="#f59e0b" stroke-width="1.8"/>
-  <circle cx="117.8" cy="809.8" r="2.5" fill="#f59e0b" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="195.9" cy="807.6" r="2.5" fill="#f472b6" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="274.0" cy="803.0" r="2.5" fill="#f472b6" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="352.0" cy="796.6" r="2.5" fill="#f472b6" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="430.1" cy="790.5" r="2.5" fill="#f472b6" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="508.2" cy="777.0" r="2.5" fill="#f472b6" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="586.3" cy="753.4" r="2.5" fill="#f472b6" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="664.3" cy="726.8" r="2.5" fill="#f472b6" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="742.4" cy="705.0" r="2.5" fill="#f472b6" stroke="#0d1117" stroke-width="0.8"/>
+  <path d="M117.8,810.0L195.9,807.1L274.0,802.3L352.0,795.6L430.1,789.6L508.2,774.6L586.3,751.6L664.3,721.1L742.4,694.6" fill="none" stroke="#f59e0b" stroke-width="1.8"/>
+  <circle cx="117.8" cy="810.0" r="2.5" fill="#f59e0b" stroke="#0d1117" stroke-width="0.8"/>
   <circle cx="195.9" cy="807.1" r="2.5" fill="#f59e0b" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="274.0" cy="802.2" r="2.5" fill="#f59e0b" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="352.0" cy="795.9" r="2.5" fill="#f59e0b" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="430.1" cy="789.4" r="2.5" fill="#f59e0b" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="508.2" cy="774.5" r="2.5" fill="#f59e0b" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="586.3" cy="750.2" r="2.5" fill="#f59e0b" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="664.3" cy="720.6" r="2.5" fill="#f59e0b" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="742.4" cy="693.3" r="2.5" fill="#f59e0b" stroke="#0d1117" stroke-width="0.8"/>
-  <path d="M117.8,811.4L195.9,809.6L274.0,807.5L352.0,805.3L430.1,803.8L508.2,799.0L586.3,791.1L664.3,783.3L742.4,774.7" fill="none" stroke="#4ade80" stroke-width="1.8"/>
+  <circle cx="274.0" cy="802.3" r="2.5" fill="#f59e0b" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="352.0" cy="795.6" r="2.5" fill="#f59e0b" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="430.1" cy="789.6" r="2.5" fill="#f59e0b" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="508.2" cy="774.6" r="2.5" fill="#f59e0b" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="586.3" cy="751.6" r="2.5" fill="#f59e0b" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="664.3" cy="721.1" r="2.5" fill="#f59e0b" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="742.4" cy="694.6" r="2.5" fill="#f59e0b" stroke="#0d1117" stroke-width="0.8"/>
+  <path d="M117.8,811.4L195.9,809.6L274.0,807.5L352.0,805.3L430.1,803.8L508.2,799.0L586.3,791.1L664.3,783.2L742.4,774.7" fill="none" stroke="#4ade80" stroke-width="1.8"/>
   <circle cx="117.8" cy="811.4" r="2.5" fill="#4ade80" stroke="#0d1117" stroke-width="0.8"/>
   <circle cx="195.9" cy="809.6" r="2.5" fill="#4ade80" stroke="#0d1117" stroke-width="0.8"/>
   <circle cx="274.0" cy="807.5" r="2.5" fill="#4ade80" stroke="#0d1117" stroke-width="0.8"/>
@@ -236,7 +236,7 @@
   <circle cx="430.1" cy="803.8" r="2.5" fill="#4ade80" stroke="#0d1117" stroke-width="0.8"/>
   <circle cx="508.2" cy="799.0" r="2.5" fill="#4ade80" stroke="#0d1117" stroke-width="0.8"/>
   <circle cx="586.3" cy="791.1" r="2.5" fill="#4ade80" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="664.3" cy="783.3" r="2.5" fill="#4ade80" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="664.3" cy="783.2" r="2.5" fill="#4ade80" stroke="#0d1117" stroke-width="0.8"/>
   <circle cx="742.4" cy="774.7" r="2.5" fill="#4ade80" stroke="#0d1117" stroke-width="0.8"/>
   <rect x="90" y="865" width="700" height="220" fill="#161b22" rx="4"/>
   <text x="440.0" y="857" text-anchor="middle" fill="#e6edf3" font-size="12" font-weight="600">x-ray</text>
@@ -258,66 +258,66 @@
   <text x="664.3" y="1099" text-anchor="middle" fill="#7d8590" font-size="9">64K</text>
   <line x1="742.4" y1="865" x2="742.4" y2="1085" stroke="#21262d" stroke-width="1"/>
   <text x="742.4" y="1099" text-anchor="middle" fill="#7d8590" font-size="9">128K</text>
-  <line x1="90" y1="1045.1" x2="790" y2="1045.1" stroke="#21262d" stroke-width="1"/>
-  <text x="82" y="1045.1" text-anchor="end" dominant-baseline="middle" fill="#7d8590" font-size="9">200</text>
-  <line x1="90" y1="1005.2" x2="790" y2="1005.2" stroke="#21262d" stroke-width="1"/>
-  <text x="82" y="1005.2" text-anchor="end" dominant-baseline="middle" fill="#7d8590" font-size="9">400</text>
-  <line x1="90" y1="965.4" x2="790" y2="965.4" stroke="#21262d" stroke-width="1"/>
-  <text x="82" y="965.4" text-anchor="end" dominant-baseline="middle" fill="#7d8590" font-size="9">600</text>
-  <line x1="90" y1="925.5" x2="790" y2="925.5" stroke="#21262d" stroke-width="1"/>
-  <text x="82" y="925.5" text-anchor="end" dominant-baseline="middle" fill="#7d8590" font-size="9">800</text>
-  <line x1="90" y1="885.6" x2="790" y2="885.6" stroke="#21262d" stroke-width="1"/>
-  <text x="82" y="885.6" text-anchor="end" dominant-baseline="middle" fill="#7d8590" font-size="9">1000</text>
-  <path d="M117.8,1051.9L195.9,1028.0L274.0,994.9L352.0,959.3L430.1,938.3L508.2,915.4L586.3,893.7L664.3,907.3L742.4,916.1" fill="none" stroke="#60a5fa" stroke-width="1.8"/>
-  <circle cx="117.8" cy="1051.9" r="2.5" fill="#60a5fa" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="195.9" cy="1028.0" r="2.5" fill="#60a5fa" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="274.0" cy="994.9" r="2.5" fill="#60a5fa" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="352.0" cy="959.3" r="2.5" fill="#60a5fa" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="430.1" cy="938.3" r="2.5" fill="#60a5fa" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="508.2" cy="915.4" r="2.5" fill="#60a5fa" stroke="#0d1117" stroke-width="0.8"/>
+  <line x1="90" y1="1045.3" x2="790" y2="1045.3" stroke="#21262d" stroke-width="1"/>
+  <text x="82" y="1045.3" text-anchor="end" dominant-baseline="middle" fill="#7d8590" font-size="9">200</text>
+  <line x1="90" y1="1005.7" x2="790" y2="1005.7" stroke="#21262d" stroke-width="1"/>
+  <text x="82" y="1005.7" text-anchor="end" dominant-baseline="middle" fill="#7d8590" font-size="9">400</text>
+  <line x1="90" y1="966.0" x2="790" y2="966.0" stroke="#21262d" stroke-width="1"/>
+  <text x="82" y="966.0" text-anchor="end" dominant-baseline="middle" fill="#7d8590" font-size="9">600</text>
+  <line x1="90" y1="926.4" x2="790" y2="926.4" stroke="#21262d" stroke-width="1"/>
+  <text x="82" y="926.4" text-anchor="end" dominant-baseline="middle" fill="#7d8590" font-size="9">800</text>
+  <line x1="90" y1="886.7" x2="790" y2="886.7" stroke="#21262d" stroke-width="1"/>
+  <text x="82" y="886.7" text-anchor="end" dominant-baseline="middle" fill="#7d8590" font-size="9">1000</text>
+  <path d="M117.8,1051.5L195.9,1026.9L274.0,994.0L352.0,958.7L430.1,937.7L508.2,915.5L586.3,893.7L664.3,908.9L742.4,917.8" fill="none" stroke="#60a5fa" stroke-width="1.8"/>
+  <circle cx="117.8" cy="1051.5" r="2.5" fill="#60a5fa" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="195.9" cy="1026.9" r="2.5" fill="#60a5fa" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="274.0" cy="994.0" r="2.5" fill="#60a5fa" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="352.0" cy="958.7" r="2.5" fill="#60a5fa" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="430.1" cy="937.7" r="2.5" fill="#60a5fa" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="508.2" cy="915.5" r="2.5" fill="#60a5fa" stroke="#0d1117" stroke-width="0.8"/>
   <circle cx="586.3" cy="893.7" r="2.5" fill="#60a5fa" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="664.3" cy="907.3" r="2.5" fill="#60a5fa" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="742.4" cy="916.1" r="2.5" fill="#60a5fa" stroke="#0d1117" stroke-width="0.8"/>
-  <path d="M117.8,1069.7L195.9,1059.6L274.0,1045.8L352.0,1031.2L430.1,1020.7L508.2,1008.5L586.3,999.8L664.3,1001.5L742.4,1005.4" fill="none" stroke="#f87171" stroke-width="1.8"/>
-  <circle cx="117.8" cy="1069.7" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="195.9" cy="1059.6" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="274.0" cy="1045.8" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="352.0" cy="1031.2" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="430.1" cy="1020.7" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="508.2" cy="1008.5" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="586.3" cy="999.8" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="664.3" cy="1001.5" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="742.4" cy="1005.4" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
-  <path d="M117.8,1069.7L195.9,1059.9L274.0,1045.9L352.0,1031.9L430.1,1022.5L508.2,1011.9L586.3,1003.9L664.3,1007.9L742.4,1010.9" fill="none" stroke="#f472b6" stroke-width="1.8"/>
-  <circle cx="117.8" cy="1069.7" r="2.5" fill="#f472b6" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="195.9" cy="1059.9" r="2.5" fill="#f472b6" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="274.0" cy="1045.9" r="2.5" fill="#f472b6" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="352.0" cy="1031.9" r="2.5" fill="#f472b6" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="430.1" cy="1022.5" r="2.5" fill="#f472b6" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="508.2" cy="1011.9" r="2.5" fill="#f472b6" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="586.3" cy="1003.9" r="2.5" fill="#f472b6" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="664.3" cy="1007.9" r="2.5" fill="#f472b6" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="742.4" cy="1010.9" r="2.5" fill="#f472b6" stroke="#0d1117" stroke-width="0.8"/>
-  <path d="M117.8,1067.4L195.9,1052.4L274.0,1030.9L352.0,1008.6L430.1,993.8L508.2,973.9L586.3,955.6L664.3,963.2L742.4,968.3" fill="none" stroke="#f59e0b" stroke-width="1.8"/>
-  <circle cx="117.8" cy="1067.4" r="2.5" fill="#f59e0b" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="195.9" cy="1052.4" r="2.5" fill="#f59e0b" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="274.0" cy="1030.9" r="2.5" fill="#f59e0b" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="352.0" cy="1008.6" r="2.5" fill="#f59e0b" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="430.1" cy="993.8" r="2.5" fill="#f59e0b" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="508.2" cy="973.9" r="2.5" fill="#f59e0b" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="586.3" cy="955.6" r="2.5" fill="#f59e0b" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="664.3" cy="963.2" r="2.5" fill="#f59e0b" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="742.4" cy="968.3" r="2.5" fill="#f59e0b" stroke="#0d1117" stroke-width="0.8"/>
-  <path d="M117.8,1074.4L195.9,1068.7L274.0,1062.8L352.0,1058.6L430.1,1056.4L508.2,1054.0L586.3,1052.1L664.3,1054.0L742.4,1054.7" fill="none" stroke="#4ade80" stroke-width="1.8"/>
-  <circle cx="117.8" cy="1074.4" r="2.5" fill="#4ade80" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="195.9" cy="1068.7" r="2.5" fill="#4ade80" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="274.0" cy="1062.8" r="2.5" fill="#4ade80" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="352.0" cy="1058.6" r="2.5" fill="#4ade80" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="430.1" cy="1056.4" r="2.5" fill="#4ade80" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="508.2" cy="1054.0" r="2.5" fill="#4ade80" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="586.3" cy="1052.1" r="2.5" fill="#4ade80" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="664.3" cy="1054.0" r="2.5" fill="#4ade80" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="742.4" cy="1054.7" r="2.5" fill="#4ade80" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="664.3" cy="908.9" r="2.5" fill="#60a5fa" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="742.4" cy="917.8" r="2.5" fill="#60a5fa" stroke="#0d1117" stroke-width="0.8"/>
+  <path d="M117.8,1069.3L195.9,1059.2L274.0,1045.0L352.0,1031.5L430.1,1022.6L508.2,1010.0L586.3,1000.9L664.3,1002.1L742.4,1006.1" fill="none" stroke="#f87171" stroke-width="1.8"/>
+  <circle cx="117.8" cy="1069.3" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="195.9" cy="1059.2" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="274.0" cy="1045.0" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="352.0" cy="1031.5" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="430.1" cy="1022.6" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="508.2" cy="1010.0" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="586.3" cy="1000.9" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="664.3" cy="1002.1" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="742.4" cy="1006.1" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
+  <path d="M117.8,1069.3L195.9,1059.3L274.0,1045.4L352.0,1032.9L430.1,1023.9L508.2,1013.0L586.3,1004.6L664.3,1009.3L742.4,1011.7" fill="none" stroke="#f472b6" stroke-width="1.8"/>
+  <circle cx="117.8" cy="1069.3" r="2.5" fill="#f472b6" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="195.9" cy="1059.3" r="2.5" fill="#f472b6" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="274.0" cy="1045.4" r="2.5" fill="#f472b6" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="352.0" cy="1032.9" r="2.5" fill="#f472b6" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="430.1" cy="1023.9" r="2.5" fill="#f472b6" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="508.2" cy="1013.0" r="2.5" fill="#f472b6" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="586.3" cy="1004.6" r="2.5" fill="#f472b6" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="664.3" cy="1009.3" r="2.5" fill="#f472b6" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="742.4" cy="1011.7" r="2.5" fill="#f472b6" stroke="#0d1117" stroke-width="0.8"/>
+  <path d="M117.8,1067.9L195.9,1053.9L274.0,1032.5L352.0,1011.0L430.1,994.5L508.2,974.2L586.3,954.4L664.3,964.3L742.4,969.1" fill="none" stroke="#f59e0b" stroke-width="1.8"/>
+  <circle cx="117.8" cy="1067.9" r="2.5" fill="#f59e0b" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="195.9" cy="1053.9" r="2.5" fill="#f59e0b" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="274.0" cy="1032.5" r="2.5" fill="#f59e0b" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="352.0" cy="1011.0" r="2.5" fill="#f59e0b" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="430.1" cy="994.5" r="2.5" fill="#f59e0b" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="508.2" cy="974.2" r="2.5" fill="#f59e0b" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="586.3" cy="954.4" r="2.5" fill="#f59e0b" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="664.3" cy="964.3" r="2.5" fill="#f59e0b" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="742.4" cy="969.1" r="2.5" fill="#f59e0b" stroke="#0d1117" stroke-width="0.8"/>
+  <path d="M117.8,1074.5L195.9,1068.8L274.0,1062.9L352.0,1058.8L430.1,1056.6L508.2,1054.1L586.3,1052.2L664.3,1054.2L742.4,1054.9" fill="none" stroke="#4ade80" stroke-width="1.8"/>
+  <circle cx="117.8" cy="1074.5" r="2.5" fill="#4ade80" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="195.9" cy="1068.8" r="2.5" fill="#4ade80" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="274.0" cy="1062.9" r="2.5" fill="#4ade80" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="352.0" cy="1058.8" r="2.5" fill="#4ade80" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="430.1" cy="1056.6" r="2.5" fill="#4ade80" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="508.2" cy="1054.1" r="2.5" fill="#4ade80" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="586.3" cy="1052.2" r="2.5" fill="#4ade80" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="664.3" cy="1054.2" r="2.5" fill="#4ade80" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="742.4" cy="1054.9" r="2.5" fill="#4ade80" stroke="#0d1117" stroke-width="0.8"/>
   <text x="20" y="570.0" text-anchor="middle" fill="#e6edf3" font-size="11" font-weight="600" transform="rotate(-90,20,570.0)">decode MB/s</text>
   <circle cx="-110" cy="1120" r="4" fill="#60a5fa"/>
   <text x="-102" y="1123.5" fill="#e6edf3" font-size="10" font-weight="500">libzstd v1.5.7 (C)</text>

--- a/examples/profile_openzl_decode.rs
+++ b/examples/profile_openzl_decode.rs
@@ -1,0 +1,112 @@
+use std::hint::black_box;
+use std::path::{Path, PathBuf};
+use std::time::{Duration, Instant};
+
+fn expected_len(path: &Path) -> Option<usize> {
+    path.file_name()
+        .and_then(|name| name.to_str())
+        .and_then(|name| name.split(".out").nth(1))
+        .and_then(|tail| tail.split('.').next())
+        .and_then(|len| len.parse().ok())
+}
+
+fn collect_targets(root: &Path) -> Vec<PathBuf> {
+    let mut paths = Vec::new();
+    let entries = std::fs::read_dir(root).unwrap_or_else(|err| {
+        panic!("failed to read {}: {err}", root.display());
+    });
+    for entry in entries {
+        let path = entry.unwrap().path();
+        if path.extension().and_then(|ext| ext.to_str()) == Some("zstd-magicless") {
+            paths.push(path);
+        }
+    }
+    paths.sort();
+    paths
+}
+
+fn measure(paths: &[PathBuf], label: &str) {
+    let inputs: Vec<(PathBuf, Vec<u8>, usize)> = paths
+        .iter()
+        .map(|path| {
+            let input = std::fs::read(path).unwrap();
+            let expected = expected_len(path).unwrap_or_else(|| {
+                panic!("missing .out length in {}", path.display());
+            });
+            (path.clone(), input, expected)
+        })
+        .collect();
+
+    let total_output: usize = inputs.iter().map(|(_, _, expected)| *expected).sum();
+    let mut ctx = zrip::DecompressContext::new();
+    let mut output = Vec::new();
+
+    for (_, input, expected) in &inputs {
+        output.clear();
+        let written = ctx
+            .decompress_after_magic_into(black_box(input), &mut output, usize::MAX)
+            .unwrap();
+        assert_eq!(written, *expected);
+        assert_eq!(output.len(), *expected);
+    }
+
+    let target = Duration::from_millis(800);
+    let mut iters = 1usize;
+    loop {
+        let start = Instant::now();
+        for _ in 0..iters {
+            for (_, input, _) in &inputs {
+                output.clear();
+                let written = ctx
+                    .decompress_after_magic_into(black_box(input), &mut output, usize::MAX)
+                    .unwrap();
+                black_box(written);
+                black_box(output.as_ptr());
+            }
+        }
+        if start.elapsed() >= target {
+            break;
+        }
+        iters *= 2;
+    }
+
+    let mut best = f64::MAX;
+    for _ in 0..5 {
+        let start = Instant::now();
+        for _ in 0..iters {
+            for (_, input, _) in &inputs {
+                output.clear();
+                let written = ctx
+                    .decompress_after_magic_into(black_box(input), &mut output, usize::MAX)
+                    .unwrap();
+                black_box(written);
+                black_box(output.as_ptr());
+            }
+        }
+        best = best.min(start.elapsed().as_secs_f64());
+    }
+
+    let bytes = total_output as f64 * iters as f64;
+    println!("{label}\t{}\t{:.1} MB/s", inputs.len(), bytes / best / 1e6);
+}
+
+fn main() {
+    let mut args = std::env::args_os().skip(1).map(PathBuf::from);
+    let paths: Vec<PathBuf> = if let Some(first) = args.next() {
+        let mut paths = vec![first];
+        paths.extend(args);
+        paths
+    } else {
+        collect_targets(Path::new("tmp/ozlrip-zstd-targets"))
+    };
+
+    let tiny: Vec<PathBuf> = paths
+        .iter()
+        .filter(|path| std::fs::metadata(path).unwrap().len() <= 512)
+        .cloned()
+        .collect();
+    if !tiny.is_empty() {
+        measure(&tiny, "tiny");
+    }
+    measure(&paths, "all");
+}


### PR DESCRIPTION
- Add magicless zstd frame decode APIs for OpenZL transform payloads.
- Reuse sequence and Huffman decode state across small frame decodes.
- Specialize one-sequence tiny-frame execution and wide match copies.
- Add an OpenZL decode profiling harness.
- Refresh `doc/charts/x86_64/small_decode.svg` after L3 small decode rebenching.
- Verified with `cargo fmt --all --check`, `cargo build`, `cargo build --no-default-features --features alloc`, `cargo clippy --all-targets -- -D warnings`, and `cargo test`.
