### PR TITLE
Speed up paranoid safe loads

### DIFF
--- a/crates/core/src/bitstream/primitives.rs
+++ b/crates/core/src/bitstream/primitives.rs
@@ -14,7 +14,7 @@ pub(crate) fn read_u64_le_unaligned(data: &[u8], offset: usize) -> u64 {
 #[cfg(feature = "paranoid")]
 #[inline(always)]
 pub(crate) fn read_u64_le_unaligned(data: &[u8], offset: usize) -> u64 {
-    u64::from_le_bytes(data[offset..offset + 8].try_into().unwrap())
+    u64::from_le_bytes(*data[offset..].first_chunk::<8>().unwrap())
 }
 
 #[cfg(all(feature = "alloc", not(feature = "paranoid")))]

--- a/crates/core/src/bitstream/reader_reverse.rs
+++ b/crates/core/src/bitstream/reader_reverse.rs
@@ -116,13 +116,10 @@ impl<'a> ReverseBitReader<'a> {
     pub fn try_refill_fast(&mut self) -> bool {
         let byte_shift = (self.bits_consumed >> 3) as usize;
         if likely(byte_shift <= self.ptr && self.data.len() >= 8) {
-            let new_ptr = self.ptr - byte_shift;
-            if likely(new_ptr <= self.data.len() - 8) {
-                self.ptr = new_ptr;
-                self.bits_consumed -= (byte_shift as u32) * 8;
-                self.container = primitives::read_u64_le_unaligned(self.data, self.ptr);
-                return true;
-            }
+            self.ptr -= byte_shift;
+            self.bits_consumed -= (byte_shift as u32) * 8;
+            self.container = primitives::read_u64_le_unaligned(self.data, self.ptr);
+            return true;
         }
         false
     }

--- a/crates/core/src/bitstream/reader_reverse.rs
+++ b/crates/core/src/bitstream/reader_reverse.rs
@@ -118,6 +118,9 @@ impl<'a> ReverseBitReader<'a> {
         if likely(byte_shift <= self.ptr && self.data.len() >= 8) {
             self.ptr -= byte_shift;
             self.bits_consumed -= (byte_shift as u32) * 8;
+            // `ptr` starts at `len - 8` for long streams and only moves toward
+            // zero, so any successful fast refill can still load eight bytes.
+            debug_assert!(self.ptr + 8 <= self.data.len());
             self.container = primitives::read_u64_le_unaligned(self.data, self.ptr);
             return true;
         }

--- a/crates/core/src/xxhash/primitives.rs
+++ b/crates/core/src/xxhash/primitives.rs
@@ -11,7 +11,7 @@ pub(crate) fn read_u32_le(data: &[u8], offset: usize) -> u32 {
 #[cfg(feature = "paranoid")]
 #[inline(always)]
 pub(crate) fn read_u32_le(data: &[u8], offset: usize) -> u32 {
-    u32::from_le_bytes(data[offset..offset + 4].try_into().unwrap())
+    u32::from_le_bytes(*data[offset..].first_chunk::<4>().unwrap())
 }
 
 #[cfg(not(feature = "paranoid"))]
@@ -27,7 +27,7 @@ pub(crate) fn read_u64_le(data: &[u8], offset: usize) -> u64 {
 #[cfg(feature = "paranoid")]
 #[inline(always)]
 pub(crate) fn read_u64_le(data: &[u8], offset: usize) -> u64 {
-    u64::from_le_bytes(data[offset..offset + 8].try_into().unwrap())
+    u64::from_le_bytes(*data[offset..].first_chunk::<8>().unwrap())
 }
 
 #[cfg(not(feature = "paranoid"))]
@@ -86,7 +86,7 @@ pub(super) fn bulk_rounds(data: &[u8], v1: &mut u64, v2: &mut u64, v3: &mut u64,
 
     #[inline(always)]
     fn rd64(data: &[u8], offset: usize) -> u64 {
-        u64::from_le_bytes(data[offset..offset + 8].try_into().unwrap())
+        u64::from_le_bytes(*data[offset..].first_chunk::<8>().unwrap())
     }
 
     let bulk_end = len & !31;

--- a/crates/encode/src/primitives.rs
+++ b/crates/encode/src/primitives.rs
@@ -13,7 +13,7 @@ pub(crate) unsafe fn rd32(src: &[u8], pos: usize) -> u32 {
 #[cfg(feature = "paranoid")]
 #[inline(always)]
 pub(crate) fn rd32(src: &[u8], pos: usize) -> u32 {
-    u32::from_le_bytes(src[pos..pos + 4].try_into().unwrap())
+    u32::from_le_bytes(*src[pos..].first_chunk::<4>().unwrap())
 }
 
 #[cfg(not(feature = "paranoid"))]
@@ -28,7 +28,7 @@ pub(crate) unsafe fn rd64(src: &[u8], pos: usize) -> u64 {
 #[cfg(feature = "paranoid")]
 #[inline(always)]
 pub(crate) fn rd64(src: &[u8], pos: usize) -> u64 {
-    u64::from_le_bytes(src[pos..pos + 8].try_into().unwrap())
+    u64::from_le_bytes(*src[pos..].first_chunk::<8>().unwrap())
 }
 
 #[cfg(not(feature = "paranoid"))]
@@ -153,8 +153,8 @@ pub(crate) fn count_match(src: &[u8], p1: usize, p2: usize, limit: usize) -> usi
     let max_len = limit - p1;
     let mut i = 0;
     while i + 8 <= max_len {
-        let a = u64::from_le_bytes(src[p1 + i..p1 + i + 8].try_into().unwrap());
-        let b = u64::from_le_bytes(src[p2 + i..p2 + i + 8].try_into().unwrap());
+        let a = u64::from_le_bytes(*src[p1 + i..].first_chunk::<8>().unwrap());
+        let b = u64::from_le_bytes(*src[p2 + i..].first_chunk::<8>().unwrap());
         let diff = a ^ b;
         if diff != 0 {
             return i + (diff.trailing_zeros() >> 3) as usize;

--- a/doc/charts/x86_64/matrix.svg
+++ b/doc/charts/x86_64/matrix.svg
@@ -4,102 +4,100 @@
   <text x="450.0" y="38" text-anchor="middle" fill="#7d8590" font-size="10">Intel Core i7-8700B @ 3.20GHz, performance governor, turbo off</text>
   <text x="22" y="445.0" text-anchor="middle" fill="#e6edf3" font-size="11" font-weight="600" transform="rotate(-90,22,445.0)">seconds / GB</text>
   <text x="450.0" y="64" text-anchor="middle" fill="#e6edf3" font-size="12" font-weight="600">High compressibility</text>
-  <line x1="70" y1="225.3" x2="830" y2="225.3" stroke="#21262d" stroke-width="1"/>
-  <text x="62" y="225.3" text-anchor="end" dominant-baseline="middle" fill="#7d8590" font-size="10">2.0</text>
-  <line x1="70" y1="180.6" x2="830" y2="180.6" stroke="#21262d" stroke-width="1"/>
-  <text x="62" y="180.6" text-anchor="end" dominant-baseline="middle" fill="#7d8590" font-size="10">4.0</text>
-  <line x1="70" y1="135.9" x2="830" y2="135.9" stroke="#21262d" stroke-width="1"/>
-  <text x="62" y="135.9" text-anchor="end" dominant-baseline="middle" fill="#7d8590" font-size="10">6.0</text>
-  <line x1="70" y1="91.3" x2="830" y2="91.3" stroke="#21262d" stroke-width="1"/>
-  <text x="62" y="91.3" text-anchor="end" dominant-baseline="middle" fill="#7d8590" font-size="10">8.0</text>
+  <line x1="70" y1="223.8" x2="830" y2="223.8" stroke="#21262d" stroke-width="1"/>
+  <text x="62" y="223.8" text-anchor="end" dominant-baseline="middle" fill="#7d8590" font-size="10">2.0</text>
+  <line x1="70" y1="177.5" x2="830" y2="177.5" stroke="#21262d" stroke-width="1"/>
+  <text x="62" y="177.5" text-anchor="end" dominant-baseline="middle" fill="#7d8590" font-size="10">4.0</text>
+  <line x1="70" y1="131.3" x2="830" y2="131.3" stroke="#21262d" stroke-width="1"/>
+  <text x="62" y="131.3" text-anchor="end" dominant-baseline="middle" fill="#7d8590" font-size="10">6.0</text>
+  <line x1="70" y1="85.0" x2="830" y2="85.0" stroke="#21262d" stroke-width="1"/>
+  <text x="62" y="85.0" text-anchor="end" dominant-baseline="middle" fill="#7d8590" font-size="10">8.0</text>
   <line x1="70" y1="270" x2="830" y2="270" stroke="#30363d" stroke-width="1.5"/>
-  <rect x="95.3" y="229.2" width="44.3" height="40.8" fill="#60a5fa" rx="1"/>
-  <rect x="95.3" y="192.0" width="44.3" height="37.1" fill="#4680c4" rx="1"/>
-  <rect x="95.3" y="178.6" width="44.3" height="13.5" fill="#60a5fa" rx="1"/>
-  <rect x="141.3" y="209.2" width="44.3" height="60.8" fill="#f87171" rx="1"/>
-  <rect x="141.3" y="171.6" width="44.3" height="37.6" fill="#c45050" rx="1"/>
-  <rect x="141.3" y="145.6" width="44.3" height="25.9" fill="#f87171" rx="1"/>
-  <rect x="187.3" y="197.0" width="44.3" height="73.0" fill="#f59e0b" rx="1"/>
-  <rect x="187.3" y="159.8" width="44.3" height="37.2" fill="#c47d08" rx="1"/>
-  <rect x="187.3" y="139.3" width="44.3" height="20.5" fill="#f59e0b" rx="1"/>
-  <rect x="233.3" y="184.5" width="44.3" height="85.5" fill="#f472b6" rx="1"/>
-  <rect x="233.3" y="146.9" width="44.3" height="37.6" fill="#c05a92" rx="1"/>
-  <rect x="233.3" y="114.6" width="44.3" height="32.3" fill="#f472b6" rx="1"/>
+  <rect x="95.3" y="227.7" width="44.3" height="42.3" fill="#60a5fa" rx="1"/>
+  <rect x="95.3" y="189.3" width="44.3" height="38.4" fill="#4680c4" rx="1"/>
+  <rect x="95.3" y="175.4" width="44.3" height="13.9" fill="#60a5fa" rx="1"/>
+  <rect x="141.3" y="207.8" width="44.3" height="62.2" fill="#f87171" rx="1"/>
+  <rect x="141.3" y="168.9" width="44.3" height="38.9" fill="#c45050" rx="1"/>
+  <rect x="141.3" y="142.1" width="44.3" height="26.8" fill="#f87171" rx="1"/>
+  <rect x="187.3" y="194.5" width="44.3" height="75.5" fill="#f59e0b" rx="1"/>
+  <rect x="187.3" y="155.9" width="44.3" height="38.5" fill="#c47d08" rx="1"/>
+  <rect x="187.3" y="134.8" width="44.3" height="21.2" fill="#f59e0b" rx="1"/>
+  <rect x="233.3" y="186.1" width="44.3" height="83.9" fill="#f472b6" rx="1"/>
+  <rect x="233.3" y="147.2" width="44.3" height="38.9" fill="#c05a92" rx="1"/>
+  <rect x="233.3" y="114.3" width="44.3" height="32.8" fill="#f472b6" rx="1"/>
   <text x="196.7" y="288" text-anchor="middle" fill="#e6edf3" font-size="11" font-weight="600">Level −1</text>
-  <rect x="348.7" y="226.4" width="44.3" height="43.6" fill="#60a5fa" rx="1"/>
-  <rect x="348.7" y="195.2" width="44.3" height="31.2" fill="#4680c4" rx="1"/>
-  <rect x="348.7" y="180.8" width="44.3" height="14.3" fill="#60a5fa" rx="1"/>
-  <rect x="394.7" y="205.0" width="44.3" height="65.0" fill="#f87171" rx="1"/>
-  <rect x="394.7" y="169.1" width="44.3" height="35.8" fill="#c45050" rx="1"/>
-  <rect x="394.7" y="139.9" width="44.3" height="29.3" fill="#f87171" rx="1"/>
-  <rect x="440.7" y="193.4" width="44.3" height="76.6" fill="#f59e0b" rx="1"/>
-  <rect x="440.7" y="162.0" width="44.3" height="31.3" fill="#c47d08" rx="1"/>
-  <rect x="440.7" y="140.7" width="44.3" height="21.3" fill="#f59e0b" rx="1"/>
-  <rect x="486.7" y="176.8" width="44.3" height="93.2" fill="#f472b6" rx="1"/>
-  <rect x="486.7" y="141.0" width="44.3" height="35.8" fill="#c05a92" rx="1"/>
-  <rect x="486.7" y="104.8" width="44.3" height="36.2" fill="#f472b6" rx="1"/>
+  <rect x="348.7" y="224.9" width="44.3" height="45.1" fill="#60a5fa" rx="1"/>
+  <rect x="348.7" y="192.6" width="44.3" height="32.3" fill="#4680c4" rx="1"/>
+  <rect x="348.7" y="177.7" width="44.3" height="14.8" fill="#60a5fa" rx="1"/>
+  <rect x="394.7" y="203.2" width="44.3" height="66.8" fill="#f87171" rx="1"/>
+  <rect x="394.7" y="166.1" width="44.3" height="37.1" fill="#c45050" rx="1"/>
+  <rect x="394.7" y="135.8" width="44.3" height="30.3" fill="#f87171" rx="1"/>
+  <rect x="440.7" y="190.7" width="44.3" height="79.3" fill="#f59e0b" rx="1"/>
+  <rect x="440.7" y="158.3" width="44.3" height="32.4" fill="#c47d08" rx="1"/>
+  <rect x="440.7" y="136.2" width="44.3" height="22.1" fill="#f59e0b" rx="1"/>
+  <rect x="486.7" y="178.6" width="44.3" height="91.4" fill="#f472b6" rx="1"/>
+  <rect x="486.7" y="141.5" width="44.3" height="37.1" fill="#c05a92" rx="1"/>
+  <rect x="486.7" y="104.5" width="44.3" height="37.1" fill="#f472b6" rx="1"/>
   <text x="450.0" y="288" text-anchor="middle" fill="#e6edf3" font-size="11" font-weight="600">Level 1</text>
-  <rect x="602.0" y="213.5" width="44.3" height="56.5" fill="#60a5fa" rx="1"/>
-  <rect x="602.0" y="184.2" width="44.3" height="29.3" fill="#4680c4" rx="1"/>
-  <rect x="602.0" y="169.3" width="44.3" height="14.9" fill="#60a5fa" rx="1"/>
-  <rect x="648.0" y="194.4" width="44.3" height="75.6" fill="#f87171" rx="1"/>
-  <rect x="648.0" y="161.5" width="44.3" height="32.8" fill="#c45050" rx="1"/>
-  <rect x="648.0" y="135.5" width="44.3" height="26.0" fill="#f87171" rx="1"/>
-  <rect x="694.0" y="153.7" width="44.3" height="116.3" fill="#f59e0b" rx="1"/>
-  <rect x="694.0" y="124.4" width="44.3" height="29.3" fill="#c47d08" rx="1"/>
-  <rect x="694.0" y="101.9" width="44.3" height="22.5" fill="#f59e0b" rx="1"/>
-  <rect x="740.0" y="161.4" width="44.3" height="108.6" fill="#f472b6" rx="1"/>
-  <rect x="740.0" y="128.6" width="44.3" height="32.8" fill="#c05a92" rx="1"/>
-  <rect x="740.0" y="96.1" width="44.3" height="32.5" fill="#f472b6" rx="1"/>
+  <rect x="602.0" y="211.5" width="44.3" height="58.5" fill="#60a5fa" rx="1"/>
+  <rect x="602.0" y="181.2" width="44.3" height="30.3" fill="#4680c4" rx="1"/>
+  <rect x="602.0" y="165.8" width="44.3" height="15.5" fill="#60a5fa" rx="1"/>
+  <rect x="648.0" y="194.1" width="44.3" height="75.9" fill="#f87171" rx="1"/>
+  <rect x="648.0" y="160.1" width="44.3" height="34.0" fill="#c45050" rx="1"/>
+  <rect x="648.0" y="133.2" width="44.3" height="26.9" fill="#f87171" rx="1"/>
+  <rect x="694.0" y="149.7" width="44.3" height="120.3" fill="#f59e0b" rx="1"/>
+  <rect x="694.0" y="119.4" width="44.3" height="30.3" fill="#c47d08" rx="1"/>
+  <rect x="694.0" y="96.1" width="44.3" height="23.3" fill="#f59e0b" rx="1"/>
+  <rect x="740.0" y="168.1" width="44.3" height="101.9" fill="#f472b6" rx="1"/>
+  <rect x="740.0" y="134.1" width="44.3" height="34.0" fill="#c05a92" rx="1"/>
+  <rect x="740.0" y="100.9" width="44.3" height="33.2" fill="#f472b6" rx="1"/>
   <text x="703.3" y="288" text-anchor="middle" fill="#e6edf3" font-size="11" font-weight="600">Level 3</text>
   <text x="450.0" y="339" text-anchor="middle" fill="#e6edf3" font-size="12" font-weight="600">Medium compressibility</text>
-  <line x1="70" y1="495.2" x2="830" y2="495.2" stroke="#21262d" stroke-width="1"/>
-  <text x="62" y="495.2" text-anchor="end" dominant-baseline="middle" fill="#7d8590" font-size="10">5.0</text>
-  <line x1="70" y1="445.5" x2="830" y2="445.5" stroke="#21262d" stroke-width="1"/>
-  <text x="62" y="445.5" text-anchor="end" dominant-baseline="middle" fill="#7d8590" font-size="10">10.0</text>
-  <line x1="70" y1="395.7" x2="830" y2="395.7" stroke="#21262d" stroke-width="1"/>
-  <text x="62" y="395.7" text-anchor="end" dominant-baseline="middle" fill="#7d8590" font-size="10">15.0</text>
-  <line x1="70" y1="346.0" x2="830" y2="346.0" stroke="#21262d" stroke-width="1"/>
-  <text x="62" y="346.0" text-anchor="end" dominant-baseline="middle" fill="#7d8590" font-size="10">20.0</text>
+  <line x1="70" y1="492.5" x2="830" y2="492.5" stroke="#21262d" stroke-width="1"/>
+  <text x="62" y="492.5" text-anchor="end" dominant-baseline="middle" fill="#7d8590" font-size="10">5.0</text>
+  <line x1="70" y1="440.0" x2="830" y2="440.0" stroke="#21262d" stroke-width="1"/>
+  <text x="62" y="440.0" text-anchor="end" dominant-baseline="middle" fill="#7d8590" font-size="10">10.0</text>
+  <line x1="70" y1="387.5" x2="830" y2="387.5" stroke="#21262d" stroke-width="1"/>
+  <text x="62" y="387.5" text-anchor="end" dominant-baseline="middle" fill="#7d8590" font-size="10">15.0</text>
   <line x1="70" y1="545" x2="830" y2="545" stroke="#30363d" stroke-width="1.5"/>
-  <rect x="95.3" y="511.5" width="44.3" height="33.5" fill="#60a5fa" rx="1"/>
-  <rect x="95.3" y="467.6" width="44.3" height="43.9" fill="#4680c4" rx="1"/>
-  <rect x="95.3" y="458.9" width="44.3" height="8.7" fill="#60a5fa" rx="1"/>
-  <rect x="141.3" y="491.9" width="44.3" height="53.1" fill="#f87171" rx="1"/>
-  <rect x="141.3" y="450.2" width="44.3" height="41.7" fill="#c45050" rx="1"/>
-  <rect x="141.3" y="431.1" width="44.3" height="19.1" fill="#f87171" rx="1"/>
-  <rect x="187.3" y="490.2" width="44.3" height="54.8" fill="#f59e0b" rx="1"/>
-  <rect x="187.3" y="446.2" width="44.3" height="44.0" fill="#c47d08" rx="1"/>
-  <rect x="187.3" y="432.6" width="44.3" height="13.6" fill="#f59e0b" rx="1"/>
-  <rect x="233.3" y="472.2" width="44.3" height="72.8" fill="#f472b6" rx="1"/>
-  <rect x="233.3" y="430.4" width="44.3" height="41.7" fill="#c05a92" rx="1"/>
-  <rect x="233.3" y="405.4" width="44.3" height="25.0" fill="#f472b6" rx="1"/>
+  <rect x="95.3" y="509.6" width="44.3" height="35.4" fill="#60a5fa" rx="1"/>
+  <rect x="95.3" y="463.3" width="44.3" height="46.3" fill="#4680c4" rx="1"/>
+  <rect x="95.3" y="454.2" width="44.3" height="9.1" fill="#60a5fa" rx="1"/>
+  <rect x="141.3" y="489.5" width="44.3" height="55.5" fill="#f87171" rx="1"/>
+  <rect x="141.3" y="445.5" width="44.3" height="44.0" fill="#c45050" rx="1"/>
+  <rect x="141.3" y="425.5" width="44.3" height="20.0" fill="#f87171" rx="1"/>
+  <rect x="187.3" y="487.2" width="44.3" height="57.8" fill="#f59e0b" rx="1"/>
+  <rect x="187.3" y="440.7" width="44.3" height="46.5" fill="#c47d08" rx="1"/>
+  <rect x="187.3" y="426.4" width="44.3" height="14.3" fill="#f59e0b" rx="1"/>
+  <rect x="233.3" y="472.3" width="44.3" height="72.7" fill="#f472b6" rx="1"/>
+  <rect x="233.3" y="428.3" width="44.3" height="44.0" fill="#c05a92" rx="1"/>
+  <rect x="233.3" y="402.7" width="44.3" height="25.6" fill="#f472b6" rx="1"/>
   <text x="196.7" y="563" text-anchor="middle" fill="#e6edf3" font-size="11" font-weight="600">Level −1</text>
-  <rect x="348.7" y="508.8" width="44.3" height="36.2" fill="#60a5fa" rx="1"/>
-  <rect x="348.7" y="472.2" width="44.3" height="36.6" fill="#4680c4" rx="1"/>
-  <rect x="348.7" y="462.1" width="44.3" height="10.2" fill="#60a5fa" rx="1"/>
-  <rect x="394.7" y="486.5" width="44.3" height="58.5" fill="#f87171" rx="1"/>
-  <rect x="394.7" y="447.3" width="44.3" height="39.2" fill="#c45050" rx="1"/>
-  <rect x="394.7" y="424.6" width="44.3" height="22.6" fill="#f87171" rx="1"/>
-  <rect x="440.7" y="483.7" width="44.3" height="61.3" fill="#f59e0b" rx="1"/>
-  <rect x="440.7" y="447.0" width="44.3" height="36.7" fill="#c47d08" rx="1"/>
-  <rect x="440.7" y="431.6" width="44.3" height="15.4" fill="#f59e0b" rx="1"/>
-  <rect x="486.7" y="460.7" width="44.3" height="84.3" fill="#f472b6" rx="1"/>
-  <rect x="486.7" y="421.5" width="44.3" height="39.2" fill="#c05a92" rx="1"/>
-  <rect x="486.7" y="391.3" width="44.3" height="30.1" fill="#f472b6" rx="1"/>
+  <rect x="348.7" y="506.8" width="44.3" height="38.2" fill="#60a5fa" rx="1"/>
+  <rect x="348.7" y="468.2" width="44.3" height="38.6" fill="#4680c4" rx="1"/>
+  <rect x="348.7" y="457.5" width="44.3" height="10.7" fill="#60a5fa" rx="1"/>
+  <rect x="394.7" y="483.1" width="44.3" height="61.9" fill="#f87171" rx="1"/>
+  <rect x="394.7" y="441.7" width="44.3" height="41.4" fill="#c45050" rx="1"/>
+  <rect x="394.7" y="417.8" width="44.3" height="23.9" fill="#f87171" rx="1"/>
+  <rect x="440.7" y="480.4" width="44.3" height="64.6" fill="#f59e0b" rx="1"/>
+  <rect x="440.7" y="441.6" width="44.3" height="38.7" fill="#c47d08" rx="1"/>
+  <rect x="440.7" y="425.4" width="44.3" height="16.3" fill="#f59e0b" rx="1"/>
+  <rect x="486.7" y="460.9" width="44.3" height="84.1" fill="#f472b6" rx="1"/>
+  <rect x="486.7" y="419.5" width="44.3" height="41.4" fill="#c05a92" rx="1"/>
+  <rect x="486.7" y="389.1" width="44.3" height="30.4" fill="#f472b6" rx="1"/>
   <text x="450.0" y="563" text-anchor="middle" fill="#e6edf3" font-size="11" font-weight="600">Level 1</text>
-  <rect x="602.0" y="485.4" width="44.3" height="59.6" fill="#60a5fa" rx="1"/>
-  <rect x="602.0" y="452.3" width="44.3" height="33.0" fill="#4680c4" rx="1"/>
-  <rect x="602.0" y="440.7" width="44.3" height="11.7" fill="#60a5fa" rx="1"/>
-  <rect x="648.0" y="465.4" width="44.3" height="79.6" fill="#f87171" rx="1"/>
-  <rect x="648.0" y="428.8" width="44.3" height="36.6" fill="#c45050" rx="1"/>
-  <rect x="648.0" y="408.8" width="44.3" height="20.0" fill="#f87171" rx="1"/>
-  <rect x="694.0" y="431.3" width="44.3" height="113.7" fill="#f59e0b" rx="1"/>
-  <rect x="694.0" y="398.0" width="44.3" height="33.3" fill="#c47d08" rx="1"/>
-  <rect x="694.0" y="380.1" width="44.3" height="17.8" fill="#f59e0b" rx="1"/>
-  <rect x="740.0" y="434.7" width="44.3" height="110.3" fill="#f472b6" rx="1"/>
-  <rect x="740.0" y="398.0" width="44.3" height="36.6" fill="#c05a92" rx="1"/>
-  <rect x="740.0" y="371.1" width="44.3" height="26.9" fill="#f472b6" rx="1"/>
+  <rect x="602.0" y="482.1" width="44.3" height="62.9" fill="#60a5fa" rx="1"/>
+  <rect x="602.0" y="447.3" width="44.3" height="34.8" fill="#4680c4" rx="1"/>
+  <rect x="602.0" y="434.9" width="44.3" height="12.3" fill="#60a5fa" rx="1"/>
+  <rect x="648.0" y="464.5" width="44.3" height="80.5" fill="#f87171" rx="1"/>
+  <rect x="648.0" y="425.8" width="44.3" height="38.7" fill="#c45050" rx="1"/>
+  <rect x="648.0" y="405.2" width="44.3" height="20.7" fill="#f87171" rx="1"/>
+  <rect x="694.0" y="425.1" width="44.3" height="119.9" fill="#f59e0b" rx="1"/>
+  <rect x="694.0" y="389.9" width="44.3" height="35.2" fill="#c47d08" rx="1"/>
+  <rect x="694.0" y="371.1" width="44.3" height="18.8" fill="#f59e0b" rx="1"/>
+  <rect x="740.0" y="440.4" width="44.3" height="104.6" fill="#f472b6" rx="1"/>
+  <rect x="740.0" y="401.8" width="44.3" height="38.7" fill="#c05a92" rx="1"/>
+  <rect x="740.0" y="374.2" width="44.3" height="27.5" fill="#f472b6" rx="1"/>
   <text x="703.3" y="563" text-anchor="middle" fill="#e6edf3" font-size="11" font-weight="600">Level 3</text>
   <text x="450.0" y="614" text-anchor="middle" fill="#e6edf3" font-size="12" font-weight="600">Low compressibility</text>
   <line x1="70" y1="758.6" x2="830" y2="758.6" stroke="#21262d" stroke-width="1"/>
@@ -113,14 +111,14 @@
   <rect x="95.3" y="750.9" width="44.3" height="58.6" fill="#4680c4" rx="1"/>
   <rect x="95.3" y="749.4" width="44.3" height="1.5" fill="#60a5fa" rx="1"/>
   <rect x="141.3" y="804.3" width="44.3" height="15.7" fill="#f87171" rx="1"/>
-  <rect x="141.3" y="746.8" width="44.3" height="57.6" fill="#c45050" rx="1"/>
-  <rect x="141.3" y="743.0" width="44.3" height="3.8" fill="#f87171" rx="1"/>
+  <rect x="141.3" y="746.7" width="44.3" height="57.6" fill="#c45050" rx="1"/>
+  <rect x="141.3" y="742.9" width="44.3" height="3.8" fill="#f87171" rx="1"/>
   <rect x="187.3" y="805.5" width="44.3" height="14.5" fill="#f59e0b" rx="1"/>
   <rect x="187.3" y="746.8" width="44.3" height="58.6" fill="#c47d08" rx="1"/>
   <rect x="187.3" y="744.4" width="44.3" height="2.5" fill="#f59e0b" rx="1"/>
-  <rect x="233.3" y="798.7" width="44.3" height="21.3" fill="#f472b6" rx="1"/>
-  <rect x="233.3" y="741.1" width="44.3" height="57.6" fill="#c05a92" rx="1"/>
-  <rect x="233.3" y="736.5" width="44.3" height="4.6" fill="#f472b6" rx="1"/>
+  <rect x="233.3" y="799.8" width="44.3" height="20.2" fill="#f472b6" rx="1"/>
+  <rect x="233.3" y="742.2" width="44.3" height="57.6" fill="#c05a92" rx="1"/>
+  <rect x="233.3" y="737.6" width="44.3" height="4.6" fill="#f472b6" rx="1"/>
   <text x="196.7" y="838" text-anchor="middle" fill="#e6edf3" font-size="11" font-weight="600">Level −1</text>
   <rect x="348.7" y="803.0" width="44.3" height="17.0" fill="#60a5fa" rx="1"/>
   <rect x="348.7" y="752.2" width="44.3" height="50.9" fill="#4680c4" rx="1"/>
@@ -131,22 +129,22 @@
   <rect x="440.7" y="785.2" width="44.3" height="34.8" fill="#f59e0b" rx="1"/>
   <rect x="440.7" y="734.4" width="44.3" height="50.9" fill="#c47d08" rx="1"/>
   <rect x="440.7" y="726.0" width="44.3" height="8.3" fill="#f59e0b" rx="1"/>
-  <rect x="486.7" y="778.2" width="44.3" height="41.8" fill="#f472b6" rx="1"/>
-  <rect x="486.7" y="724.0" width="44.3" height="54.2" fill="#c05a92" rx="1"/>
-  <rect x="486.7" y="714.2" width="44.3" height="9.8" fill="#f472b6" rx="1"/>
+  <rect x="486.7" y="779.5" width="44.3" height="40.5" fill="#f472b6" rx="1"/>
+  <rect x="486.7" y="725.3" width="44.3" height="54.2" fill="#c05a92" rx="1"/>
+  <rect x="486.7" y="715.5" width="44.3" height="9.8" fill="#f472b6" rx="1"/>
   <text x="450.0" y="838" text-anchor="middle" fill="#e6edf3" font-size="11" font-weight="600">Level 1</text>
   <rect x="602.0" y="758.9" width="44.3" height="61.1" fill="#60a5fa" rx="1"/>
   <rect x="602.0" y="713.5" width="44.3" height="45.4" fill="#4680c4" rx="1"/>
   <rect x="602.0" y="704.5" width="44.3" height="9.0" fill="#60a5fa" rx="1"/>
-  <rect x="648.0" y="756.7" width="44.3" height="63.3" fill="#f87171" rx="1"/>
-  <rect x="648.0" y="708.0" width="44.3" height="48.7" fill="#c45050" rx="1"/>
-  <rect x="648.0" y="696.4" width="44.3" height="11.6" fill="#f87171" rx="1"/>
+  <rect x="648.0" y="759.8" width="44.3" height="60.2" fill="#f87171" rx="1"/>
+  <rect x="648.0" y="711.1" width="44.3" height="48.7" fill="#c45050" rx="1"/>
+  <rect x="648.0" y="699.5" width="44.3" height="11.6" fill="#f87171" rx="1"/>
   <rect x="694.0" y="704.7" width="44.3" height="115.3" fill="#f59e0b" rx="1"/>
   <rect x="694.0" y="658.6" width="44.3" height="46.1" fill="#c47d08" rx="1"/>
   <rect x="694.0" y="646.1" width="44.3" height="12.5" fill="#f59e0b" rx="1"/>
-  <rect x="740.0" y="735.6" width="44.3" height="84.4" fill="#f472b6" rx="1"/>
-  <rect x="740.0" y="686.9" width="44.3" height="48.7" fill="#c05a92" rx="1"/>
-  <rect x="740.0" y="671.4" width="44.3" height="15.5" fill="#f472b6" rx="1"/>
+  <rect x="740.0" y="741.4" width="44.3" height="78.6" fill="#f472b6" rx="1"/>
+  <rect x="740.0" y="692.7" width="44.3" height="48.7" fill="#c05a92" rx="1"/>
+  <rect x="740.0" y="677.4" width="44.3" height="15.3" fill="#f472b6" rx="1"/>
   <text x="703.3" y="838" text-anchor="middle" fill="#e6edf3" font-size="11" font-weight="600">Level 3</text>
   <rect x="230" y="850" width="12" height="12" fill="#60a5fa" rx="2"/>
   <text x="248" y="860" fill="#e6edf3" font-size="10" font-weight="500">libzstd v1.5.7 (C)</text>

--- a/doc/charts/x86_64/pipeline.svg
+++ b/doc/charts/x86_64/pipeline.svg
@@ -15,15 +15,15 @@
   <rect x="71.1" y="265.5" width="19.4" height="24.5" fill="#60a5fa" rx="1"/>
   <rect x="71.1" y="243.5" width="19.4" height="22.0" fill="#4680c4" rx="1"/>
   <rect x="71.1" y="238.2" width="19.4" height="5.3" fill="#60a5fa" rx="1"/>
-  <rect x="90.5" y="249.2" width="19.4" height="40.8" fill="#f87171" rx="1"/>
-  <rect x="90.5" y="225.8" width="19.4" height="23.5" fill="#c45050" rx="1"/>
-  <rect x="90.5" y="211.1" width="19.4" height="14.7" fill="#f87171" rx="1"/>
+  <rect x="90.5" y="248.6" width="19.4" height="41.4" fill="#f87171" rx="1"/>
+  <rect x="90.5" y="225.2" width="19.4" height="23.5" fill="#c45050" rx="1"/>
+  <rect x="90.5" y="210.3" width="19.4" height="14.9" fill="#f87171" rx="1"/>
   <rect x="109.9" y="252.1" width="19.4" height="37.9" fill="#f59e0b" rx="1"/>
   <rect x="109.9" y="230.1" width="19.4" height="21.9" fill="#c47d08" rx="1"/>
   <rect x="109.9" y="221.0" width="19.4" height="9.1" fill="#f59e0b" rx="1"/>
-  <rect x="129.3" y="229.7" width="19.4" height="60.3" fill="#f472b6" rx="1"/>
-  <rect x="129.3" y="206.2" width="19.4" height="23.5" fill="#c05a92" rx="1"/>
-  <rect x="129.3" y="186.3" width="19.4" height="19.9" fill="#f472b6" rx="1"/>
+  <rect x="129.3" y="233.2" width="19.4" height="56.8" fill="#f472b6" rx="1"/>
+  <rect x="129.3" y="209.7" width="19.4" height="23.5" fill="#c05a92" rx="1"/>
+  <rect x="129.3" y="190.1" width="19.4" height="19.6" fill="#f472b6" rx="1"/>
   <rect x="148.6" y="171.6" width="19.4" height="118.4" fill="#4ade80" rx="1"/>
   <rect x="148.6" y="145.9" width="19.4" height="25.7" fill="#3aaf60" rx="1"/>
   <rect x="148.6" y="106.7" width="19.4" height="39.2" fill="#4ade80" rx="1"/>
@@ -32,15 +32,15 @@
   <rect x="200.3" y="284.5" width="19.4" height="5.5" fill="#60a5fa" rx="1"/>
   <rect x="200.3" y="281.9" width="19.4" height="2.6" fill="#4680c4" rx="1"/>
   <rect x="200.3" y="279.9" width="19.4" height="2.0" fill="#60a5fa" rx="1"/>
-  <rect x="219.7" y="281.6" width="19.4" height="8.4" fill="#f87171" rx="1"/>
-  <rect x="219.7" y="278.6" width="19.4" height="3.0" fill="#c45050" rx="1"/>
-  <rect x="219.7" y="274.4" width="19.4" height="4.2" fill="#f87171" rx="1"/>
+  <rect x="219.7" y="281.8" width="19.4" height="8.2" fill="#f87171" rx="1"/>
+  <rect x="219.7" y="278.7" width="19.4" height="3.0" fill="#c45050" rx="1"/>
+  <rect x="219.7" y="274.5" width="19.4" height="4.3" fill="#f87171" rx="1"/>
   <rect x="239.1" y="279.5" width="19.4" height="10.5" fill="#f59e0b" rx="1"/>
   <rect x="239.1" y="276.8" width="19.4" height="2.6" fill="#c47d08" rx="1"/>
   <rect x="239.1" y="273.9" width="19.4" height="2.9" fill="#f59e0b" rx="1"/>
-  <rect x="258.4" y="278.3" width="19.4" height="11.7" fill="#f472b6" rx="1"/>
-  <rect x="258.4" y="275.2" width="19.4" height="3.0" fill="#c05a92" rx="1"/>
-  <rect x="258.4" y="270.3" width="19.4" height="4.9" fill="#f472b6" rx="1"/>
+  <rect x="258.4" y="278.8" width="19.4" height="11.2" fill="#f472b6" rx="1"/>
+  <rect x="258.4" y="275.7" width="19.4" height="3.0" fill="#c05a92" rx="1"/>
+  <rect x="258.4" y="270.8" width="19.4" height="5.0" fill="#f472b6" rx="1"/>
   <rect x="277.8" y="240.8" width="19.4" height="49.2" fill="#4ade80" rx="1"/>
   <rect x="277.8" y="235.7" width="19.4" height="5.0" fill="#3aaf60" rx="1"/>
   <rect x="277.8" y="226.7" width="19.4" height="9.0" fill="#4ade80" rx="1"/>
@@ -49,15 +49,15 @@
   <rect x="329.5" y="273.4" width="19.4" height="16.6" fill="#60a5fa" rx="1"/>
   <rect x="329.5" y="252.9" width="19.4" height="20.5" fill="#4680c4" rx="1"/>
   <rect x="329.5" y="247.2" width="19.4" height="5.7" fill="#60a5fa" rx="1"/>
-  <rect x="348.9" y="263.6" width="19.4" height="26.4" fill="#f87171" rx="1"/>
-  <rect x="348.9" y="242.1" width="19.4" height="21.6" fill="#c45050" rx="1"/>
-  <rect x="348.9" y="230.5" width="19.4" height="11.5" fill="#f87171" rx="1"/>
+  <rect x="348.9" y="263.5" width="19.4" height="26.5" fill="#f87171" rx="1"/>
+  <rect x="348.9" y="242.0" width="19.4" height="21.6" fill="#c45050" rx="1"/>
+  <rect x="348.9" y="230.5" width="19.4" height="11.4" fill="#f87171" rx="1"/>
   <rect x="368.2" y="259.4" width="19.4" height="30.6" fill="#f59e0b" rx="1"/>
   <rect x="368.2" y="238.7" width="19.4" height="20.7" fill="#c47d08" rx="1"/>
   <rect x="368.2" y="230.2" width="19.4" height="8.5" fill="#f59e0b" rx="1"/>
-  <rect x="387.6" y="251.4" width="19.4" height="38.6" fill="#f472b6" rx="1"/>
-  <rect x="387.6" y="229.8" width="19.4" height="21.6" fill="#c05a92" rx="1"/>
-  <rect x="387.6" y="214.4" width="19.4" height="15.4" fill="#f472b6" rx="1"/>
+  <rect x="387.6" y="254.4" width="19.4" height="35.6" fill="#f472b6" rx="1"/>
+  <rect x="387.6" y="232.9" width="19.4" height="21.6" fill="#c05a92" rx="1"/>
+  <rect x="387.6" y="218.8" width="19.4" height="14.1" fill="#f472b6" rx="1"/>
   <rect x="407.0" y="182.4" width="19.4" height="107.6" fill="#4ade80" rx="1"/>
   <rect x="407.0" y="155.7" width="19.4" height="26.7" fill="#3aaf60" rx="1"/>
   <rect x="407.0" y="133.9" width="19.4" height="21.8" fill="#4ade80" rx="1"/>
@@ -66,15 +66,15 @@
   <rect x="458.6" y="272.0" width="19.4" height="18.0" fill="#60a5fa" rx="1"/>
   <rect x="458.6" y="251.9" width="19.4" height="20.1" fill="#4680c4" rx="1"/>
   <rect x="458.6" y="247.1" width="19.4" height="4.8" fill="#60a5fa" rx="1"/>
-  <rect x="478.0" y="256.6" width="19.4" height="33.4" fill="#f87171" rx="1"/>
-  <rect x="478.0" y="235.1" width="19.4" height="21.5" fill="#c45050" rx="1"/>
-  <rect x="478.0" y="222.4" width="19.4" height="12.7" fill="#f87171" rx="1"/>
+  <rect x="478.0" y="257.0" width="19.4" height="33.0" fill="#f87171" rx="1"/>
+  <rect x="478.0" y="235.5" width="19.4" height="21.5" fill="#c45050" rx="1"/>
+  <rect x="478.0" y="222.7" width="19.4" height="12.8" fill="#f87171" rx="1"/>
   <rect x="497.4" y="258.7" width="19.4" height="31.3" fill="#f59e0b" rx="1"/>
   <rect x="497.4" y="238.7" width="19.4" height="20.1" fill="#c47d08" rx="1"/>
   <rect x="497.4" y="231.2" width="19.4" height="7.5" fill="#f59e0b" rx="1"/>
-  <rect x="516.8" y="241.6" width="19.4" height="48.4" fill="#f472b6" rx="1"/>
-  <rect x="516.8" y="220.1" width="19.4" height="21.5" fill="#c05a92" rx="1"/>
-  <rect x="516.8" y="204.0" width="19.4" height="16.1" fill="#f472b6" rx="1"/>
+  <rect x="516.8" y="243.7" width="19.4" height="46.3" fill="#f472b6" rx="1"/>
+  <rect x="516.8" y="222.2" width="19.4" height="21.5" fill="#c05a92" rx="1"/>
+  <rect x="516.8" y="206.4" width="19.4" height="15.8" fill="#f472b6" rx="1"/>
   <rect x="536.1" y="188.7" width="19.4" height="101.3" fill="#4ade80" rx="1"/>
   <rect x="536.1" y="162.7" width="19.4" height="26.0" fill="#3aaf60" rx="1"/>
   <rect x="536.1" y="135.9" width="19.4" height="26.8" fill="#4ade80" rx="1"/>
@@ -83,15 +83,15 @@
   <rect x="587.8" y="281.2" width="19.4" height="8.8" fill="#60a5fa" rx="1"/>
   <rect x="587.8" y="276.7" width="19.4" height="4.5" fill="#4680c4" rx="1"/>
   <rect x="587.8" y="273.5" width="19.4" height="3.2" fill="#60a5fa" rx="1"/>
-  <rect x="607.2" y="276.8" width="19.4" height="13.2" fill="#f87171" rx="1"/>
-  <rect x="607.2" y="271.4" width="19.4" height="5.3" fill="#c45050" rx="1"/>
-  <rect x="607.2" y="264.9" width="19.4" height="6.5" fill="#f87171" rx="1"/>
+  <rect x="607.2" y="276.9" width="19.4" height="13.1" fill="#f87171" rx="1"/>
+  <rect x="607.2" y="271.6" width="19.4" height="5.3" fill="#c45050" rx="1"/>
+  <rect x="607.2" y="265.1" width="19.4" height="6.5" fill="#f87171" rx="1"/>
   <rect x="626.6" y="273.7" width="19.4" height="16.3" fill="#f59e0b" rx="1"/>
   <rect x="626.6" y="269.2" width="19.4" height="4.5" fill="#c47d08" rx="1"/>
   <rect x="626.6" y="264.3" width="19.4" height="4.9" fill="#f59e0b" rx="1"/>
-  <rect x="645.9" y="270.7" width="19.4" height="19.3" fill="#f472b6" rx="1"/>
-  <rect x="645.9" y="265.4" width="19.4" height="5.3" fill="#c05a92" rx="1"/>
-  <rect x="645.9" y="257.6" width="19.4" height="7.7" fill="#f472b6" rx="1"/>
+  <rect x="645.9" y="271.9" width="19.4" height="18.1" fill="#f472b6" rx="1"/>
+  <rect x="645.9" y="266.6" width="19.4" height="5.3" fill="#c05a92" rx="1"/>
+  <rect x="645.9" y="258.9" width="19.4" height="7.7" fill="#f472b6" rx="1"/>
   <rect x="665.3" y="231.8" width="19.4" height="58.2" fill="#4ade80" rx="1"/>
   <rect x="665.3" y="224.0" width="19.4" height="7.7" fill="#3aaf60" rx="1"/>
   <rect x="665.3" y="209.8" width="19.4" height="14.3" fill="#4ade80" rx="1"/>
@@ -102,13 +102,13 @@
   <rect x="717.0" y="249.4" width="19.4" height="4.7" fill="#60a5fa" rx="1"/>
   <rect x="736.4" y="267.0" width="19.4" height="23.0" fill="#f87171" rx="1"/>
   <rect x="736.4" y="246.4" width="19.4" height="20.6" fill="#c45050" rx="1"/>
-  <rect x="736.4" y="239.1" width="19.4" height="7.3" fill="#f87171" rx="1"/>
+  <rect x="736.4" y="239.0" width="19.4" height="7.4" fill="#f87171" rx="1"/>
   <rect x="755.7" y="262.0" width="19.4" height="28.0" fill="#f59e0b" rx="1"/>
   <rect x="755.7" y="242.6" width="19.4" height="19.4" fill="#c47d08" rx="1"/>
   <rect x="755.7" y="236.2" width="19.4" height="6.4" fill="#f59e0b" rx="1"/>
-  <rect x="775.1" y="256.5" width="19.4" height="33.5" fill="#f472b6" rx="1"/>
-  <rect x="775.1" y="235.9" width="19.4" height="20.6" fill="#c05a92" rx="1"/>
-  <rect x="775.1" y="226.5" width="19.4" height="9.4" fill="#f472b6" rx="1"/>
+  <rect x="775.1" y="258.6" width="19.4" height="31.4" fill="#f472b6" rx="1"/>
+  <rect x="775.1" y="238.0" width="19.4" height="20.6" fill="#c05a92" rx="1"/>
+  <rect x="775.1" y="228.8" width="19.4" height="9.1" fill="#f472b6" rx="1"/>
   <rect x="794.5" y="200.6" width="19.4" height="89.4" fill="#4ade80" rx="1"/>
   <rect x="794.5" y="177.7" width="19.4" height="22.9" fill="#3aaf60" rx="1"/>
   <rect x="794.5" y="162.1" width="19.4" height="15.6" fill="#4ade80" rx="1"/>
@@ -126,15 +126,15 @@
   <rect x="71.1" y="576.2" width="19.4" height="23.8" fill="#60a5fa" rx="1"/>
   <rect x="71.1" y="559.2" width="19.4" height="17.0" fill="#4680c4" rx="1"/>
   <rect x="71.1" y="553.7" width="19.4" height="5.5" fill="#60a5fa" rx="1"/>
-  <rect x="90.5" y="567.0" width="19.4" height="33.0" fill="#f87171" rx="1"/>
+  <rect x="90.5" y="566.9" width="19.4" height="33.1" fill="#f87171" rx="1"/>
   <rect x="90.5" y="548.2" width="19.4" height="18.8" fill="#c45050" rx="1"/>
-  <rect x="90.5" y="535.0" width="19.4" height="13.2" fill="#f87171" rx="1"/>
+  <rect x="90.5" y="534.7" width="19.4" height="13.4" fill="#f87171" rx="1"/>
   <rect x="109.9" y="561.8" width="19.4" height="38.2" fill="#f59e0b" rx="1"/>
   <rect x="109.9" y="544.8" width="19.4" height="17.0" fill="#c47d08" rx="1"/>
   <rect x="109.9" y="535.8" width="19.4" height="9.0" fill="#f59e0b" rx="1"/>
-  <rect x="129.3" y="550.8" width="19.4" height="49.2" fill="#f472b6" rx="1"/>
-  <rect x="129.3" y="532.0" width="19.4" height="18.8" fill="#c05a92" rx="1"/>
-  <rect x="129.3" y="514.1" width="19.4" height="17.9" fill="#f472b6" rx="1"/>
+  <rect x="129.3" y="552.8" width="19.4" height="47.2" fill="#f472b6" rx="1"/>
+  <rect x="129.3" y="534.1" width="19.4" height="18.8" fill="#c05a92" rx="1"/>
+  <rect x="129.3" y="516.5" width="19.4" height="17.5" fill="#f472b6" rx="1"/>
   <rect x="148.6" y="496.9" width="19.4" height="103.1" fill="#4ade80" rx="1"/>
   <rect x="148.6" y="475.1" width="19.4" height="21.8" fill="#3aaf60" rx="1"/>
   <rect x="148.6" y="441.4" width="19.4" height="33.7" fill="#4ade80" rx="1"/>
@@ -143,15 +143,15 @@
   <rect x="200.3" y="586.1" width="19.4" height="13.9" fill="#60a5fa" rx="1"/>
   <rect x="200.3" y="572.8" width="19.4" height="13.3" fill="#4680c4" rx="1"/>
   <rect x="200.3" y="568.8" width="19.4" height="4.0" fill="#60a5fa" rx="1"/>
-  <rect x="219.7" y="579.5" width="19.4" height="20.5" fill="#f87171" rx="1"/>
-  <rect x="219.7" y="564.5" width="19.4" height="15.0" fill="#c45050" rx="1"/>
-  <rect x="219.7" y="556.2" width="19.4" height="8.3" fill="#f87171" rx="1"/>
+  <rect x="219.7" y="579.6" width="19.4" height="20.4" fill="#f87171" rx="1"/>
+  <rect x="219.7" y="564.6" width="19.4" height="15.0" fill="#c45050" rx="1"/>
+  <rect x="219.7" y="556.3" width="19.4" height="8.3" fill="#f87171" rx="1"/>
   <rect x="239.1" y="577.1" width="19.4" height="22.9" fill="#f59e0b" rx="1"/>
   <rect x="239.1" y="563.7" width="19.4" height="13.4" fill="#c47d08" rx="1"/>
   <rect x="239.1" y="557.8" width="19.4" height="5.9" fill="#f59e0b" rx="1"/>
-  <rect x="258.4" y="571.1" width="19.4" height="28.9" fill="#f472b6" rx="1"/>
-  <rect x="258.4" y="556.1" width="19.4" height="15.0" fill="#c05a92" rx="1"/>
-  <rect x="258.4" y="545.3" width="19.4" height="10.8" fill="#f472b6" rx="1"/>
+  <rect x="258.4" y="572.3" width="19.4" height="27.7" fill="#f472b6" rx="1"/>
+  <rect x="258.4" y="557.3" width="19.4" height="15.0" fill="#c05a92" rx="1"/>
+  <rect x="258.4" y="546.7" width="19.4" height="10.6" fill="#f472b6" rx="1"/>
   <rect x="277.8" y="514.4" width="19.4" height="85.6" fill="#4ade80" rx="1"/>
   <rect x="277.8" y="496.7" width="19.4" height="17.8" fill="#3aaf60" rx="1"/>
   <rect x="277.8" y="474.8" width="19.4" height="21.9" fill="#4ade80" rx="1"/>
@@ -160,15 +160,15 @@
   <rect x="329.5" y="578.6" width="19.4" height="21.4" fill="#60a5fa" rx="1"/>
   <rect x="329.5" y="533.4" width="19.4" height="45.2" fill="#4680c4" rx="1"/>
   <rect x="329.5" y="527.7" width="19.4" height="5.7" fill="#60a5fa" rx="1"/>
-  <rect x="348.9" y="578.0" width="19.4" height="22.0" fill="#f87171" rx="1"/>
-  <rect x="348.9" y="532.4" width="19.4" height="45.6" fill="#c45050" rx="1"/>
+  <rect x="348.9" y="577.9" width="19.4" height="22.1" fill="#f87171" rx="1"/>
+  <rect x="348.9" y="532.3" width="19.4" height="45.6" fill="#c45050" rx="1"/>
   <rect x="348.9" y="526.0" width="19.4" height="6.4" fill="#f87171" rx="1"/>
   <rect x="368.2" y="563.0" width="19.4" height="37.0" fill="#f59e0b" rx="1"/>
   <rect x="368.2" y="517.8" width="19.4" height="45.2" fill="#c47d08" rx="1"/>
   <rect x="368.2" y="509.7" width="19.4" height="8.1" fill="#f59e0b" rx="1"/>
-  <rect x="387.6" y="568.9" width="19.4" height="31.1" fill="#f472b6" rx="1"/>
-  <rect x="387.6" y="523.3" width="19.4" height="45.6" fill="#c05a92" rx="1"/>
-  <rect x="387.6" y="515.2" width="19.4" height="8.0" fill="#f472b6" rx="1"/>
+  <rect x="387.6" y="569.9" width="19.4" height="30.1" fill="#f472b6" rx="1"/>
+  <rect x="387.6" y="524.3" width="19.4" height="45.6" fill="#c05a92" rx="1"/>
+  <rect x="387.6" y="516.2" width="19.4" height="8.1" fill="#f472b6" rx="1"/>
   <rect x="407.0" y="447.8" width="19.4" height="152.2" fill="#4ade80" rx="1"/>
   <rect x="407.0" y="404.3" width="19.4" height="43.5" fill="#3aaf60" rx="1"/>
   <rect x="407.0" y="385.9" width="19.4" height="18.4" fill="#4ade80" rx="1"/>
@@ -177,15 +177,15 @@
   <rect x="458.6" y="579.0" width="19.4" height="21.0" fill="#60a5fa" rx="1"/>
   <rect x="458.6" y="561.7" width="19.4" height="17.3" fill="#4680c4" rx="1"/>
   <rect x="458.6" y="556.5" width="19.4" height="5.2" fill="#60a5fa" rx="1"/>
-  <rect x="478.0" y="565.1" width="19.4" height="34.9" fill="#f87171" rx="1"/>
+  <rect x="478.0" y="565.0" width="19.4" height="35.0" fill="#f87171" rx="1"/>
   <rect x="478.0" y="545.9" width="19.4" height="19.1" fill="#c45050" rx="1"/>
-  <rect x="478.0" y="533.4" width="19.4" height="12.5" fill="#f87171" rx="1"/>
+  <rect x="478.0" y="533.3" width="19.4" height="12.6" fill="#f87171" rx="1"/>
   <rect x="497.4" y="566.6" width="19.4" height="33.4" fill="#f59e0b" rx="1"/>
   <rect x="497.4" y="549.3" width="19.4" height="17.3" fill="#c47d08" rx="1"/>
   <rect x="497.4" y="541.5" width="19.4" height="7.8" fill="#f59e0b" rx="1"/>
-  <rect x="516.8" y="551.3" width="19.4" height="48.7" fill="#f472b6" rx="1"/>
-  <rect x="516.8" y="532.2" width="19.4" height="19.1" fill="#c05a92" rx="1"/>
-  <rect x="516.8" y="515.4" width="19.4" height="16.8" fill="#f472b6" rx="1"/>
+  <rect x="516.8" y="552.8" width="19.4" height="47.2" fill="#f472b6" rx="1"/>
+  <rect x="516.8" y="533.7" width="19.4" height="19.1" fill="#c05a92" rx="1"/>
+  <rect x="516.8" y="517.2" width="19.4" height="16.5" fill="#f472b6" rx="1"/>
   <rect x="536.1" y="494.8" width="19.4" height="105.2" fill="#4ade80" rx="1"/>
   <rect x="536.1" y="473.7" width="19.4" height="21.1" fill="#3aaf60" rx="1"/>
   <rect x="536.1" y="441.5" width="19.4" height="32.2" fill="#4ade80" rx="1"/>
@@ -194,15 +194,15 @@
   <rect x="587.8" y="591.4" width="19.4" height="8.6" fill="#60a5fa" rx="1"/>
   <rect x="587.8" y="549.4" width="19.4" height="42.0" fill="#4680c4" rx="1"/>
   <rect x="587.8" y="544.6" width="19.4" height="4.8" fill="#60a5fa" rx="1"/>
-  <rect x="607.2" y="572.1" width="19.4" height="27.9" fill="#f87171" rx="1"/>
-  <rect x="607.2" y="525.2" width="19.4" height="46.9" fill="#c45050" rx="1"/>
+  <rect x="607.2" y="572.2" width="19.4" height="27.8" fill="#f87171" rx="1"/>
+  <rect x="607.2" y="525.3" width="19.4" height="46.9" fill="#c45050" rx="1"/>
   <rect x="607.2" y="517.9" width="19.4" height="7.3" fill="#f87171" rx="1"/>
   <rect x="626.6" y="576.5" width="19.4" height="23.5" fill="#f59e0b" rx="1"/>
   <rect x="626.6" y="534.5" width="19.4" height="42.0" fill="#c47d08" rx="1"/>
   <rect x="626.6" y="528.2" width="19.4" height="6.3" fill="#f59e0b" rx="1"/>
-  <rect x="645.9" y="560.3" width="19.4" height="39.7" fill="#f472b6" rx="1"/>
-  <rect x="645.9" y="513.4" width="19.4" height="46.9" fill="#c05a92" rx="1"/>
-  <rect x="645.9" y="504.7" width="19.4" height="8.7" fill="#f472b6" rx="1"/>
+  <rect x="645.9" y="561.5" width="19.4" height="38.5" fill="#f472b6" rx="1"/>
+  <rect x="645.9" y="514.6" width="19.4" height="46.9" fill="#c05a92" rx="1"/>
+  <rect x="645.9" y="506.0" width="19.4" height="8.6" fill="#f472b6" rx="1"/>
   <rect x="665.3" y="445.8" width="19.4" height="154.2" fill="#4ade80" rx="1"/>
   <rect x="665.3" y="399.6" width="19.4" height="46.1" fill="#3aaf60" rx="1"/>
   <rect x="665.3" y="381.8" width="19.4" height="17.8" fill="#4ade80" rx="1"/>
@@ -211,15 +211,15 @@
   <rect x="717.0" y="589.1" width="19.4" height="10.9" fill="#60a5fa" rx="1"/>
   <rect x="717.0" y="581.7" width="19.4" height="7.4" fill="#4680c4" rx="1"/>
   <rect x="717.0" y="578.3" width="19.4" height="3.5" fill="#60a5fa" rx="1"/>
-  <rect x="736.4" y="583.8" width="19.4" height="16.2" fill="#f87171" rx="1"/>
-  <rect x="736.4" y="575.4" width="19.4" height="8.4" fill="#c45050" rx="1"/>
-  <rect x="736.4" y="568.5" width="19.4" height="6.9" fill="#f87171" rx="1"/>
+  <rect x="736.4" y="583.9" width="19.4" height="16.1" fill="#f87171" rx="1"/>
+  <rect x="736.4" y="575.5" width="19.4" height="8.4" fill="#c45050" rx="1"/>
+  <rect x="736.4" y="568.7" width="19.4" height="6.9" fill="#f87171" rx="1"/>
   <rect x="755.7" y="581.3" width="19.4" height="18.7" fill="#f59e0b" rx="1"/>
   <rect x="755.7" y="573.9" width="19.4" height="7.4" fill="#c47d08" rx="1"/>
   <rect x="755.7" y="569.1" width="19.4" height="4.9" fill="#f59e0b" rx="1"/>
-  <rect x="775.1" y="577.1" width="19.4" height="22.9" fill="#f472b6" rx="1"/>
-  <rect x="775.1" y="568.7" width="19.4" height="8.4" fill="#c05a92" rx="1"/>
-  <rect x="775.1" y="560.0" width="19.4" height="8.7" fill="#f472b6" rx="1"/>
+  <rect x="775.1" y="577.9" width="19.4" height="22.1" fill="#f472b6" rx="1"/>
+  <rect x="775.1" y="569.6" width="19.4" height="8.4" fill="#c05a92" rx="1"/>
+  <rect x="775.1" y="561.0" width="19.4" height="8.6" fill="#f472b6" rx="1"/>
   <rect x="794.5" y="529.9" width="19.4" height="70.1" fill="#4ade80" rx="1"/>
   <rect x="794.5" y="518.1" width="19.4" height="11.8" fill="#3aaf60" rx="1"/>
   <rect x="794.5" y="499.6" width="19.4" height="18.5" fill="#4ade80" rx="1"/>

--- a/doc/charts/x86_64/scatter.svg
+++ b/doc/charts/x86_64/scatter.svg
@@ -42,24 +42,24 @@
   <text x="440.3" y="93.7" text-anchor="start" fill="#60a5fa" font-size="8" font-weight="600">3</text>
   <circle cx="432.6" cy="93.7" r="3.5" fill="#60a5fa" stroke="#0d1117" stroke-width="1"/>
   <text x="426.6" y="93.7" text-anchor="end" fill="#60a5fa" font-size="8" font-weight="600">4</text>
-  <path d="M461.8,249.7L446.5,247.0L441.3,228.1L436.3,216.8L433.7,206.9L429.6,193.4L425.8,175.1L423.7,151.6L411.8,140.9L408.9,137.5L388.0,122.1L379.8,117.0" fill="none" stroke="#f87171" stroke-width="1.5" stroke-opacity="0.6"/>
-  <circle cx="461.8" cy="249.7" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
-  <text x="467.8" y="249.7" text-anchor="start" fill="#f87171" font-size="8" font-weight="600">-8</text>
-  <circle cx="446.5" cy="247.0" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
-  <circle cx="441.3" cy="228.1" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
-  <circle cx="436.3" cy="216.8" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
-  <text x="442.3" y="216.8" text-anchor="start" fill="#f87171" font-size="8" font-weight="600">-5</text>
-  <circle cx="433.7" cy="206.9" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
-  <circle cx="429.6" cy="193.4" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
-  <circle cx="425.8" cy="175.1" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
-  <text x="431.8" y="175.1" text-anchor="start" fill="#f87171" font-size="8" font-weight="600">-2</text>
-  <circle cx="423.7" cy="151.6" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
-  <circle cx="411.8" cy="140.9" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
-  <circle cx="408.9" cy="137.5" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
-  <text x="414.9" y="137.5" text-anchor="start" fill="#f87171" font-size="8" font-weight="600">2</text>
-  <circle cx="388.0" cy="122.1" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
-  <circle cx="379.8" cy="117.0" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
-  <text x="385.8" y="117.0" text-anchor="start" fill="#f87171" font-size="8" font-weight="600">4</text>
+  <path d="M466.8,249.7L449.7,247.0L443.5,228.1L437.8,216.8L435.2,206.9L431.1,193.4L427.5,175.1L425.3,151.6L412.9,140.9L410.1,137.5L391.1,122.1L389.8,117.0" fill="none" stroke="#f87171" stroke-width="1.5" stroke-opacity="0.6"/>
+  <circle cx="466.8" cy="249.7" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
+  <text x="472.8" y="249.7" text-anchor="start" fill="#f87171" font-size="8" font-weight="600">-8</text>
+  <circle cx="449.7" cy="247.0" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
+  <circle cx="443.5" cy="228.1" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
+  <circle cx="437.8" cy="216.8" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
+  <text x="443.8" y="216.8" text-anchor="start" fill="#f87171" font-size="8" font-weight="600">-5</text>
+  <circle cx="435.2" cy="206.9" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
+  <circle cx="431.1" cy="193.4" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
+  <circle cx="427.5" cy="175.1" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
+  <text x="433.5" y="175.1" text-anchor="start" fill="#f87171" font-size="8" font-weight="600">-2</text>
+  <circle cx="425.3" cy="151.6" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
+  <circle cx="412.9" cy="140.9" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
+  <circle cx="410.1" cy="137.5" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
+  <text x="416.1" y="137.5" text-anchor="start" fill="#f87171" font-size="8" font-weight="600">2</text>
+  <circle cx="391.1" cy="122.1" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
+  <circle cx="389.8" cy="117.0" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
+  <text x="395.8" y="117.0" text-anchor="start" fill="#f87171" font-size="8" font-weight="600">4</text>
   <path d="M418.4,236.1L412.9,225.0L409.9,214.8L407.2,200.7L402.4,184.3L398.3,166.6L392.0,153.7L384.3,104.0L376.5,100.7L329.7,93.2L328.5,92.8" fill="none" stroke="#f59e0b" stroke-width="1.5" stroke-opacity="0.6"/>
   <circle cx="418.4" cy="236.1" r="3.5" fill="#f59e0b" stroke="#0d1117" stroke-width="1"/>
   <text x="424.4" y="236.1" text-anchor="start" fill="#f59e0b" font-size="8" font-weight="600">-7</text>
@@ -77,24 +77,24 @@
   <text x="335.7" y="93.2" text-anchor="start" fill="#f59e0b" font-size="8" font-weight="600">3</text>
   <circle cx="328.5" cy="92.8" r="3.5" fill="#f59e0b" stroke="#0d1117" stroke-width="1"/>
   <text x="322.5" y="92.8" text-anchor="end" fill="#f59e0b" font-size="8" font-weight="600">4</text>
-  <path d="M411.5,249.7L399.2,247.0L394.3,228.1L388.3,216.8L386.5,206.9L383.0,193.4L378.6,175.1L377.5,151.6L364.1,140.9L362.4,137.5L340.5,122.1L325.2,117.0" fill="none" stroke="#f472b6" stroke-width="1.5" stroke-opacity="0.6"/>
-  <circle cx="411.5" cy="249.7" r="3.5" fill="#f472b6" stroke="#0d1117" stroke-width="1"/>
-  <text x="417.5" y="249.7" text-anchor="start" fill="#f472b6" font-size="8" font-weight="600">-8</text>
-  <circle cx="399.2" cy="247.0" r="3.5" fill="#f472b6" stroke="#0d1117" stroke-width="1"/>
-  <circle cx="394.3" cy="228.1" r="3.5" fill="#f472b6" stroke="#0d1117" stroke-width="1"/>
-  <circle cx="388.3" cy="216.8" r="3.5" fill="#f472b6" stroke="#0d1117" stroke-width="1"/>
-  <text x="394.3" y="216.8" text-anchor="start" fill="#f472b6" font-size="8" font-weight="600">-5</text>
-  <circle cx="386.5" cy="206.9" r="3.5" fill="#f472b6" stroke="#0d1117" stroke-width="1"/>
-  <circle cx="383.0" cy="193.4" r="3.5" fill="#f472b6" stroke="#0d1117" stroke-width="1"/>
-  <circle cx="378.6" cy="175.1" r="3.5" fill="#f472b6" stroke="#0d1117" stroke-width="1"/>
-  <text x="384.6" y="175.1" text-anchor="start" fill="#f472b6" font-size="8" font-weight="600">-2</text>
-  <circle cx="377.5" cy="151.6" r="3.5" fill="#f472b6" stroke="#0d1117" stroke-width="1"/>
-  <circle cx="364.1" cy="140.9" r="3.5" fill="#f472b6" stroke="#0d1117" stroke-width="1"/>
-  <circle cx="362.4" cy="137.5" r="3.5" fill="#f472b6" stroke="#0d1117" stroke-width="1"/>
-  <text x="368.4" y="137.5" text-anchor="start" fill="#f472b6" font-size="8" font-weight="600">2</text>
-  <circle cx="340.5" cy="122.1" r="3.5" fill="#f472b6" stroke="#0d1117" stroke-width="1"/>
-  <circle cx="325.2" cy="117.0" r="3.5" fill="#f472b6" stroke="#0d1117" stroke-width="1"/>
-  <text x="331.2" y="117.0" text-anchor="start" fill="#f472b6" font-size="8" font-weight="600">4</text>
+  <path d="M418.1,249.7L406.7,247.0L400.7,228.1L394.7,216.8L392.2,206.9L388.3,193.4L384.9,175.1L382.7,151.6L370.0,140.9L369.6,137.5L350.7,122.1L350.1,117.0" fill="none" stroke="#f472b6" stroke-width="1.5" stroke-opacity="0.6"/>
+  <circle cx="418.1" cy="249.7" r="3.5" fill="#f472b6" stroke="#0d1117" stroke-width="1"/>
+  <text x="424.1" y="249.7" text-anchor="start" fill="#f472b6" font-size="8" font-weight="600">-8</text>
+  <circle cx="406.7" cy="247.0" r="3.5" fill="#f472b6" stroke="#0d1117" stroke-width="1"/>
+  <circle cx="400.7" cy="228.1" r="3.5" fill="#f472b6" stroke="#0d1117" stroke-width="1"/>
+  <circle cx="394.7" cy="216.8" r="3.5" fill="#f472b6" stroke="#0d1117" stroke-width="1"/>
+  <text x="400.7" y="216.8" text-anchor="start" fill="#f472b6" font-size="8" font-weight="600">-5</text>
+  <circle cx="392.2" cy="206.9" r="3.5" fill="#f472b6" stroke="#0d1117" stroke-width="1"/>
+  <circle cx="388.3" cy="193.4" r="3.5" fill="#f472b6" stroke="#0d1117" stroke-width="1"/>
+  <circle cx="384.9" cy="175.1" r="3.5" fill="#f472b6" stroke="#0d1117" stroke-width="1"/>
+  <text x="390.9" y="175.1" text-anchor="start" fill="#f472b6" font-size="8" font-weight="600">-2</text>
+  <circle cx="382.7" cy="151.6" r="3.5" fill="#f472b6" stroke="#0d1117" stroke-width="1"/>
+  <circle cx="370.0" cy="140.9" r="3.5" fill="#f472b6" stroke="#0d1117" stroke-width="1"/>
+  <circle cx="369.6" cy="137.5" r="3.5" fill="#f472b6" stroke="#0d1117" stroke-width="1"/>
+  <text x="375.6" y="137.5" text-anchor="start" fill="#f472b6" font-size="8" font-weight="600">2</text>
+  <circle cx="350.7" cy="122.1" r="3.5" fill="#f472b6" stroke="#0d1117" stroke-width="1"/>
+  <circle cx="350.1" cy="117.0" r="3.5" fill="#f472b6" stroke="#0d1117" stroke-width="1"/>
+  <text x="356.1" y="117.0" text-anchor="start" fill="#f472b6" font-size="8" font-weight="600">4</text>
   <circle cx="202.6" cy="212.6" r="3.5" fill="#4ade80" stroke="#0d1117" stroke-width="1"/>
   <text x="208.6" y="212.6" text-anchor="start" fill="#4ade80" font-size="8" font-weight="600">L1</text>
   <circle cx="509.3" cy="230.7" r="3.5" fill="#c084fc" stroke="#0d1117" stroke-width="1"/>
@@ -141,24 +141,24 @@
   <text x="302.8" y="410.9" text-anchor="start" fill="#60a5fa" font-size="8" font-weight="600">3</text>
   <circle cx="293.3" cy="407.3" r="3.5" fill="#60a5fa" stroke="#0d1117" stroke-width="1"/>
   <text x="287.3" y="407.3" text-anchor="end" fill="#60a5fa" font-size="8" font-weight="600">4</text>
-  <path d="M355.6,576.2L341.9,551.5L333.0,539.7L329.6,533.7L326.1,525.8L320.3,513.4L315.3,502.9L310.2,491.8L297.4,474.7L282.2,461.7L254.5,456.2L236.1,448.2" fill="none" stroke="#f87171" stroke-width="1.5" stroke-opacity="0.6"/>
-  <circle cx="355.6" cy="576.2" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
-  <text x="361.6" y="576.2" text-anchor="start" fill="#f87171" font-size="8" font-weight="600">-8</text>
-  <circle cx="341.9" cy="551.5" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
-  <circle cx="333.0" cy="539.7" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
-  <circle cx="329.6" cy="533.7" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
-  <text x="335.6" y="533.7" text-anchor="start" fill="#f87171" font-size="8" font-weight="600">-5</text>
-  <circle cx="326.1" cy="525.8" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
-  <circle cx="320.3" cy="513.4" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
-  <circle cx="315.3" cy="502.9" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
-  <text x="321.3" y="502.9" text-anchor="start" fill="#f87171" font-size="8" font-weight="600">-2</text>
-  <circle cx="310.2" cy="491.8" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
-  <circle cx="297.4" cy="474.7" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
-  <circle cx="282.2" cy="461.7" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
-  <text x="288.2" y="461.7" text-anchor="start" fill="#f87171" font-size="8" font-weight="600">2</text>
-  <circle cx="254.5" cy="456.2" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
-  <circle cx="236.1" cy="448.2" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
-  <text x="242.1" y="448.2" text-anchor="start" fill="#f87171" font-size="8" font-weight="600">4</text>
+  <path d="M358.1,576.2L342.8,551.5L333.8,539.7L330.6,533.7L327.1,525.8L321.4,513.4L316.9,502.9L311.6,491.8L297.1,474.7L284.6,461.7L258.6,456.2L249.6,448.2" fill="none" stroke="#f87171" stroke-width="1.5" stroke-opacity="0.6"/>
+  <circle cx="358.1" cy="576.2" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
+  <text x="364.1" y="576.2" text-anchor="start" fill="#f87171" font-size="8" font-weight="600">-8</text>
+  <circle cx="342.8" cy="551.5" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
+  <circle cx="333.8" cy="539.7" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
+  <circle cx="330.6" cy="533.7" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
+  <text x="336.6" y="533.7" text-anchor="start" fill="#f87171" font-size="8" font-weight="600">-5</text>
+  <circle cx="327.1" cy="525.8" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
+  <circle cx="321.4" cy="513.4" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
+  <circle cx="316.9" cy="502.9" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
+  <text x="322.9" y="502.9" text-anchor="start" fill="#f87171" font-size="8" font-weight="600">-2</text>
+  <circle cx="311.6" cy="491.8" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
+  <circle cx="297.1" cy="474.7" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
+  <circle cx="284.6" cy="461.7" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
+  <text x="290.6" y="461.7" text-anchor="start" fill="#f87171" font-size="8" font-weight="600">2</text>
+  <circle cx="258.6" cy="456.2" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
+  <circle cx="249.6" cy="448.2" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
+  <text x="255.6" y="448.2" text-anchor="start" fill="#f87171" font-size="8" font-weight="600">4</text>
   <path d="M338.2,573.0L335.0,567.5L328.8,559.8L322.6,548.8L315.2,537.2L308.7,525.9L300.2,513.9L286.2,445.5L265.7,426.1L202.3,412.4L201.6,407.6" fill="none" stroke="#f59e0b" stroke-width="1.5" stroke-opacity="0.6"/>
   <circle cx="338.2" cy="573.0" r="3.5" fill="#f59e0b" stroke="#0d1117" stroke-width="1"/>
   <text x="344.2" y="573.0" text-anchor="start" fill="#f59e0b" font-size="8" font-weight="600">-7</text>
@@ -176,24 +176,24 @@
   <text x="208.3" y="412.4" text-anchor="start" fill="#f59e0b" font-size="8" font-weight="600">3</text>
   <circle cx="201.6" cy="407.6" r="3.5" fill="#f59e0b" stroke="#0d1117" stroke-width="1"/>
   <text x="195.6" y="407.6" text-anchor="end" fill="#f59e0b" font-size="8" font-weight="600">4</text>
-  <path d="M308.6,576.2L300.7,551.5L291.5,539.7L287.9,533.7L284.3,525.8L278.5,513.4L273.9,502.9L268.4,491.8L247.4,474.7L238.0,461.7L211.0,456.2L178.1,448.2" fill="none" stroke="#f472b6" stroke-width="1.5" stroke-opacity="0.6"/>
-  <circle cx="308.6" cy="576.2" r="3.5" fill="#f472b6" stroke="#0d1117" stroke-width="1"/>
-  <text x="314.6" y="576.2" text-anchor="start" fill="#f472b6" font-size="8" font-weight="600">-8</text>
-  <circle cx="300.7" cy="551.5" r="3.5" fill="#f472b6" stroke="#0d1117" stroke-width="1"/>
-  <circle cx="291.5" cy="539.7" r="3.5" fill="#f472b6" stroke="#0d1117" stroke-width="1"/>
-  <circle cx="287.9" cy="533.7" r="3.5" fill="#f472b6" stroke="#0d1117" stroke-width="1"/>
-  <text x="293.9" y="533.7" text-anchor="start" fill="#f472b6" font-size="8" font-weight="600">-5</text>
-  <circle cx="284.3" cy="525.8" r="3.5" fill="#f472b6" stroke="#0d1117" stroke-width="1"/>
-  <circle cx="278.5" cy="513.4" r="3.5" fill="#f472b6" stroke="#0d1117" stroke-width="1"/>
-  <circle cx="273.9" cy="502.9" r="3.5" fill="#f472b6" stroke="#0d1117" stroke-width="1"/>
-  <text x="279.9" y="502.9" text-anchor="start" fill="#f472b6" font-size="8" font-weight="600">-2</text>
-  <circle cx="268.4" cy="491.8" r="3.5" fill="#f472b6" stroke="#0d1117" stroke-width="1"/>
-  <circle cx="247.4" cy="474.7" r="3.5" fill="#f472b6" stroke="#0d1117" stroke-width="1"/>
-  <circle cx="238.0" cy="461.7" r="3.5" fill="#f472b6" stroke="#0d1117" stroke-width="1"/>
-  <text x="244.0" y="461.7" text-anchor="start" fill="#f472b6" font-size="8" font-weight="600">2</text>
-  <circle cx="211.0" cy="456.2" r="3.5" fill="#f472b6" stroke="#0d1117" stroke-width="1"/>
-  <circle cx="178.1" cy="448.2" r="3.5" fill="#f472b6" stroke="#0d1117" stroke-width="1"/>
-  <text x="184.1" y="448.2" text-anchor="start" fill="#f472b6" font-size="8" font-weight="600">4</text>
+  <path d="M315.3,576.2L307.1,551.5L297.9,539.7L294.3,533.7L289.8,525.8L284.8,513.4L280.6,502.9L275.0,491.8L254.6,474.7L244.9,461.7L222.5,456.2L213.9,448.2" fill="none" stroke="#f472b6" stroke-width="1.5" stroke-opacity="0.6"/>
+  <circle cx="315.3" cy="576.2" r="3.5" fill="#f472b6" stroke="#0d1117" stroke-width="1"/>
+  <text x="321.3" y="576.2" text-anchor="start" fill="#f472b6" font-size="8" font-weight="600">-8</text>
+  <circle cx="307.1" cy="551.5" r="3.5" fill="#f472b6" stroke="#0d1117" stroke-width="1"/>
+  <circle cx="297.9" cy="539.7" r="3.5" fill="#f472b6" stroke="#0d1117" stroke-width="1"/>
+  <circle cx="294.3" cy="533.7" r="3.5" fill="#f472b6" stroke="#0d1117" stroke-width="1"/>
+  <text x="300.3" y="533.7" text-anchor="start" fill="#f472b6" font-size="8" font-weight="600">-5</text>
+  <circle cx="289.8" cy="525.8" r="3.5" fill="#f472b6" stroke="#0d1117" stroke-width="1"/>
+  <circle cx="284.8" cy="513.4" r="3.5" fill="#f472b6" stroke="#0d1117" stroke-width="1"/>
+  <circle cx="280.6" cy="502.9" r="3.5" fill="#f472b6" stroke="#0d1117" stroke-width="1"/>
+  <text x="286.6" y="502.9" text-anchor="start" fill="#f472b6" font-size="8" font-weight="600">-2</text>
+  <circle cx="275.0" cy="491.8" r="3.5" fill="#f472b6" stroke="#0d1117" stroke-width="1"/>
+  <circle cx="254.6" cy="474.7" r="3.5" fill="#f472b6" stroke="#0d1117" stroke-width="1"/>
+  <circle cx="244.9" cy="461.7" r="3.5" fill="#f472b6" stroke="#0d1117" stroke-width="1"/>
+  <text x="250.9" y="461.7" text-anchor="start" fill="#f472b6" font-size="8" font-weight="600">2</text>
+  <circle cx="222.5" cy="456.2" r="3.5" fill="#f472b6" stroke="#0d1117" stroke-width="1"/>
+  <circle cx="213.9" cy="448.2" r="3.5" fill="#f472b6" stroke="#0d1117" stroke-width="1"/>
+  <text x="219.9" y="448.2" text-anchor="start" fill="#f472b6" font-size="8" font-weight="600">4</text>
   <circle cx="135.3" cy="512.1" r="3.5" fill="#4ade80" stroke="#0d1117" stroke-width="1"/>
   <text x="141.3" y="512.1" text-anchor="start" fill="#4ade80" font-size="8" font-weight="600">L1</text>
   <circle cx="426.9" cy="579.3" r="3.5" fill="#c084fc" stroke="#0d1117" stroke-width="1"/>
@@ -244,24 +244,24 @@
   <text x="241.3" y="767.6" text-anchor="start" fill="#60a5fa" font-size="8" font-weight="600">3</text>
   <circle cx="224.1" cy="742.4" r="3.5" fill="#60a5fa" stroke="#0d1117" stroke-width="1"/>
   <text x="230.1" y="742.4" text-anchor="start" fill="#60a5fa" font-size="8" font-weight="600">4</text>
-  <path d="M652.0,913.3L595.1,909.7L548.2,902.9L533.1,899.3L515.5,897.3L495.2,895.2L451.0,891.5L420.6,884.7L336.1,857.8L263.4,817.1L239.8,807.1L205.2,782.7" fill="none" stroke="#f87171" stroke-width="1.5" stroke-opacity="0.6"/>
-  <circle cx="652.0" cy="913.3" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
-  <text x="658.0" y="913.3" text-anchor="start" fill="#f87171" font-size="8" font-weight="600">-8</text>
-  <circle cx="595.1" cy="909.7" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
-  <circle cx="548.2" cy="902.9" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
-  <circle cx="533.1" cy="899.3" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
-  <text x="539.1" y="899.3" text-anchor="start" fill="#f87171" font-size="8" font-weight="600">-5</text>
-  <circle cx="515.5" cy="897.3" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
-  <circle cx="495.2" cy="895.2" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
-  <circle cx="451.0" cy="891.5" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
-  <text x="457.0" y="891.5" text-anchor="start" fill="#f87171" font-size="8" font-weight="600">-2</text>
-  <circle cx="420.6" cy="884.7" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
-  <circle cx="336.1" cy="857.8" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
-  <circle cx="263.4" cy="817.1" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
-  <text x="269.4" y="817.1" text-anchor="start" fill="#f87171" font-size="8" font-weight="600">2</text>
-  <circle cx="239.8" cy="807.1" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
-  <circle cx="205.2" cy="782.7" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
-  <text x="211.2" y="782.7" text-anchor="start" fill="#f87171" font-size="8" font-weight="600">4</text>
+  <path d="M659.0,913.3L596.6,909.7L549.5,902.9L535.1,899.3L516.5,897.3L495.9,895.2L450.8,891.5L420.2,884.7L336.0,857.8L271.8,817.1L248.8,807.1L221.3,782.7" fill="none" stroke="#f87171" stroke-width="1.5" stroke-opacity="0.6"/>
+  <circle cx="659.0" cy="913.3" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
+  <text x="665.0" y="913.3" text-anchor="start" fill="#f87171" font-size="8" font-weight="600">-8</text>
+  <circle cx="596.6" cy="909.7" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
+  <circle cx="549.5" cy="902.9" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
+  <circle cx="535.1" cy="899.3" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
+  <text x="541.1" y="899.3" text-anchor="start" fill="#f87171" font-size="8" font-weight="600">-5</text>
+  <circle cx="516.5" cy="897.3" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
+  <circle cx="495.9" cy="895.2" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
+  <circle cx="450.8" cy="891.5" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
+  <text x="456.8" y="891.5" text-anchor="start" fill="#f87171" font-size="8" font-weight="600">-2</text>
+  <circle cx="420.2" cy="884.7" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
+  <circle cx="336.0" cy="857.8" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
+  <circle cx="271.8" cy="817.1" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
+  <text x="277.8" y="817.1" text-anchor="start" fill="#f87171" font-size="8" font-weight="600">2</text>
+  <circle cx="248.8" cy="807.1" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
+  <circle cx="221.3" cy="782.7" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
+  <text x="227.3" y="782.7" text-anchor="start" fill="#f87171" font-size="8" font-weight="600">4</text>
   <path d="M553.1,904.5L540.8,900.9L531.4,901.7L524.9,899.3L509.1,897.2L491.8,894.5L473.4,892.0L312.3,828.8L269.4,806.3L148.6,776.3L139.6,752.6" fill="none" stroke="#f59e0b" stroke-width="1.5" stroke-opacity="0.6"/>
   <circle cx="553.1" cy="904.5" r="3.5" fill="#f59e0b" stroke="#0d1117" stroke-width="1"/>
   <text x="559.1" y="904.5" text-anchor="start" fill="#f59e0b" font-size="8" font-weight="600">-7</text>
@@ -279,24 +279,24 @@
   <text x="154.6" y="776.3" text-anchor="start" fill="#f59e0b" font-size="8" font-weight="600">3</text>
   <circle cx="139.6" cy="752.6" r="3.5" fill="#f59e0b" stroke="#0d1117" stroke-width="1"/>
   <text x="145.6" y="752.6" text-anchor="start" fill="#f59e0b" font-size="8" font-weight="600">4</text>
-  <path d="M618.6,913.3L562.5,909.7L514.9,902.9L499.7,899.3L478.7,897.3L457.6,895.2L411.0,891.5L378.4,884.7L288.4,857.8L227.8,817.1L201.4,807.1L155.4,782.7" fill="none" stroke="#f472b6" stroke-width="1.5" stroke-opacity="0.6"/>
-  <circle cx="618.6" cy="913.3" r="3.5" fill="#f472b6" stroke="#0d1117" stroke-width="1"/>
-  <text x="624.6" y="913.3" text-anchor="start" fill="#f472b6" font-size="8" font-weight="600">-8</text>
-  <circle cx="562.5" cy="909.7" r="3.5" fill="#f472b6" stroke="#0d1117" stroke-width="1"/>
-  <circle cx="514.9" cy="902.9" r="3.5" fill="#f472b6" stroke="#0d1117" stroke-width="1"/>
-  <circle cx="499.7" cy="899.3" r="3.5" fill="#f472b6" stroke="#0d1117" stroke-width="1"/>
-  <text x="505.7" y="899.3" text-anchor="start" fill="#f472b6" font-size="8" font-weight="600">-5</text>
-  <circle cx="478.7" cy="897.3" r="3.5" fill="#f472b6" stroke="#0d1117" stroke-width="1"/>
-  <circle cx="457.6" cy="895.2" r="3.5" fill="#f472b6" stroke="#0d1117" stroke-width="1"/>
-  <circle cx="411.0" cy="891.5" r="3.5" fill="#f472b6" stroke="#0d1117" stroke-width="1"/>
-  <text x="417.0" y="891.5" text-anchor="start" fill="#f472b6" font-size="8" font-weight="600">-2</text>
-  <circle cx="378.4" cy="884.7" r="3.5" fill="#f472b6" stroke="#0d1117" stroke-width="1"/>
-  <circle cx="288.4" cy="857.8" r="3.5" fill="#f472b6" stroke="#0d1117" stroke-width="1"/>
-  <circle cx="227.8" cy="817.1" r="3.5" fill="#f472b6" stroke="#0d1117" stroke-width="1"/>
-  <text x="233.8" y="817.1" text-anchor="start" fill="#f472b6" font-size="8" font-weight="600">2</text>
-  <circle cx="201.4" cy="807.1" r="3.5" fill="#f472b6" stroke="#0d1117" stroke-width="1"/>
-  <circle cx="155.4" cy="782.7" r="3.5" fill="#f472b6" stroke="#0d1117" stroke-width="1"/>
-  <text x="161.4" y="782.7" text-anchor="start" fill="#f472b6" font-size="8" font-weight="600">4</text>
+  <path d="M622.4,913.3L568.5,909.7L520.0,902.9L505.9,899.3L485.0,897.3L464.4,895.2L418.6,891.5L385.7,884.7L292.7,857.8L232.8,817.1L212.0,807.1L180.1,782.7" fill="none" stroke="#f472b6" stroke-width="1.5" stroke-opacity="0.6"/>
+  <circle cx="622.4" cy="913.3" r="3.5" fill="#f472b6" stroke="#0d1117" stroke-width="1"/>
+  <text x="628.4" y="913.3" text-anchor="start" fill="#f472b6" font-size="8" font-weight="600">-8</text>
+  <circle cx="568.5" cy="909.7" r="3.5" fill="#f472b6" stroke="#0d1117" stroke-width="1"/>
+  <circle cx="520.0" cy="902.9" r="3.5" fill="#f472b6" stroke="#0d1117" stroke-width="1"/>
+  <circle cx="505.9" cy="899.3" r="3.5" fill="#f472b6" stroke="#0d1117" stroke-width="1"/>
+  <text x="511.9" y="899.3" text-anchor="start" fill="#f472b6" font-size="8" font-weight="600">-5</text>
+  <circle cx="485.0" cy="897.3" r="3.5" fill="#f472b6" stroke="#0d1117" stroke-width="1"/>
+  <circle cx="464.4" cy="895.2" r="3.5" fill="#f472b6" stroke="#0d1117" stroke-width="1"/>
+  <circle cx="418.6" cy="891.5" r="3.5" fill="#f472b6" stroke="#0d1117" stroke-width="1"/>
+  <text x="424.6" y="891.5" text-anchor="start" fill="#f472b6" font-size="8" font-weight="600">-2</text>
+  <circle cx="385.7" cy="884.7" r="3.5" fill="#f472b6" stroke="#0d1117" stroke-width="1"/>
+  <circle cx="292.7" cy="857.8" r="3.5" fill="#f472b6" stroke="#0d1117" stroke-width="1"/>
+  <circle cx="232.8" cy="817.1" r="3.5" fill="#f472b6" stroke="#0d1117" stroke-width="1"/>
+  <text x="238.8" y="817.1" text-anchor="start" fill="#f472b6" font-size="8" font-weight="600">2</text>
+  <circle cx="212.0" cy="807.1" r="3.5" fill="#f472b6" stroke="#0d1117" stroke-width="1"/>
+  <circle cx="180.1" cy="782.7" r="3.5" fill="#f472b6" stroke="#0d1117" stroke-width="1"/>
+  <text x="186.1" y="782.7" text-anchor="start" fill="#f472b6" font-size="8" font-weight="600">4</text>
   <circle cx="88.1" cy="842.5" r="3.5" fill="#4ade80" stroke="#0d1117" stroke-width="1"/>
   <text x="94.1" y="842.5" text-anchor="start" fill="#4ade80" font-size="8" font-weight="600">L1</text>
   <circle cx="712.6" cy="911.7" r="3.5" fill="#c084fc" stroke="#0d1117" stroke-width="1"/>

--- a/doc/charts/x86_64/summary.svg
+++ b/doc/charts/x86_64/summary.svg
@@ -14,17 +14,17 @@
   <rect x="111.0" y="257.9" width="80.0" height="23.4" fill="#4680c4" rx="1"/>
   <rect x="111.0" y="250.8" width="80.0" height="7.1" fill="#60a5fa" rx="1"/>
   <text x="151.0" y="321" text-anchor="middle" fill="#e6edf3" font-size="10" font-weight="600">C zstd</text>
-  <rect x="223.0" y="267.3" width="80.0" height="37.7" fill="#f87171" rx="1"/>
-  <rect x="223.0" y="241.4" width="80.0" height="25.9" fill="#c45050" rx="1"/>
-  <rect x="223.0" y="227.6" width="80.0" height="13.8" fill="#f87171" rx="1"/>
+  <rect x="223.0" y="267.4" width="80.0" height="37.6" fill="#f87171" rx="1"/>
+  <rect x="223.0" y="241.5" width="80.0" height="25.9" fill="#c45050" rx="1"/>
+  <rect x="223.0" y="227.6" width="80.0" height="13.9" fill="#f87171" rx="1"/>
   <text x="263.0" y="321" text-anchor="middle" fill="#e6edf3" font-size="10" font-weight="600">zrip</text>
   <rect x="335.0" y="261.9" width="80.0" height="43.1" fill="#f59e0b" rx="1"/>
   <rect x="335.0" y="238.4" width="80.0" height="23.4" fill="#c47d08" rx="1"/>
   <rect x="335.0" y="227.7" width="80.0" height="10.7" fill="#f59e0b" rx="1"/>
   <text x="375.0" y="321" text-anchor="middle" fill="#e6edf3" font-size="10" font-weight="600">structured-zstd</text>
-  <rect x="447.0" y="251.0" width="80.0" height="54.0" fill="#f472b6" rx="1"/>
-  <rect x="447.0" y="225.1" width="80.0" height="25.9" fill="#c05a92" rx="1"/>
-  <rect x="447.0" y="207.1" width="80.0" height="18.0" fill="#f472b6" rx="1"/>
+  <rect x="447.0" y="253.5" width="80.0" height="51.5" fill="#f472b6" rx="1"/>
+  <rect x="447.0" y="227.6" width="80.0" height="25.9" fill="#c05a92" rx="1"/>
+  <rect x="447.0" y="209.9" width="80.0" height="17.7" fill="#f472b6" rx="1"/>
   <text x="487.0" y="321" text-anchor="middle" fill="#e6edf3" font-size="10" font-weight="600">zrip paranoid</text>
   <rect x="559.0" y="153.5" width="80.0" height="151.5" fill="#4ade80" rx="1"/>
   <rect x="559.0" y="122.8" width="80.0" height="30.7" fill="#3aaf60" rx="1"/>


### PR DESCRIPTION
- Uses `first_chunk::<N>()` for paranoid safe little-endian loads in encode, bitstream, and xxhash primitives.
- Removes a redundant reverse-bitstream fast-refill bound implied by the reader pointer invariant.
- Keeps normal-mode unsafe primitives unchanged.
- Targeted measurements: `dickens.txt` L3 paranoid improved from recent `68.2-71.2` MB/s encode to `74.7` MB/s encode; `mozilla` L3 paranoid decode-only improved from `350.3` MB/s to `367.3` MB/s.