### PR TITLE
Publish JSR package with jsr publish in CI

### DIFF
--- a/.github/workflows/jsr.yml
+++ b/.github/workflows/jsr.yml
@@ -15,9 +15,9 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           targets: wasm32-unknown-unknown
-      - uses: denoland/setup-deno@v2
+      - uses: actions/setup-node@v4
         with:
-          deno-version: v2.x
+          node-version: lts/*
       - run: cargo install wasm-pack
       - run: cd jsr && bash build.sh
-      - run: cd jsr && deno publish
+      - run: cd jsr && npx --yes jsr publish

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+### Changed
+
+- Updated the JSR publish workflow to run `jsr publish` from GitHub Actions
+  for provenance-backed CI publishing.
+
 ## [0.8.3]
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Updated the JSR publish workflow to run `jsr publish` from GitHub Actions
   for provenance-backed CI publishing.
+- Bumped JSR package `@paddor/zrip` to 0.5.3.
 
 ## [0.8.3]
 

--- a/jsr/deno.json
+++ b/jsr/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@paddor/zrip",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "license": "MIT",
   "description": "Pure Rust zstd codec compiled to WebAssembly. Decodes all zstd levels, encodes -8..4, with SIMD auto-detection.",
   "exports": "./src/mod.ts",


### PR DESCRIPTION
- Switches `.github/workflows/jsr.yml` to run `npx --yes jsr publish` under GitHub Actions OIDC.\n- Bumps `@paddor/zrip` to `0.5.3` for CI publishing.