### PR TITLE
Mark functions with caller-upheld preconditions unsafe fn

### DIFF
--- a/crates/core/src/huffman/decode.rs
+++ b/crates/core/src/huffman/decode.rs
@@ -1,4 +1,4 @@
-#![forbid(unsafe_code)]
+#![cfg_attr(feature = "paranoid", forbid(unsafe_code))]
 
 #[cfg(feature = "alloc")]
 use alloc::vec;
@@ -80,9 +80,12 @@ pub fn decode_single_stream_vec(
     #[cfg(all(target_arch = "x86_64", not(feature = "paranoid")))]
     {
         if crate::simd::cpu_tier() >= crate::simd::CpuTier::Bmi2 {
-            let result = super::decode_4stream::decode_single_stream_bmi2_safe(
-                table, table_log, data, output,
-            );
+            // SAFETY: cpu_tier() >= Bmi2 proves BMI2 is available.
+            let result = unsafe {
+                super::decode_4stream::decode_single_stream_bmi2_safe(
+                    table, table_log, data, output,
+                )
+            };
             if result.is_err() {
                 output.clear();
             }
@@ -120,13 +123,16 @@ pub fn decode_4_streams_into(
     #[cfg(all(target_arch = "x86_64", not(feature = "paranoid")))]
     {
         if crate::simd::cpu_tier() >= crate::simd::CpuTier::Bmi2 {
-            let result = super::decode_4stream::decode_4_streams_core_bmi2_safe(
-                table,
-                table_log,
-                data,
-                output_size,
-                output,
-            );
+            // SAFETY: cpu_tier() >= Bmi2 proves BMI2 is available.
+            let result = unsafe {
+                super::decode_4stream::decode_4_streams_core_bmi2_safe(
+                    table,
+                    table_log,
+                    data,
+                    output_size,
+                    output,
+                )
+            };
             if result.is_err() {
                 output.clear();
             }

--- a/crates/core/src/huffman/decode_4stream.rs
+++ b/crates/core/src/huffman/decode_4stream.rs
@@ -16,7 +16,7 @@ fn decode_single_stream_bmi2(
 }
 
 #[cfg(all(target_arch = "x86_64", not(feature = "paranoid")))]
-pub(super) fn decode_single_stream_bmi2_safe(
+pub(super) unsafe fn decode_single_stream_bmi2_safe(
     table: &[HuffmanDecodeEntry],
     table_log: u8,
     data: &[u8],
@@ -39,7 +39,7 @@ fn decode_4_streams_core_bmi2(
 }
 
 #[cfg(all(target_arch = "x86_64", not(feature = "paranoid")))]
-pub(super) fn decode_4_streams_core_bmi2_safe(
+pub(super) unsafe fn decode_4_streams_core_bmi2_safe(
     table: &[HuffmanDecodeEntry],
     table_log: u8,
     data: &[u8],

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -1,9 +1,24 @@
 #![cfg_attr(not(feature = "std"), no_std)]
+#![deny(unsafe_op_in_unsafe_fn)]
 #![cfg_attr(feature = "nightly", feature(optimize_attribute))]
 #![cfg_attr(feature = "paranoid", forbid(unsafe_code))]
 
 #[cfg(feature = "alloc")]
 extern crate alloc;
+
+#[cfg(not(feature = "paranoid"))]
+macro_rules! paranoid_unsafe_call {
+    ($e:expr) => {
+        unsafe { $e }
+    };
+}
+
+#[cfg(feature = "paranoid")]
+macro_rules! paranoid_unsafe_call {
+    ($e:expr) => {
+        $e
+    };
+}
 
 pub mod error;
 pub mod hint;

--- a/crates/core/src/xxhash/mod.rs
+++ b/crates/core/src/xxhash/mod.rs
@@ -31,7 +31,9 @@ pub fn xxh64(data: &[u8], seed: u64) -> u64 {
         let mut v3 = seed;
         let mut v4 = seed.wrapping_sub(PRIME64_1);
 
-        primitives::bulk_rounds(data, &mut v1, &mut v2, &mut v3, &mut v4);
+        paranoid_unsafe_call!(primitives::bulk_rounds(
+            data, &mut v1, &mut v2, &mut v3, &mut v4
+        ));
 
         h64 = v1
             .rotate_left(1)
@@ -135,7 +137,13 @@ impl Xxh64State {
 
         if data.len() >= 32 {
             self.large = true;
-            primitives::bulk_rounds(data, &mut self.v1, &mut self.v2, &mut self.v3, &mut self.v4);
+            paranoid_unsafe_call!(primitives::bulk_rounds(
+                data,
+                &mut self.v1,
+                &mut self.v2,
+                &mut self.v3,
+                &mut self.v4
+            ));
             let consumed = data.len() & !31;
             data = &data[consumed..];
         }

--- a/crates/core/src/xxhash/primitives.rs
+++ b/crates/core/src/xxhash/primitives.rs
@@ -32,7 +32,13 @@ pub(crate) fn read_u64_le(data: &[u8], offset: usize) -> u64 {
 
 #[cfg(not(feature = "paranoid"))]
 #[inline(always)]
-pub(super) fn bulk_rounds(data: &[u8], v1: &mut u64, v2: &mut u64, v3: &mut u64, v4: &mut u64) {
+pub(super) unsafe fn bulk_rounds(
+    data: &[u8],
+    v1: &mut u64,
+    v2: &mut u64,
+    v3: &mut u64,
+    v4: &mut u64,
+) {
     let len = data.len();
     debug_assert!(len >= 32);
 

--- a/crates/decode/src/exec.rs
+++ b/crates/decode/src/exec.rs
@@ -1,4 +1,4 @@
-#![forbid(unsafe_code)]
+#![cfg_attr(feature = "paranoid", forbid(unsafe_code))]
 
 #[cfg(feature = "alloc")]
 use alloc::vec::Vec;
@@ -44,7 +44,7 @@ pub(crate) fn decode_execute_sequences<const HAS_HISTORY: bool>(
     macro_rules! table_entry {
         ($table:expr, $state:expr) => {{
             let idx = ($state & FSE_SEQ_TABLE_MASK) as usize;
-            $table.get(idx)
+            paranoid_unsafe_call!($table.get(idx))
         }};
     }
     macro_rules! compute_offset_local {
@@ -263,7 +263,7 @@ pub(crate) fn decode_execute_single_sequence<const HAS_HISTORY: bool>(
     macro_rules! table_entry {
         ($table:expr, $state:expr) => {{
             let idx = ($state & FSE_SEQ_TABLE_MASK) as usize;
-            $table.get(idx)
+            paranoid_unsafe_call!($table.get(idx))
         }};
     }
 

--- a/crates/decode/src/lib.rs
+++ b/crates/decode/src/lib.rs
@@ -1,9 +1,24 @@
 #![cfg_attr(not(feature = "std"), no_std)]
+#![deny(unsafe_op_in_unsafe_fn)]
 #![cfg_attr(feature = "nightly", feature(optimize_attribute))]
 #![cfg_attr(feature = "paranoid", forbid(unsafe_code))]
 
 #[cfg(feature = "alloc")]
 extern crate alloc;
+
+#[cfg(not(feature = "paranoid"))]
+macro_rules! paranoid_unsafe_call {
+    ($e:expr) => {
+        unsafe { $e }
+    };
+}
+
+#[cfg(feature = "paranoid")]
+macro_rules! paranoid_unsafe_call {
+    ($e:expr) => {
+        $e
+    };
+}
 
 pub(crate) mod block_decoder;
 #[cfg(feature = "std")]

--- a/crates/decode/src/seq_table.rs
+++ b/crates/decode/src/seq_table.rs
@@ -45,7 +45,7 @@ impl SeqTable {
 
     #[cfg(not(feature = "paranoid"))]
     #[inline(always)]
-    pub(crate) fn get(&self, idx: usize) -> FseSeqDecodeEntry {
+    pub(crate) unsafe fn get(&self, idx: usize) -> FseSeqDecodeEntry {
         debug_assert!(idx < self.initialized);
         // SAFETY: The FSE state machine bounds idx to [0, 1 << accuracy_log).
         // promote_* initializes all entries in that range. set_single is used
@@ -189,7 +189,7 @@ mod tests {
         let mut table = SeqTable::promote_ll(&fse);
         table.set_single(seq_entry(17));
 
-        assert_eq!(table.get(0).baseline_value, 17);
+        assert_eq!(paranoid_unsafe_call!(table.get(0)).baseline_value, 17);
     }
 
     #[test]
@@ -218,7 +218,7 @@ mod tests {
         ];
         let table = SeqTable::promote_of(&fse);
 
-        assert_eq!(table.get(0).baseline_value, 1);
-        assert_eq!(table.get(1).baseline_value, 2);
+        assert_eq!(paranoid_unsafe_call!(table.get(0)).baseline_value, 1);
+        assert_eq!(paranoid_unsafe_call!(table.get(1)).baseline_value, 2);
     }
 }

--- a/crates/encode/src/dfast.rs
+++ b/crates/encode/src/dfast.rs
@@ -10,81 +10,33 @@ use crate::strategy::LevelParams;
 use zrip_core::Sequence;
 use zrip_core::hash::{PRIME32_1, PRIME64_1};
 
-#[cfg(not(feature = "paranoid"))]
-macro_rules! rd32 {
-    ($src:expr, $pos:expr) => {{
-        // SAFETY: dfast.rs only calls rd32 at positions guarded by block limits
-        // or previously validated match positions.
-        unsafe { primitives::rd32($src, $pos) }
-    }};
-}
-
-#[cfg(feature = "paranoid")]
 macro_rules! rd32 {
     ($src:expr, $pos:expr) => {
-        primitives::rd32($src, $pos)
+        paranoid_unsafe_call!(primitives::rd32($src, $pos))
     };
 }
 
-#[cfg(not(feature = "paranoid"))]
-macro_rules! rd64 {
-    ($src:expr, $pos:expr) => {{
-        // SAFETY: dfast.rs only calls rd64 at positions guarded by block limits
-        // or previously validated match positions.
-        unsafe { primitives::rd64($src, $pos) }
-    }};
-}
-
-#[cfg(feature = "paranoid")]
 macro_rules! rd64 {
     ($src:expr, $pos:expr) => {
-        primitives::rd64($src, $pos)
+        paranoid_unsafe_call!(primitives::rd64($src, $pos))
     };
 }
 
-#[cfg(not(feature = "paranoid"))]
-macro_rules! hash_load {
-    ($table:expr, $idx:expr) => {{
-        // SAFETY: hash indexes are produced from table-sized hash logs.
-        unsafe { primitives::hash_load($table, $idx) }
-    }};
-}
-
-#[cfg(feature = "paranoid")]
 macro_rules! hash_load {
     ($table:expr, $idx:expr) => {
-        primitives::hash_load($table, $idx)
+        paranoid_unsafe_call!(primitives::hash_load($table, $idx))
     };
 }
 
-#[cfg(not(feature = "paranoid"))]
-macro_rules! hash_store {
-    ($table:expr, $idx:expr, $val:expr) => {{
-        // SAFETY: hash indexes are produced from table-sized hash logs.
-        unsafe { primitives::hash_store($table, $idx, $val) }
-    }};
-}
-
-#[cfg(feature = "paranoid")]
 macro_rules! hash_store {
     ($table:expr, $idx:expr, $val:expr) => {
-        primitives::hash_store($table, $idx, $val)
+        paranoid_unsafe_call!(primitives::hash_store($table, $idx, $val))
     };
 }
 
-#[cfg(not(feature = "paranoid"))]
-macro_rules! count_match {
-    ($src:expr, $p1:expr, $p2:expr, $limit:expr) => {{
-        // SAFETY: all call sites pass positions within the current block with
-        // p2 behind p1 and limit bounded by the block end.
-        unsafe { primitives::count_match($src, $p1, $p2, $limit) }
-    }};
-}
-
-#[cfg(feature = "paranoid")]
 macro_rules! count_match {
     ($src:expr, $p1:expr, $p2:expr, $limit:expr) => {
-        primitives::count_match($src, $p1, $p2, $limit)
+        paranoid_unsafe_call!(primitives::count_match($src, $p1, $p2, $limit))
     };
 }
 

--- a/crates/encode/src/fast.rs
+++ b/crates/encode/src/fast.rs
@@ -11,97 +11,39 @@ use zrip_core::Sequence;
 use zrip_core::hash::{PRIME32_1, PRIME64_1};
 use zrip_core::hint::unlikely;
 
-#[cfg(not(feature = "paranoid"))]
-macro_rules! rd32 {
-    ($src:expr, $pos:expr) => {{
-        // SAFETY: fast.rs only calls rd32 at positions guarded by the block
-        // limits or by previously validated match positions.
-        unsafe { primitives::rd32($src, $pos) }
-    }};
-}
-
-#[cfg(feature = "paranoid")]
 macro_rules! rd32 {
     ($src:expr, $pos:expr) => {
-        primitives::rd32($src, $pos)
+        paranoid_unsafe_call!(primitives::rd32($src, $pos))
     };
 }
 
-#[cfg(not(feature = "paranoid"))]
-macro_rules! rd64 {
-    ($src:expr, $pos:expr) => {{
-        // SAFETY: fast.rs only calls rd64 at positions guarded by the block
-        // limits or by previously validated match positions.
-        unsafe { primitives::rd64($src, $pos) }
-    }};
-}
-
-#[cfg(feature = "paranoid")]
 macro_rules! rd64 {
     ($src:expr, $pos:expr) => {
-        primitives::rd64($src, $pos)
+        paranoid_unsafe_call!(primitives::rd64($src, $pos))
     };
 }
 
-#[cfg(not(feature = "paranoid"))]
-macro_rules! hash_load {
-    ($table:expr, $idx:expr) => {{
-        // SAFETY: hash indexes are produced from table-sized hash logs.
-        unsafe { primitives::hash_load($table, $idx) }
-    }};
-}
-
-#[cfg(feature = "paranoid")]
 macro_rules! hash_load {
     ($table:expr, $idx:expr) => {
-        primitives::hash_load($table, $idx)
+        paranoid_unsafe_call!(primitives::hash_load($table, $idx))
     };
 }
 
-#[cfg(not(feature = "paranoid"))]
-macro_rules! hash_store {
-    ($table:expr, $idx:expr, $val:expr) => {{
-        // SAFETY: hash indexes are produced from table-sized hash logs.
-        unsafe { primitives::hash_store($table, $idx, $val) }
-    }};
-}
-
-#[cfg(feature = "paranoid")]
 macro_rules! hash_store {
     ($table:expr, $idx:expr, $val:expr) => {
-        primitives::hash_store($table, $idx, $val)
+        paranoid_unsafe_call!(primitives::hash_store($table, $idx, $val))
     };
 }
 
-#[cfg(not(feature = "paranoid"))]
-macro_rules! count_match {
-    ($src:expr, $p1:expr, $p2:expr, $limit:expr) => {{
-        // SAFETY: all call sites pass positions within the current block with
-        // p2 behind p1 and limit bounded by the block end.
-        unsafe { primitives::count_match($src, $p1, $p2, $limit) }
-    }};
-}
-
-#[cfg(feature = "paranoid")]
 macro_rules! count_match {
     ($src:expr, $p1:expr, $p2:expr, $limit:expr) => {
-        primitives::count_match($src, $p1, $p2, $limit)
+        paranoid_unsafe_call!(primitives::count_match($src, $p1, $p2, $limit))
     };
 }
 
-#[cfg(not(feature = "paranoid"))]
-macro_rules! match_at {
-    ($src:expr, $a:expr, $b:expr, $mls:expr) => {{
-        // SAFETY: match candidates are checked against block bounds before
-        // reaching this comparison.
-        unsafe { primitives::match_at::<$mls>($src, $a, $b) }
-    }};
-}
-
-#[cfg(feature = "paranoid")]
 macro_rules! match_at {
     ($src:expr, $a:expr, $b:expr, $mls:expr) => {
-        primitives::match_at::<$mls>($src, $a, $b)
+        paranoid_unsafe_call!(primitives::match_at::<$mls>($src, $a, $b))
     };
 }
 

--- a/crates/encode/src/lib.rs
+++ b/crates/encode/src/lib.rs
@@ -1,9 +1,24 @@
 #![cfg_attr(not(feature = "std"), no_std)]
+#![deny(unsafe_op_in_unsafe_fn)]
 #![cfg_attr(feature = "nightly", feature(optimize_attribute))]
 #![cfg_attr(feature = "paranoid", forbid(unsafe_code))]
 
 #[cfg(feature = "alloc")]
 extern crate alloc;
+
+#[cfg(not(feature = "paranoid"))]
+macro_rules! paranoid_unsafe_call {
+    ($e:expr) => {
+        unsafe { $e }
+    };
+}
+
+#[cfg(feature = "paranoid")]
+macro_rules! paranoid_unsafe_call {
+    ($e:expr) => {
+        $e
+    };
+}
 
 pub(crate) mod block_encoder;
 #[cfg(feature = "std")]

--- a/doc/charts/x86_64/matrix.svg
+++ b/doc/charts/x86_64/matrix.svg
@@ -6,98 +6,98 @@
   <text x="450.0" y="64" text-anchor="middle" fill="#e6edf3" font-size="12" font-weight="600">High compressibility</text>
   <line x1="70" y1="223.8" x2="830" y2="223.8" stroke="#21262d" stroke-width="1"/>
   <text x="62" y="223.8" text-anchor="end" dominant-baseline="middle" fill="#7d8590" font-size="10">2.0</text>
-  <line x1="70" y1="177.5" x2="830" y2="177.5" stroke="#21262d" stroke-width="1"/>
-  <text x="62" y="177.5" text-anchor="end" dominant-baseline="middle" fill="#7d8590" font-size="10">4.0</text>
+  <line x1="70" y1="177.6" x2="830" y2="177.6" stroke="#21262d" stroke-width="1"/>
+  <text x="62" y="177.6" text-anchor="end" dominant-baseline="middle" fill="#7d8590" font-size="10">4.0</text>
   <line x1="70" y1="131.3" x2="830" y2="131.3" stroke="#21262d" stroke-width="1"/>
   <text x="62" y="131.3" text-anchor="end" dominant-baseline="middle" fill="#7d8590" font-size="10">6.0</text>
-  <line x1="70" y1="85.0" x2="830" y2="85.0" stroke="#21262d" stroke-width="1"/>
-  <text x="62" y="85.0" text-anchor="end" dominant-baseline="middle" fill="#7d8590" font-size="10">8.0</text>
+  <line x1="70" y1="85.1" x2="830" y2="85.1" stroke="#21262d" stroke-width="1"/>
+  <text x="62" y="85.1" text-anchor="end" dominant-baseline="middle" fill="#7d8590" font-size="10">8.0</text>
   <line x1="70" y1="270" x2="830" y2="270" stroke="#30363d" stroke-width="1.5"/>
-  <rect x="95.3" y="227.7" width="44.3" height="42.3" fill="#60a5fa" rx="1"/>
+  <rect x="95.3" y="227.8" width="44.3" height="42.2" fill="#60a5fa" rx="1"/>
   <rect x="95.3" y="189.3" width="44.3" height="38.4" fill="#4680c4" rx="1"/>
   <rect x="95.3" y="175.4" width="44.3" height="13.9" fill="#60a5fa" rx="1"/>
-  <rect x="141.3" y="207.8" width="44.3" height="62.2" fill="#f87171" rx="1"/>
-  <rect x="141.3" y="168.9" width="44.3" height="38.9" fill="#c45050" rx="1"/>
-  <rect x="141.3" y="142.1" width="44.3" height="26.8" fill="#f87171" rx="1"/>
+  <rect x="141.3" y="205.2" width="44.3" height="64.8" fill="#f87171" rx="1"/>
+  <rect x="141.3" y="166.3" width="44.3" height="38.9" fill="#c45050" rx="1"/>
+  <rect x="141.3" y="138.7" width="44.3" height="27.5" fill="#f87171" rx="1"/>
   <rect x="187.3" y="194.5" width="44.3" height="75.5" fill="#f59e0b" rx="1"/>
-  <rect x="187.3" y="155.9" width="44.3" height="38.5" fill="#c47d08" rx="1"/>
+  <rect x="187.3" y="156.0" width="44.3" height="38.5" fill="#c47d08" rx="1"/>
   <rect x="187.3" y="134.8" width="44.3" height="21.2" fill="#f59e0b" rx="1"/>
-  <rect x="233.3" y="186.1" width="44.3" height="83.9" fill="#f472b6" rx="1"/>
-  <rect x="233.3" y="147.2" width="44.3" height="38.9" fill="#c05a92" rx="1"/>
-  <rect x="233.3" y="114.3" width="44.3" height="32.8" fill="#f472b6" rx="1"/>
+  <rect x="233.3" y="183.8" width="44.3" height="86.2" fill="#f472b6" rx="1"/>
+  <rect x="233.3" y="144.9" width="44.3" height="38.9" fill="#c05a92" rx="1"/>
+  <rect x="233.3" y="111.8" width="44.3" height="33.1" fill="#f472b6" rx="1"/>
   <text x="196.7" y="288" text-anchor="middle" fill="#e6edf3" font-size="11" font-weight="600">Level −1</text>
   <rect x="348.7" y="224.9" width="44.3" height="45.1" fill="#60a5fa" rx="1"/>
   <rect x="348.7" y="192.6" width="44.3" height="32.3" fill="#4680c4" rx="1"/>
-  <rect x="348.7" y="177.7" width="44.3" height="14.8" fill="#60a5fa" rx="1"/>
-  <rect x="394.7" y="203.2" width="44.3" height="66.8" fill="#f87171" rx="1"/>
-  <rect x="394.7" y="166.1" width="44.3" height="37.1" fill="#c45050" rx="1"/>
-  <rect x="394.7" y="135.8" width="44.3" height="30.3" fill="#f87171" rx="1"/>
+  <rect x="348.7" y="177.8" width="44.3" height="14.8" fill="#60a5fa" rx="1"/>
+  <rect x="394.7" y="200.9" width="44.3" height="69.1" fill="#f87171" rx="1"/>
+  <rect x="394.7" y="163.9" width="44.3" height="37.0" fill="#c45050" rx="1"/>
+  <rect x="394.7" y="132.7" width="44.3" height="31.2" fill="#f87171" rx="1"/>
   <rect x="440.7" y="190.7" width="44.3" height="79.3" fill="#f59e0b" rx="1"/>
   <rect x="440.7" y="158.3" width="44.3" height="32.4" fill="#c47d08" rx="1"/>
-  <rect x="440.7" y="136.2" width="44.3" height="22.1" fill="#f59e0b" rx="1"/>
-  <rect x="486.7" y="178.6" width="44.3" height="91.4" fill="#f472b6" rx="1"/>
-  <rect x="486.7" y="141.5" width="44.3" height="37.1" fill="#c05a92" rx="1"/>
-  <rect x="486.7" y="104.5" width="44.3" height="37.1" fill="#f472b6" rx="1"/>
+  <rect x="440.7" y="136.3" width="44.3" height="22.1" fill="#f59e0b" rx="1"/>
+  <rect x="486.7" y="176.3" width="44.3" height="93.7" fill="#f472b6" rx="1"/>
+  <rect x="486.7" y="139.3" width="44.3" height="37.0" fill="#c05a92" rx="1"/>
+  <rect x="486.7" y="102.0" width="44.3" height="37.3" fill="#f472b6" rx="1"/>
   <text x="450.0" y="288" text-anchor="middle" fill="#e6edf3" font-size="11" font-weight="600">Level 1</text>
   <rect x="602.0" y="211.5" width="44.3" height="58.5" fill="#60a5fa" rx="1"/>
-  <rect x="602.0" y="181.2" width="44.3" height="30.3" fill="#4680c4" rx="1"/>
-  <rect x="602.0" y="165.8" width="44.3" height="15.5" fill="#60a5fa" rx="1"/>
-  <rect x="648.0" y="194.1" width="44.3" height="75.9" fill="#f87171" rx="1"/>
-  <rect x="648.0" y="160.1" width="44.3" height="34.0" fill="#c45050" rx="1"/>
-  <rect x="648.0" y="133.2" width="44.3" height="26.9" fill="#f87171" rx="1"/>
+  <rect x="602.0" y="181.3" width="44.3" height="30.3" fill="#4680c4" rx="1"/>
+  <rect x="602.0" y="165.8" width="44.3" height="15.4" fill="#60a5fa" rx="1"/>
+  <rect x="648.0" y="189.3" width="44.3" height="80.7" fill="#f87171" rx="1"/>
+  <rect x="648.0" y="155.4" width="44.3" height="34.0" fill="#c45050" rx="1"/>
+  <rect x="648.0" y="127.7" width="44.3" height="27.7" fill="#f87171" rx="1"/>
   <rect x="694.0" y="149.7" width="44.3" height="120.3" fill="#f59e0b" rx="1"/>
   <rect x="694.0" y="119.4" width="44.3" height="30.3" fill="#c47d08" rx="1"/>
-  <rect x="694.0" y="96.1" width="44.3" height="23.3" fill="#f59e0b" rx="1"/>
-  <rect x="740.0" y="168.1" width="44.3" height="101.9" fill="#f472b6" rx="1"/>
-  <rect x="740.0" y="134.1" width="44.3" height="34.0" fill="#c05a92" rx="1"/>
-  <rect x="740.0" y="100.9" width="44.3" height="33.2" fill="#f472b6" rx="1"/>
+  <rect x="694.0" y="96.2" width="44.3" height="23.3" fill="#f59e0b" rx="1"/>
+  <rect x="740.0" y="163.5" width="44.3" height="106.5" fill="#f472b6" rx="1"/>
+  <rect x="740.0" y="129.5" width="44.3" height="34.0" fill="#c05a92" rx="1"/>
+  <rect x="740.0" y="96.1" width="44.3" height="33.4" fill="#f472b6" rx="1"/>
   <text x="703.3" y="288" text-anchor="middle" fill="#e6edf3" font-size="11" font-weight="600">Level 3</text>
   <text x="450.0" y="339" text-anchor="middle" fill="#e6edf3" font-size="12" font-weight="600">Medium compressibility</text>
-  <line x1="70" y1="492.5" x2="830" y2="492.5" stroke="#21262d" stroke-width="1"/>
-  <text x="62" y="492.5" text-anchor="end" dominant-baseline="middle" fill="#7d8590" font-size="10">5.0</text>
-  <line x1="70" y1="440.0" x2="830" y2="440.0" stroke="#21262d" stroke-width="1"/>
-  <text x="62" y="440.0" text-anchor="end" dominant-baseline="middle" fill="#7d8590" font-size="10">10.0</text>
-  <line x1="70" y1="387.5" x2="830" y2="387.5" stroke="#21262d" stroke-width="1"/>
-  <text x="62" y="387.5" text-anchor="end" dominant-baseline="middle" fill="#7d8590" font-size="10">15.0</text>
+  <line x1="70" y1="493.5" x2="830" y2="493.5" stroke="#21262d" stroke-width="1"/>
+  <text x="62" y="493.5" text-anchor="end" dominant-baseline="middle" fill="#7d8590" font-size="10">5.0</text>
+  <line x1="70" y1="442.0" x2="830" y2="442.0" stroke="#21262d" stroke-width="1"/>
+  <text x="62" y="442.0" text-anchor="end" dominant-baseline="middle" fill="#7d8590" font-size="10">10.0</text>
+  <line x1="70" y1="390.6" x2="830" y2="390.6" stroke="#21262d" stroke-width="1"/>
+  <text x="62" y="390.6" text-anchor="end" dominant-baseline="middle" fill="#7d8590" font-size="10">15.0</text>
   <line x1="70" y1="545" x2="830" y2="545" stroke="#30363d" stroke-width="1.5"/>
-  <rect x="95.3" y="509.6" width="44.3" height="35.4" fill="#60a5fa" rx="1"/>
-  <rect x="95.3" y="463.3" width="44.3" height="46.3" fill="#4680c4" rx="1"/>
-  <rect x="95.3" y="454.2" width="44.3" height="9.1" fill="#60a5fa" rx="1"/>
-  <rect x="141.3" y="489.5" width="44.3" height="55.5" fill="#f87171" rx="1"/>
-  <rect x="141.3" y="445.5" width="44.3" height="44.0" fill="#c45050" rx="1"/>
-  <rect x="141.3" y="425.5" width="44.3" height="20.0" fill="#f87171" rx="1"/>
-  <rect x="187.3" y="487.2" width="44.3" height="57.8" fill="#f59e0b" rx="1"/>
-  <rect x="187.3" y="440.7" width="44.3" height="46.5" fill="#c47d08" rx="1"/>
-  <rect x="187.3" y="426.4" width="44.3" height="14.3" fill="#f59e0b" rx="1"/>
-  <rect x="233.3" y="472.3" width="44.3" height="72.7" fill="#f472b6" rx="1"/>
-  <rect x="233.3" y="428.3" width="44.3" height="44.0" fill="#c05a92" rx="1"/>
-  <rect x="233.3" y="402.7" width="44.3" height="25.6" fill="#f472b6" rx="1"/>
+  <rect x="95.3" y="510.3" width="44.3" height="34.7" fill="#60a5fa" rx="1"/>
+  <rect x="95.3" y="464.9" width="44.3" height="45.4" fill="#4680c4" rx="1"/>
+  <rect x="95.3" y="455.9" width="44.3" height="9.0" fill="#60a5fa" rx="1"/>
+  <rect x="141.3" y="487.6" width="44.3" height="57.4" fill="#f87171" rx="1"/>
+  <rect x="141.3" y="444.5" width="44.3" height="43.2" fill="#c45050" rx="1"/>
+  <rect x="141.3" y="424.4" width="44.3" height="20.0" fill="#f87171" rx="1"/>
+  <rect x="187.3" y="488.3" width="44.3" height="56.7" fill="#f59e0b" rx="1"/>
+  <rect x="187.3" y="442.7" width="44.3" height="45.6" fill="#c47d08" rx="1"/>
+  <rect x="187.3" y="428.7" width="44.3" height="14.0" fill="#f59e0b" rx="1"/>
+  <rect x="233.3" y="470.3" width="44.3" height="74.7" fill="#f472b6" rx="1"/>
+  <rect x="233.3" y="427.1" width="44.3" height="43.2" fill="#c05a92" rx="1"/>
+  <rect x="233.3" y="401.8" width="44.3" height="25.3" fill="#f472b6" rx="1"/>
   <text x="196.7" y="563" text-anchor="middle" fill="#e6edf3" font-size="11" font-weight="600">Level −1</text>
-  <rect x="348.7" y="506.8" width="44.3" height="38.2" fill="#60a5fa" rx="1"/>
-  <rect x="348.7" y="468.2" width="44.3" height="38.6" fill="#4680c4" rx="1"/>
-  <rect x="348.7" y="457.5" width="44.3" height="10.7" fill="#60a5fa" rx="1"/>
-  <rect x="394.7" y="483.1" width="44.3" height="61.9" fill="#f87171" rx="1"/>
-  <rect x="394.7" y="441.7" width="44.3" height="41.4" fill="#c45050" rx="1"/>
-  <rect x="394.7" y="417.8" width="44.3" height="23.9" fill="#f87171" rx="1"/>
-  <rect x="440.7" y="480.4" width="44.3" height="64.6" fill="#f59e0b" rx="1"/>
-  <rect x="440.7" y="441.6" width="44.3" height="38.7" fill="#c47d08" rx="1"/>
-  <rect x="440.7" y="425.4" width="44.3" height="16.3" fill="#f59e0b" rx="1"/>
-  <rect x="486.7" y="460.9" width="44.3" height="84.1" fill="#f472b6" rx="1"/>
-  <rect x="486.7" y="419.5" width="44.3" height="41.4" fill="#c05a92" rx="1"/>
-  <rect x="486.7" y="389.1" width="44.3" height="30.4" fill="#f472b6" rx="1"/>
+  <rect x="348.7" y="507.5" width="44.3" height="37.5" fill="#60a5fa" rx="1"/>
+  <rect x="348.7" y="469.7" width="44.3" height="37.8" fill="#4680c4" rx="1"/>
+  <rect x="348.7" y="459.2" width="44.3" height="10.5" fill="#60a5fa" rx="1"/>
+  <rect x="394.7" y="482.2" width="44.3" height="62.8" fill="#f87171" rx="1"/>
+  <rect x="394.7" y="441.6" width="44.3" height="40.6" fill="#c45050" rx="1"/>
+  <rect x="394.7" y="417.6" width="44.3" height="24.0" fill="#f87171" rx="1"/>
+  <rect x="440.7" y="481.6" width="44.3" height="63.4" fill="#f59e0b" rx="1"/>
+  <rect x="440.7" y="443.6" width="44.3" height="38.0" fill="#c47d08" rx="1"/>
+  <rect x="440.7" y="427.7" width="44.3" height="15.9" fill="#f59e0b" rx="1"/>
+  <rect x="486.7" y="459.4" width="44.3" height="85.6" fill="#f472b6" rx="1"/>
+  <rect x="486.7" y="418.8" width="44.3" height="40.6" fill="#c05a92" rx="1"/>
+  <rect x="486.7" y="388.8" width="44.3" height="30.0" fill="#f472b6" rx="1"/>
   <text x="450.0" y="563" text-anchor="middle" fill="#e6edf3" font-size="11" font-weight="600">Level 1</text>
-  <rect x="602.0" y="482.1" width="44.3" height="62.9" fill="#60a5fa" rx="1"/>
-  <rect x="602.0" y="447.3" width="44.3" height="34.8" fill="#4680c4" rx="1"/>
-  <rect x="602.0" y="434.9" width="44.3" height="12.3" fill="#60a5fa" rx="1"/>
-  <rect x="648.0" y="464.5" width="44.3" height="80.5" fill="#f87171" rx="1"/>
-  <rect x="648.0" y="425.8" width="44.3" height="38.7" fill="#c45050" rx="1"/>
-  <rect x="648.0" y="405.2" width="44.3" height="20.7" fill="#f87171" rx="1"/>
-  <rect x="694.0" y="425.1" width="44.3" height="119.9" fill="#f59e0b" rx="1"/>
-  <rect x="694.0" y="389.9" width="44.3" height="35.2" fill="#c47d08" rx="1"/>
-  <rect x="694.0" y="371.1" width="44.3" height="18.8" fill="#f59e0b" rx="1"/>
-  <rect x="740.0" y="440.4" width="44.3" height="104.6" fill="#f472b6" rx="1"/>
-  <rect x="740.0" y="401.8" width="44.3" height="38.7" fill="#c05a92" rx="1"/>
-  <rect x="740.0" y="374.2" width="44.3" height="27.5" fill="#f472b6" rx="1"/>
+  <rect x="602.0" y="483.3" width="44.3" height="61.7" fill="#60a5fa" rx="1"/>
+  <rect x="602.0" y="449.1" width="44.3" height="34.2" fill="#4680c4" rx="1"/>
+  <rect x="602.0" y="437.1" width="44.3" height="12.1" fill="#60a5fa" rx="1"/>
+  <rect x="648.0" y="461.1" width="44.3" height="83.9" fill="#f87171" rx="1"/>
+  <rect x="648.0" y="423.2" width="44.3" height="37.9" fill="#c45050" rx="1"/>
+  <rect x="648.0" y="402.5" width="44.3" height="20.7" fill="#f87171" rx="1"/>
+  <rect x="694.0" y="427.4" width="44.3" height="117.6" fill="#f59e0b" rx="1"/>
+  <rect x="694.0" y="392.9" width="44.3" height="34.5" fill="#c47d08" rx="1"/>
+  <rect x="694.0" y="374.4" width="44.3" height="18.4" fill="#f59e0b" rx="1"/>
+  <rect x="740.0" y="436.1" width="44.3" height="108.9" fill="#f472b6" rx="1"/>
+  <rect x="740.0" y="398.2" width="44.3" height="37.9" fill="#c05a92" rx="1"/>
+  <rect x="740.0" y="371.1" width="44.3" height="27.1" fill="#f472b6" rx="1"/>
   <text x="703.3" y="563" text-anchor="middle" fill="#e6edf3" font-size="11" font-weight="600">Level 3</text>
   <text x="450.0" y="614" text-anchor="middle" fill="#e6edf3" font-size="12" font-weight="600">Low compressibility</text>
   <line x1="70" y1="758.6" x2="830" y2="758.6" stroke="#21262d" stroke-width="1"/>
@@ -110,41 +110,41 @@
   <rect x="95.3" y="809.5" width="44.3" height="10.5" fill="#60a5fa" rx="1"/>
   <rect x="95.3" y="750.9" width="44.3" height="58.6" fill="#4680c4" rx="1"/>
   <rect x="95.3" y="749.4" width="44.3" height="1.5" fill="#60a5fa" rx="1"/>
-  <rect x="141.3" y="804.3" width="44.3" height="15.7" fill="#f87171" rx="1"/>
-  <rect x="141.3" y="746.7" width="44.3" height="57.6" fill="#c45050" rx="1"/>
-  <rect x="141.3" y="742.9" width="44.3" height="3.8" fill="#f87171" rx="1"/>
+  <rect x="141.3" y="804.1" width="44.3" height="15.9" fill="#f87171" rx="1"/>
+  <rect x="141.3" y="746.6" width="44.3" height="57.6" fill="#c45050" rx="1"/>
+  <rect x="141.3" y="742.6" width="44.3" height="4.0" fill="#f87171" rx="1"/>
   <rect x="187.3" y="805.5" width="44.3" height="14.5" fill="#f59e0b" rx="1"/>
   <rect x="187.3" y="746.8" width="44.3" height="58.6" fill="#c47d08" rx="1"/>
   <rect x="187.3" y="744.4" width="44.3" height="2.5" fill="#f59e0b" rx="1"/>
-  <rect x="233.3" y="799.8" width="44.3" height="20.2" fill="#f472b6" rx="1"/>
-  <rect x="233.3" y="742.2" width="44.3" height="57.6" fill="#c05a92" rx="1"/>
-  <rect x="233.3" y="737.6" width="44.3" height="4.6" fill="#f472b6" rx="1"/>
+  <rect x="233.3" y="799.2" width="44.3" height="20.8" fill="#f472b6" rx="1"/>
+  <rect x="233.3" y="741.7" width="44.3" height="57.6" fill="#c05a92" rx="1"/>
+  <rect x="233.3" y="736.9" width="44.3" height="4.7" fill="#f472b6" rx="1"/>
   <text x="196.7" y="838" text-anchor="middle" fill="#e6edf3" font-size="11" font-weight="600">Level −1</text>
   <rect x="348.7" y="803.0" width="44.3" height="17.0" fill="#60a5fa" rx="1"/>
   <rect x="348.7" y="752.2" width="44.3" height="50.9" fill="#4680c4" rx="1"/>
   <rect x="348.7" y="746.1" width="44.3" height="6.1" fill="#60a5fa" rx="1"/>
-  <rect x="394.7" y="790.6" width="44.3" height="29.4" fill="#f87171" rx="1"/>
-  <rect x="394.7" y="736.4" width="44.3" height="54.2" fill="#c45050" rx="1"/>
-  <rect x="394.7" y="728.3" width="44.3" height="8.1" fill="#f87171" rx="1"/>
+  <rect x="394.7" y="790.3" width="44.3" height="29.7" fill="#f87171" rx="1"/>
+  <rect x="394.7" y="736.1" width="44.3" height="54.2" fill="#c45050" rx="1"/>
+  <rect x="394.7" y="727.9" width="44.3" height="8.2" fill="#f87171" rx="1"/>
   <rect x="440.7" y="785.2" width="44.3" height="34.8" fill="#f59e0b" rx="1"/>
   <rect x="440.7" y="734.4" width="44.3" height="50.9" fill="#c47d08" rx="1"/>
   <rect x="440.7" y="726.0" width="44.3" height="8.3" fill="#f59e0b" rx="1"/>
-  <rect x="486.7" y="779.5" width="44.3" height="40.5" fill="#f472b6" rx="1"/>
-  <rect x="486.7" y="725.3" width="44.3" height="54.2" fill="#c05a92" rx="1"/>
-  <rect x="486.7" y="715.5" width="44.3" height="9.8" fill="#f472b6" rx="1"/>
+  <rect x="486.7" y="778.3" width="44.3" height="41.7" fill="#f472b6" rx="1"/>
+  <rect x="486.7" y="724.1" width="44.3" height="54.2" fill="#c05a92" rx="1"/>
+  <rect x="486.7" y="714.3" width="44.3" height="9.8" fill="#f472b6" rx="1"/>
   <text x="450.0" y="838" text-anchor="middle" fill="#e6edf3" font-size="11" font-weight="600">Level 1</text>
   <rect x="602.0" y="758.9" width="44.3" height="61.1" fill="#60a5fa" rx="1"/>
   <rect x="602.0" y="713.5" width="44.3" height="45.4" fill="#4680c4" rx="1"/>
   <rect x="602.0" y="704.5" width="44.3" height="9.0" fill="#60a5fa" rx="1"/>
-  <rect x="648.0" y="759.8" width="44.3" height="60.2" fill="#f87171" rx="1"/>
-  <rect x="648.0" y="711.1" width="44.3" height="48.7" fill="#c45050" rx="1"/>
-  <rect x="648.0" y="699.5" width="44.3" height="11.6" fill="#f87171" rx="1"/>
+  <rect x="648.0" y="756.0" width="44.3" height="64.0" fill="#f87171" rx="1"/>
+  <rect x="648.0" y="707.3" width="44.3" height="48.7" fill="#c45050" rx="1"/>
+  <rect x="648.0" y="695.5" width="44.3" height="11.9" fill="#f87171" rx="1"/>
   <rect x="694.0" y="704.7" width="44.3" height="115.3" fill="#f59e0b" rx="1"/>
   <rect x="694.0" y="658.6" width="44.3" height="46.1" fill="#c47d08" rx="1"/>
   <rect x="694.0" y="646.1" width="44.3" height="12.5" fill="#f59e0b" rx="1"/>
-  <rect x="740.0" y="741.4" width="44.3" height="78.6" fill="#f472b6" rx="1"/>
-  <rect x="740.0" y="692.7" width="44.3" height="48.7" fill="#c05a92" rx="1"/>
-  <rect x="740.0" y="677.4" width="44.3" height="15.3" fill="#f472b6" rx="1"/>
+  <rect x="740.0" y="737.2" width="44.3" height="82.8" fill="#f472b6" rx="1"/>
+  <rect x="740.0" y="688.5" width="44.3" height="48.7" fill="#c05a92" rx="1"/>
+  <rect x="740.0" y="673.1" width="44.3" height="15.4" fill="#f472b6" rx="1"/>
   <text x="703.3" y="838" text-anchor="middle" fill="#e6edf3" font-size="11" font-weight="600">Level 3</text>
   <rect x="230" y="850" width="12" height="12" fill="#60a5fa" rx="2"/>
   <text x="248" y="860" fill="#e6edf3" font-size="10" font-weight="500">libzstd v1.5.7 (C)</text>

--- a/doc/charts/x86_64/pipeline.svg
+++ b/doc/charts/x86_64/pipeline.svg
@@ -15,15 +15,15 @@
   <rect x="71.1" y="265.5" width="19.4" height="24.5" fill="#60a5fa" rx="1"/>
   <rect x="71.1" y="243.5" width="19.4" height="22.0" fill="#4680c4" rx="1"/>
   <rect x="71.1" y="238.2" width="19.4" height="5.3" fill="#60a5fa" rx="1"/>
-  <rect x="90.5" y="248.6" width="19.4" height="41.4" fill="#f87171" rx="1"/>
-  <rect x="90.5" y="225.2" width="19.4" height="23.5" fill="#c45050" rx="1"/>
-  <rect x="90.5" y="210.3" width="19.4" height="14.9" fill="#f87171" rx="1"/>
+  <rect x="90.5" y="248.3" width="19.4" height="41.7" fill="#f87171" rx="1"/>
+  <rect x="90.5" y="224.9" width="19.4" height="23.5" fill="#c45050" rx="1"/>
+  <rect x="90.5" y="209.5" width="19.4" height="15.4" fill="#f87171" rx="1"/>
   <rect x="109.9" y="252.1" width="19.4" height="37.9" fill="#f59e0b" rx="1"/>
   <rect x="109.9" y="230.1" width="19.4" height="21.9" fill="#c47d08" rx="1"/>
   <rect x="109.9" y="221.0" width="19.4" height="9.1" fill="#f59e0b" rx="1"/>
-  <rect x="129.3" y="233.2" width="19.4" height="56.8" fill="#f472b6" rx="1"/>
-  <rect x="129.3" y="209.7" width="19.4" height="23.5" fill="#c05a92" rx="1"/>
-  <rect x="129.3" y="190.1" width="19.4" height="19.6" fill="#f472b6" rx="1"/>
+  <rect x="129.3" y="232.4" width="19.4" height="57.6" fill="#f472b6" rx="1"/>
+  <rect x="129.3" y="208.9" width="19.4" height="23.5" fill="#c05a92" rx="1"/>
+  <rect x="129.3" y="189.2" width="19.4" height="19.7" fill="#f472b6" rx="1"/>
   <rect x="148.6" y="171.6" width="19.4" height="118.4" fill="#4ade80" rx="1"/>
   <rect x="148.6" y="145.9" width="19.4" height="25.7" fill="#3aaf60" rx="1"/>
   <rect x="148.6" y="106.7" width="19.4" height="39.2" fill="#4ade80" rx="1"/>
@@ -32,15 +32,15 @@
   <rect x="200.3" y="284.5" width="19.4" height="5.5" fill="#60a5fa" rx="1"/>
   <rect x="200.3" y="281.9" width="19.4" height="2.6" fill="#4680c4" rx="1"/>
   <rect x="200.3" y="279.9" width="19.4" height="2.0" fill="#60a5fa" rx="1"/>
-  <rect x="219.7" y="281.8" width="19.4" height="8.2" fill="#f87171" rx="1"/>
-  <rect x="219.7" y="278.7" width="19.4" height="3.0" fill="#c45050" rx="1"/>
-  <rect x="219.7" y="274.5" width="19.4" height="4.3" fill="#f87171" rx="1"/>
+  <rect x="219.7" y="281.5" width="19.4" height="8.5" fill="#f87171" rx="1"/>
+  <rect x="219.7" y="278.5" width="19.4" height="3.0" fill="#c45050" rx="1"/>
+  <rect x="219.7" y="274.1" width="19.4" height="4.3" fill="#f87171" rx="1"/>
   <rect x="239.1" y="279.5" width="19.4" height="10.5" fill="#f59e0b" rx="1"/>
   <rect x="239.1" y="276.8" width="19.4" height="2.6" fill="#c47d08" rx="1"/>
   <rect x="239.1" y="273.9" width="19.4" height="2.9" fill="#f59e0b" rx="1"/>
-  <rect x="258.4" y="278.8" width="19.4" height="11.2" fill="#f472b6" rx="1"/>
-  <rect x="258.4" y="275.7" width="19.4" height="3.0" fill="#c05a92" rx="1"/>
-  <rect x="258.4" y="270.8" width="19.4" height="5.0" fill="#f472b6" rx="1"/>
+  <rect x="258.4" y="278.6" width="19.4" height="11.4" fill="#f472b6" rx="1"/>
+  <rect x="258.4" y="275.6" width="19.4" height="3.0" fill="#c05a92" rx="1"/>
+  <rect x="258.4" y="270.6" width="19.4" height="5.0" fill="#f472b6" rx="1"/>
   <rect x="277.8" y="240.8" width="19.4" height="49.2" fill="#4ade80" rx="1"/>
   <rect x="277.8" y="235.7" width="19.4" height="5.0" fill="#3aaf60" rx="1"/>
   <rect x="277.8" y="226.7" width="19.4" height="9.0" fill="#4ade80" rx="1"/>
@@ -49,15 +49,15 @@
   <rect x="329.5" y="273.4" width="19.4" height="16.6" fill="#60a5fa" rx="1"/>
   <rect x="329.5" y="252.9" width="19.4" height="20.5" fill="#4680c4" rx="1"/>
   <rect x="329.5" y="247.2" width="19.4" height="5.7" fill="#60a5fa" rx="1"/>
-  <rect x="348.9" y="263.5" width="19.4" height="26.5" fill="#f87171" rx="1"/>
-  <rect x="348.9" y="242.0" width="19.4" height="21.6" fill="#c45050" rx="1"/>
-  <rect x="348.9" y="230.5" width="19.4" height="11.4" fill="#f87171" rx="1"/>
+  <rect x="348.9" y="262.1" width="19.4" height="27.9" fill="#f87171" rx="1"/>
+  <rect x="348.9" y="240.5" width="19.4" height="21.6" fill="#c45050" rx="1"/>
+  <rect x="348.9" y="228.9" width="19.4" height="11.6" fill="#f87171" rx="1"/>
   <rect x="368.2" y="259.4" width="19.4" height="30.6" fill="#f59e0b" rx="1"/>
   <rect x="368.2" y="238.7" width="19.4" height="20.7" fill="#c47d08" rx="1"/>
   <rect x="368.2" y="230.2" width="19.4" height="8.5" fill="#f59e0b" rx="1"/>
-  <rect x="387.6" y="254.4" width="19.4" height="35.6" fill="#f472b6" rx="1"/>
-  <rect x="387.6" y="232.9" width="19.4" height="21.6" fill="#c05a92" rx="1"/>
-  <rect x="387.6" y="218.8" width="19.4" height="14.1" fill="#f472b6" rx="1"/>
+  <rect x="387.6" y="252.5" width="19.4" height="37.5" fill="#f472b6" rx="1"/>
+  <rect x="387.6" y="231.0" width="19.4" height="21.6" fill="#c05a92" rx="1"/>
+  <rect x="387.6" y="216.9" width="19.4" height="14.1" fill="#f472b6" rx="1"/>
   <rect x="407.0" y="182.4" width="19.4" height="107.6" fill="#4ade80" rx="1"/>
   <rect x="407.0" y="155.7" width="19.4" height="26.7" fill="#3aaf60" rx="1"/>
   <rect x="407.0" y="133.9" width="19.4" height="21.8" fill="#4ade80" rx="1"/>
@@ -66,15 +66,15 @@
   <rect x="458.6" y="272.0" width="19.4" height="18.0" fill="#60a5fa" rx="1"/>
   <rect x="458.6" y="251.9" width="19.4" height="20.1" fill="#4680c4" rx="1"/>
   <rect x="458.6" y="247.1" width="19.4" height="4.8" fill="#60a5fa" rx="1"/>
-  <rect x="478.0" y="257.0" width="19.4" height="33.0" fill="#f87171" rx="1"/>
-  <rect x="478.0" y="235.5" width="19.4" height="21.5" fill="#c45050" rx="1"/>
-  <rect x="478.0" y="222.7" width="19.4" height="12.8" fill="#f87171" rx="1"/>
+  <rect x="478.0" y="256.8" width="19.4" height="33.2" fill="#f87171" rx="1"/>
+  <rect x="478.0" y="235.3" width="19.4" height="21.5" fill="#c45050" rx="1"/>
+  <rect x="478.0" y="222.1" width="19.4" height="13.1" fill="#f87171" rx="1"/>
   <rect x="497.4" y="258.7" width="19.4" height="31.3" fill="#f59e0b" rx="1"/>
   <rect x="497.4" y="238.7" width="19.4" height="20.1" fill="#c47d08" rx="1"/>
   <rect x="497.4" y="231.2" width="19.4" height="7.5" fill="#f59e0b" rx="1"/>
-  <rect x="516.8" y="243.7" width="19.4" height="46.3" fill="#f472b6" rx="1"/>
-  <rect x="516.8" y="222.2" width="19.4" height="21.5" fill="#c05a92" rx="1"/>
-  <rect x="516.8" y="206.4" width="19.4" height="15.8" fill="#f472b6" rx="1"/>
+  <rect x="516.8" y="243.2" width="19.4" height="46.8" fill="#f472b6" rx="1"/>
+  <rect x="516.8" y="221.7" width="19.4" height="21.5" fill="#c05a92" rx="1"/>
+  <rect x="516.8" y="205.8" width="19.4" height="15.9" fill="#f472b6" rx="1"/>
   <rect x="536.1" y="188.7" width="19.4" height="101.3" fill="#4ade80" rx="1"/>
   <rect x="536.1" y="162.7" width="19.4" height="26.0" fill="#3aaf60" rx="1"/>
   <rect x="536.1" y="135.9" width="19.4" height="26.8" fill="#4ade80" rx="1"/>
@@ -83,15 +83,15 @@
   <rect x="587.8" y="281.2" width="19.4" height="8.8" fill="#60a5fa" rx="1"/>
   <rect x="587.8" y="276.7" width="19.4" height="4.5" fill="#4680c4" rx="1"/>
   <rect x="587.8" y="273.5" width="19.4" height="3.2" fill="#60a5fa" rx="1"/>
-  <rect x="607.2" y="276.9" width="19.4" height="13.1" fill="#f87171" rx="1"/>
-  <rect x="607.2" y="271.6" width="19.4" height="5.3" fill="#c45050" rx="1"/>
-  <rect x="607.2" y="265.1" width="19.4" height="6.5" fill="#f87171" rx="1"/>
+  <rect x="607.2" y="276.2" width="19.4" height="13.8" fill="#f87171" rx="1"/>
+  <rect x="607.2" y="270.9" width="19.4" height="5.3" fill="#c45050" rx="1"/>
+  <rect x="607.2" y="264.2" width="19.4" height="6.7" fill="#f87171" rx="1"/>
   <rect x="626.6" y="273.7" width="19.4" height="16.3" fill="#f59e0b" rx="1"/>
   <rect x="626.6" y="269.2" width="19.4" height="4.5" fill="#c47d08" rx="1"/>
   <rect x="626.6" y="264.3" width="19.4" height="4.9" fill="#f59e0b" rx="1"/>
-  <rect x="645.9" y="271.9" width="19.4" height="18.1" fill="#f472b6" rx="1"/>
-  <rect x="645.9" y="266.6" width="19.4" height="5.3" fill="#c05a92" rx="1"/>
-  <rect x="645.9" y="258.9" width="19.4" height="7.7" fill="#f472b6" rx="1"/>
+  <rect x="645.9" y="271.3" width="19.4" height="18.7" fill="#f472b6" rx="1"/>
+  <rect x="645.9" y="265.9" width="19.4" height="5.3" fill="#c05a92" rx="1"/>
+  <rect x="645.9" y="258.2" width="19.4" height="7.7" fill="#f472b6" rx="1"/>
   <rect x="665.3" y="231.8" width="19.4" height="58.2" fill="#4ade80" rx="1"/>
   <rect x="665.3" y="224.0" width="19.4" height="7.7" fill="#3aaf60" rx="1"/>
   <rect x="665.3" y="209.8" width="19.4" height="14.3" fill="#4ade80" rx="1"/>
@@ -100,15 +100,15 @@
   <rect x="717.0" y="273.4" width="19.4" height="16.6" fill="#60a5fa" rx="1"/>
   <rect x="717.0" y="254.0" width="19.4" height="19.4" fill="#4680c4" rx="1"/>
   <rect x="717.0" y="249.4" width="19.4" height="4.7" fill="#60a5fa" rx="1"/>
-  <rect x="736.4" y="267.0" width="19.4" height="23.0" fill="#f87171" rx="1"/>
-  <rect x="736.4" y="246.4" width="19.4" height="20.6" fill="#c45050" rx="1"/>
-  <rect x="736.4" y="239.0" width="19.4" height="7.4" fill="#f87171" rx="1"/>
+  <rect x="736.4" y="266.8" width="19.4" height="23.2" fill="#f87171" rx="1"/>
+  <rect x="736.4" y="246.2" width="19.4" height="20.6" fill="#c45050" rx="1"/>
+  <rect x="736.4" y="238.6" width="19.4" height="7.6" fill="#f87171" rx="1"/>
   <rect x="755.7" y="262.0" width="19.4" height="28.0" fill="#f59e0b" rx="1"/>
   <rect x="755.7" y="242.6" width="19.4" height="19.4" fill="#c47d08" rx="1"/>
   <rect x="755.7" y="236.2" width="19.4" height="6.4" fill="#f59e0b" rx="1"/>
-  <rect x="775.1" y="258.6" width="19.4" height="31.4" fill="#f472b6" rx="1"/>
-  <rect x="775.1" y="238.0" width="19.4" height="20.6" fill="#c05a92" rx="1"/>
-  <rect x="775.1" y="228.8" width="19.4" height="9.1" fill="#f472b6" rx="1"/>
+  <rect x="775.1" y="258.0" width="19.4" height="32.0" fill="#f472b6" rx="1"/>
+  <rect x="775.1" y="237.4" width="19.4" height="20.6" fill="#c05a92" rx="1"/>
+  <rect x="775.1" y="228.2" width="19.4" height="9.2" fill="#f472b6" rx="1"/>
   <rect x="794.5" y="200.6" width="19.4" height="89.4" fill="#4ade80" rx="1"/>
   <rect x="794.5" y="177.7" width="19.4" height="22.9" fill="#3aaf60" rx="1"/>
   <rect x="794.5" y="162.1" width="19.4" height="15.6" fill="#4ade80" rx="1"/>
@@ -126,15 +126,15 @@
   <rect x="71.1" y="576.2" width="19.4" height="23.8" fill="#60a5fa" rx="1"/>
   <rect x="71.1" y="559.2" width="19.4" height="17.0" fill="#4680c4" rx="1"/>
   <rect x="71.1" y="553.7" width="19.4" height="5.5" fill="#60a5fa" rx="1"/>
-  <rect x="90.5" y="566.9" width="19.4" height="33.1" fill="#f87171" rx="1"/>
-  <rect x="90.5" y="548.2" width="19.4" height="18.8" fill="#c45050" rx="1"/>
-  <rect x="90.5" y="534.7" width="19.4" height="13.4" fill="#f87171" rx="1"/>
+  <rect x="90.5" y="566.5" width="19.4" height="33.5" fill="#f87171" rx="1"/>
+  <rect x="90.5" y="547.8" width="19.4" height="18.8" fill="#c45050" rx="1"/>
+  <rect x="90.5" y="534.0" width="19.4" height="13.8" fill="#f87171" rx="1"/>
   <rect x="109.9" y="561.8" width="19.4" height="38.2" fill="#f59e0b" rx="1"/>
   <rect x="109.9" y="544.8" width="19.4" height="17.0" fill="#c47d08" rx="1"/>
   <rect x="109.9" y="535.8" width="19.4" height="9.0" fill="#f59e0b" rx="1"/>
-  <rect x="129.3" y="552.8" width="19.4" height="47.2" fill="#f472b6" rx="1"/>
-  <rect x="129.3" y="534.1" width="19.4" height="18.8" fill="#c05a92" rx="1"/>
-  <rect x="129.3" y="516.5" width="19.4" height="17.5" fill="#f472b6" rx="1"/>
+  <rect x="129.3" y="552.0" width="19.4" height="48.0" fill="#f472b6" rx="1"/>
+  <rect x="129.3" y="533.2" width="19.4" height="18.8" fill="#c05a92" rx="1"/>
+  <rect x="129.3" y="515.6" width="19.4" height="17.6" fill="#f472b6" rx="1"/>
   <rect x="148.6" y="496.9" width="19.4" height="103.1" fill="#4ade80" rx="1"/>
   <rect x="148.6" y="475.1" width="19.4" height="21.8" fill="#3aaf60" rx="1"/>
   <rect x="148.6" y="441.4" width="19.4" height="33.7" fill="#4ade80" rx="1"/>
@@ -143,15 +143,15 @@
   <rect x="200.3" y="586.1" width="19.4" height="13.9" fill="#60a5fa" rx="1"/>
   <rect x="200.3" y="572.8" width="19.4" height="13.3" fill="#4680c4" rx="1"/>
   <rect x="200.3" y="568.8" width="19.4" height="4.0" fill="#60a5fa" rx="1"/>
-  <rect x="219.7" y="579.6" width="19.4" height="20.4" fill="#f87171" rx="1"/>
-  <rect x="219.7" y="564.6" width="19.4" height="15.0" fill="#c45050" rx="1"/>
-  <rect x="219.7" y="556.3" width="19.4" height="8.3" fill="#f87171" rx="1"/>
+  <rect x="219.7" y="579.2" width="19.4" height="20.8" fill="#f87171" rx="1"/>
+  <rect x="219.7" y="564.2" width="19.4" height="15.0" fill="#c45050" rx="1"/>
+  <rect x="219.7" y="555.6" width="19.4" height="8.6" fill="#f87171" rx="1"/>
   <rect x="239.1" y="577.1" width="19.4" height="22.9" fill="#f59e0b" rx="1"/>
   <rect x="239.1" y="563.7" width="19.4" height="13.4" fill="#c47d08" rx="1"/>
   <rect x="239.1" y="557.8" width="19.4" height="5.9" fill="#f59e0b" rx="1"/>
-  <rect x="258.4" y="572.3" width="19.4" height="27.7" fill="#f472b6" rx="1"/>
-  <rect x="258.4" y="557.3" width="19.4" height="15.0" fill="#c05a92" rx="1"/>
-  <rect x="258.4" y="546.7" width="19.4" height="10.6" fill="#f472b6" rx="1"/>
+  <rect x="258.4" y="571.9" width="19.4" height="28.1" fill="#f472b6" rx="1"/>
+  <rect x="258.4" y="556.9" width="19.4" height="15.0" fill="#c05a92" rx="1"/>
+  <rect x="258.4" y="546.1" width="19.4" height="10.7" fill="#f472b6" rx="1"/>
   <rect x="277.8" y="514.4" width="19.4" height="85.6" fill="#4ade80" rx="1"/>
   <rect x="277.8" y="496.7" width="19.4" height="17.8" fill="#3aaf60" rx="1"/>
   <rect x="277.8" y="474.8" width="19.4" height="21.9" fill="#4ade80" rx="1"/>
@@ -160,15 +160,15 @@
   <rect x="329.5" y="578.6" width="19.4" height="21.4" fill="#60a5fa" rx="1"/>
   <rect x="329.5" y="533.4" width="19.4" height="45.2" fill="#4680c4" rx="1"/>
   <rect x="329.5" y="527.7" width="19.4" height="5.7" fill="#60a5fa" rx="1"/>
-  <rect x="348.9" y="577.9" width="19.4" height="22.1" fill="#f87171" rx="1"/>
-  <rect x="348.9" y="532.3" width="19.4" height="45.6" fill="#c45050" rx="1"/>
-  <rect x="348.9" y="526.0" width="19.4" height="6.4" fill="#f87171" rx="1"/>
+  <rect x="348.9" y="577.7" width="19.4" height="22.3" fill="#f87171" rx="1"/>
+  <rect x="348.9" y="532.1" width="19.4" height="45.6" fill="#c45050" rx="1"/>
+  <rect x="348.9" y="525.5" width="19.4" height="6.5" fill="#f87171" rx="1"/>
   <rect x="368.2" y="563.0" width="19.4" height="37.0" fill="#f59e0b" rx="1"/>
   <rect x="368.2" y="517.8" width="19.4" height="45.2" fill="#c47d08" rx="1"/>
   <rect x="368.2" y="509.7" width="19.4" height="8.1" fill="#f59e0b" rx="1"/>
-  <rect x="387.6" y="569.9" width="19.4" height="30.1" fill="#f472b6" rx="1"/>
-  <rect x="387.6" y="524.3" width="19.4" height="45.6" fill="#c05a92" rx="1"/>
-  <rect x="387.6" y="516.2" width="19.4" height="8.1" fill="#f472b6" rx="1"/>
+  <rect x="387.6" y="569.1" width="19.4" height="30.9" fill="#f472b6" rx="1"/>
+  <rect x="387.6" y="523.5" width="19.4" height="45.6" fill="#c05a92" rx="1"/>
+  <rect x="387.6" y="515.5" width="19.4" height="8.0" fill="#f472b6" rx="1"/>
   <rect x="407.0" y="447.8" width="19.4" height="152.2" fill="#4ade80" rx="1"/>
   <rect x="407.0" y="404.3" width="19.4" height="43.5" fill="#3aaf60" rx="1"/>
   <rect x="407.0" y="385.9" width="19.4" height="18.4" fill="#4ade80" rx="1"/>
@@ -177,15 +177,15 @@
   <rect x="458.6" y="579.0" width="19.4" height="21.0" fill="#60a5fa" rx="1"/>
   <rect x="458.6" y="561.7" width="19.4" height="17.3" fill="#4680c4" rx="1"/>
   <rect x="458.6" y="556.5" width="19.4" height="5.2" fill="#60a5fa" rx="1"/>
-  <rect x="478.0" y="565.0" width="19.4" height="35.0" fill="#f87171" rx="1"/>
-  <rect x="478.0" y="545.9" width="19.4" height="19.1" fill="#c45050" rx="1"/>
-  <rect x="478.0" y="533.3" width="19.4" height="12.6" fill="#f87171" rx="1"/>
+  <rect x="478.0" y="563.7" width="19.4" height="36.3" fill="#f87171" rx="1"/>
+  <rect x="478.0" y="544.6" width="19.4" height="19.1" fill="#c45050" rx="1"/>
+  <rect x="478.0" y="531.7" width="19.4" height="12.9" fill="#f87171" rx="1"/>
   <rect x="497.4" y="566.6" width="19.4" height="33.4" fill="#f59e0b" rx="1"/>
   <rect x="497.4" y="549.3" width="19.4" height="17.3" fill="#c47d08" rx="1"/>
   <rect x="497.4" y="541.5" width="19.4" height="7.8" fill="#f59e0b" rx="1"/>
-  <rect x="516.8" y="552.8" width="19.4" height="47.2" fill="#f472b6" rx="1"/>
-  <rect x="516.8" y="533.7" width="19.4" height="19.1" fill="#c05a92" rx="1"/>
-  <rect x="516.8" y="517.2" width="19.4" height="16.5" fill="#f472b6" rx="1"/>
+  <rect x="516.8" y="550.7" width="19.4" height="49.3" fill="#f472b6" rx="1"/>
+  <rect x="516.8" y="531.6" width="19.4" height="19.1" fill="#c05a92" rx="1"/>
+  <rect x="516.8" y="515.0" width="19.4" height="16.6" fill="#f472b6" rx="1"/>
   <rect x="536.1" y="494.8" width="19.4" height="105.2" fill="#4ade80" rx="1"/>
   <rect x="536.1" y="473.7" width="19.4" height="21.1" fill="#3aaf60" rx="1"/>
   <rect x="536.1" y="441.5" width="19.4" height="32.2" fill="#4ade80" rx="1"/>
@@ -194,15 +194,15 @@
   <rect x="587.8" y="591.4" width="19.4" height="8.6" fill="#60a5fa" rx="1"/>
   <rect x="587.8" y="549.4" width="19.4" height="42.0" fill="#4680c4" rx="1"/>
   <rect x="587.8" y="544.6" width="19.4" height="4.8" fill="#60a5fa" rx="1"/>
-  <rect x="607.2" y="572.2" width="19.4" height="27.8" fill="#f87171" rx="1"/>
-  <rect x="607.2" y="525.3" width="19.4" height="46.9" fill="#c45050" rx="1"/>
-  <rect x="607.2" y="517.9" width="19.4" height="7.3" fill="#f87171" rx="1"/>
+  <rect x="607.2" y="571.9" width="19.4" height="28.1" fill="#f87171" rx="1"/>
+  <rect x="607.2" y="525.0" width="19.4" height="46.9" fill="#c45050" rx="1"/>
+  <rect x="607.2" y="517.6" width="19.4" height="7.5" fill="#f87171" rx="1"/>
   <rect x="626.6" y="576.5" width="19.4" height="23.5" fill="#f59e0b" rx="1"/>
   <rect x="626.6" y="534.5" width="19.4" height="42.0" fill="#c47d08" rx="1"/>
   <rect x="626.6" y="528.2" width="19.4" height="6.3" fill="#f59e0b" rx="1"/>
-  <rect x="645.9" y="561.5" width="19.4" height="38.5" fill="#f472b6" rx="1"/>
-  <rect x="645.9" y="514.6" width="19.4" height="46.9" fill="#c05a92" rx="1"/>
-  <rect x="645.9" y="506.0" width="19.4" height="8.6" fill="#f472b6" rx="1"/>
+  <rect x="645.9" y="560.3" width="19.4" height="39.7" fill="#f472b6" rx="1"/>
+  <rect x="645.9" y="513.4" width="19.4" height="46.9" fill="#c05a92" rx="1"/>
+  <rect x="645.9" y="504.7" width="19.4" height="8.7" fill="#f472b6" rx="1"/>
   <rect x="665.3" y="445.8" width="19.4" height="154.2" fill="#4ade80" rx="1"/>
   <rect x="665.3" y="399.6" width="19.4" height="46.1" fill="#3aaf60" rx="1"/>
   <rect x="665.3" y="381.8" width="19.4" height="17.8" fill="#4ade80" rx="1"/>
@@ -211,15 +211,15 @@
   <rect x="717.0" y="589.1" width="19.4" height="10.9" fill="#60a5fa" rx="1"/>
   <rect x="717.0" y="581.7" width="19.4" height="7.4" fill="#4680c4" rx="1"/>
   <rect x="717.0" y="578.3" width="19.4" height="3.5" fill="#60a5fa" rx="1"/>
-  <rect x="736.4" y="583.9" width="19.4" height="16.1" fill="#f87171" rx="1"/>
-  <rect x="736.4" y="575.5" width="19.4" height="8.4" fill="#c45050" rx="1"/>
-  <rect x="736.4" y="568.7" width="19.4" height="6.9" fill="#f87171" rx="1"/>
+  <rect x="736.4" y="583.6" width="19.4" height="16.4" fill="#f87171" rx="1"/>
+  <rect x="736.4" y="575.2" width="19.4" height="8.4" fill="#c45050" rx="1"/>
+  <rect x="736.4" y="568.2" width="19.4" height="7.0" fill="#f87171" rx="1"/>
   <rect x="755.7" y="581.3" width="19.4" height="18.7" fill="#f59e0b" rx="1"/>
   <rect x="755.7" y="573.9" width="19.4" height="7.4" fill="#c47d08" rx="1"/>
   <rect x="755.7" y="569.1" width="19.4" height="4.9" fill="#f59e0b" rx="1"/>
-  <rect x="775.1" y="577.9" width="19.4" height="22.1" fill="#f472b6" rx="1"/>
-  <rect x="775.1" y="569.6" width="19.4" height="8.4" fill="#c05a92" rx="1"/>
-  <rect x="775.1" y="561.0" width="19.4" height="8.6" fill="#f472b6" rx="1"/>
+  <rect x="775.1" y="577.6" width="19.4" height="22.4" fill="#f472b6" rx="1"/>
+  <rect x="775.1" y="569.2" width="19.4" height="8.4" fill="#c05a92" rx="1"/>
+  <rect x="775.1" y="560.6" width="19.4" height="8.6" fill="#f472b6" rx="1"/>
   <rect x="794.5" y="529.9" width="19.4" height="70.1" fill="#4ade80" rx="1"/>
   <rect x="794.5" y="518.1" width="19.4" height="11.8" fill="#3aaf60" rx="1"/>
   <rect x="794.5" y="499.6" width="19.4" height="18.5" fill="#4ade80" rx="1"/>

--- a/doc/charts/x86_64/scatter.svg
+++ b/doc/charts/x86_64/scatter.svg
@@ -42,24 +42,24 @@
   <text x="440.3" y="93.7" text-anchor="start" fill="#60a5fa" font-size="8" font-weight="600">3</text>
   <circle cx="432.6" cy="93.7" r="3.5" fill="#60a5fa" stroke="#0d1117" stroke-width="1"/>
   <text x="426.6" y="93.7" text-anchor="end" fill="#60a5fa" font-size="8" font-weight="600">4</text>
-  <path d="M466.8,249.7L449.7,247.0L443.5,228.1L437.8,216.8L435.2,206.9L431.1,193.4L427.5,175.1L425.3,151.6L412.9,140.9L410.1,137.5L391.1,122.1L389.8,117.0" fill="none" stroke="#f87171" stroke-width="1.5" stroke-opacity="0.6"/>
-  <circle cx="466.8" cy="249.7" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
-  <text x="472.8" y="249.7" text-anchor="start" fill="#f87171" font-size="8" font-weight="600">-8</text>
-  <circle cx="449.7" cy="247.0" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
-  <circle cx="443.5" cy="228.1" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
-  <circle cx="437.8" cy="216.8" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
-  <text x="443.8" y="216.8" text-anchor="start" fill="#f87171" font-size="8" font-weight="600">-5</text>
-  <circle cx="435.2" cy="206.9" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
-  <circle cx="431.1" cy="193.4" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
-  <circle cx="427.5" cy="175.1" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
-  <text x="433.5" y="175.1" text-anchor="start" fill="#f87171" font-size="8" font-weight="600">-2</text>
-  <circle cx="425.3" cy="151.6" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
-  <circle cx="412.9" cy="140.9" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
-  <circle cx="410.1" cy="137.5" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
-  <text x="416.1" y="137.5" text-anchor="start" fill="#f87171" font-size="8" font-weight="600">2</text>
-  <circle cx="391.1" cy="122.1" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
-  <circle cx="389.8" cy="117.0" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
-  <text x="395.8" y="117.0" text-anchor="start" fill="#f87171" font-size="8" font-weight="600">4</text>
+  <path d="M460.1,249.7L444.2,247.0L438.4,228.1L432.7,216.8L430.4,206.9L426.3,193.4L423.2,175.1L421.2,151.6L409.4,140.9L405.7,137.5L385.8,122.1L357.9,117.0" fill="none" stroke="#f87171" stroke-width="1.5" stroke-opacity="0.6"/>
+  <circle cx="460.1" cy="249.7" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
+  <text x="466.1" y="249.7" text-anchor="start" fill="#f87171" font-size="8" font-weight="600">-8</text>
+  <circle cx="444.2" cy="247.0" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
+  <circle cx="438.4" cy="228.1" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
+  <circle cx="432.7" cy="216.8" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
+  <text x="438.7" y="216.8" text-anchor="start" fill="#f87171" font-size="8" font-weight="600">-5</text>
+  <circle cx="430.4" cy="206.9" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
+  <circle cx="426.3" cy="193.4" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
+  <circle cx="423.2" cy="175.1" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
+  <text x="429.2" y="175.1" text-anchor="start" fill="#f87171" font-size="8" font-weight="600">-2</text>
+  <circle cx="421.2" cy="151.6" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
+  <circle cx="409.4" cy="140.9" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
+  <circle cx="405.7" cy="137.5" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
+  <text x="411.7" y="137.5" text-anchor="start" fill="#f87171" font-size="8" font-weight="600">2</text>
+  <circle cx="385.8" cy="122.1" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
+  <circle cx="357.9" cy="117.0" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
+  <text x="363.9" y="117.0" text-anchor="start" fill="#f87171" font-size="8" font-weight="600">4</text>
   <path d="M418.4,236.1L412.9,225.0L409.9,214.8L407.2,200.7L402.4,184.3L398.3,166.6L392.0,153.7L384.3,104.0L376.5,100.7L329.7,93.2L328.5,92.8" fill="none" stroke="#f59e0b" stroke-width="1.5" stroke-opacity="0.6"/>
   <circle cx="418.4" cy="236.1" r="3.5" fill="#f59e0b" stroke="#0d1117" stroke-width="1"/>
   <text x="424.4" y="236.1" text-anchor="start" fill="#f59e0b" font-size="8" font-weight="600">-7</text>
@@ -77,24 +77,24 @@
   <text x="335.7" y="93.2" text-anchor="start" fill="#f59e0b" font-size="8" font-weight="600">3</text>
   <circle cx="328.5" cy="92.8" r="3.5" fill="#f59e0b" stroke="#0d1117" stroke-width="1"/>
   <text x="322.5" y="92.8" text-anchor="end" fill="#f59e0b" font-size="8" font-weight="600">4</text>
-  <path d="M418.1,249.7L406.7,247.0L400.7,228.1L394.7,216.8L392.2,206.9L388.3,193.4L384.9,175.1L382.7,151.6L370.0,140.9L369.6,137.5L350.7,122.1L350.1,117.0" fill="none" stroke="#f472b6" stroke-width="1.5" stroke-opacity="0.6"/>
-  <circle cx="418.1" cy="249.7" r="3.5" fill="#f472b6" stroke="#0d1117" stroke-width="1"/>
-  <text x="424.1" y="249.7" text-anchor="start" fill="#f472b6" font-size="8" font-weight="600">-8</text>
-  <circle cx="406.7" cy="247.0" r="3.5" fill="#f472b6" stroke="#0d1117" stroke-width="1"/>
-  <circle cx="400.7" cy="228.1" r="3.5" fill="#f472b6" stroke="#0d1117" stroke-width="1"/>
-  <circle cx="394.7" cy="216.8" r="3.5" fill="#f472b6" stroke="#0d1117" stroke-width="1"/>
-  <text x="400.7" y="216.8" text-anchor="start" fill="#f472b6" font-size="8" font-weight="600">-5</text>
-  <circle cx="392.2" cy="206.9" r="3.5" fill="#f472b6" stroke="#0d1117" stroke-width="1"/>
-  <circle cx="388.3" cy="193.4" r="3.5" fill="#f472b6" stroke="#0d1117" stroke-width="1"/>
-  <circle cx="384.9" cy="175.1" r="3.5" fill="#f472b6" stroke="#0d1117" stroke-width="1"/>
-  <text x="390.9" y="175.1" text-anchor="start" fill="#f472b6" font-size="8" font-weight="600">-2</text>
-  <circle cx="382.7" cy="151.6" r="3.5" fill="#f472b6" stroke="#0d1117" stroke-width="1"/>
-  <circle cx="370.0" cy="140.9" r="3.5" fill="#f472b6" stroke="#0d1117" stroke-width="1"/>
-  <circle cx="369.6" cy="137.5" r="3.5" fill="#f472b6" stroke="#0d1117" stroke-width="1"/>
-  <text x="375.6" y="137.5" text-anchor="start" fill="#f472b6" font-size="8" font-weight="600">2</text>
-  <circle cx="350.7" cy="122.1" r="3.5" fill="#f472b6" stroke="#0d1117" stroke-width="1"/>
-  <circle cx="350.1" cy="117.0" r="3.5" fill="#f472b6" stroke="#0d1117" stroke-width="1"/>
-  <text x="356.1" y="117.0" text-anchor="start" fill="#f472b6" font-size="8" font-weight="600">4</text>
+  <path d="M413.6,249.7L403.2,247.0L397.3,228.1L391.5,216.8L389.1,206.9L385.5,193.4L382.3,175.1L380.1,151.6L367.4,140.9L364.2,137.5L346.6,122.1L327.6,117.0" fill="none" stroke="#f472b6" stroke-width="1.5" stroke-opacity="0.6"/>
+  <circle cx="413.6" cy="249.7" r="3.5" fill="#f472b6" stroke="#0d1117" stroke-width="1"/>
+  <text x="419.6" y="249.7" text-anchor="start" fill="#f472b6" font-size="8" font-weight="600">-8</text>
+  <circle cx="403.2" cy="247.0" r="3.5" fill="#f472b6" stroke="#0d1117" stroke-width="1"/>
+  <circle cx="397.3" cy="228.1" r="3.5" fill="#f472b6" stroke="#0d1117" stroke-width="1"/>
+  <circle cx="391.5" cy="216.8" r="3.5" fill="#f472b6" stroke="#0d1117" stroke-width="1"/>
+  <text x="397.5" y="216.8" text-anchor="start" fill="#f472b6" font-size="8" font-weight="600">-5</text>
+  <circle cx="389.1" cy="206.9" r="3.5" fill="#f472b6" stroke="#0d1117" stroke-width="1"/>
+  <circle cx="385.5" cy="193.4" r="3.5" fill="#f472b6" stroke="#0d1117" stroke-width="1"/>
+  <circle cx="382.3" cy="175.1" r="3.5" fill="#f472b6" stroke="#0d1117" stroke-width="1"/>
+  <text x="388.3" y="175.1" text-anchor="start" fill="#f472b6" font-size="8" font-weight="600">-2</text>
+  <circle cx="380.1" cy="151.6" r="3.5" fill="#f472b6" stroke="#0d1117" stroke-width="1"/>
+  <circle cx="367.4" cy="140.9" r="3.5" fill="#f472b6" stroke="#0d1117" stroke-width="1"/>
+  <circle cx="364.2" cy="137.5" r="3.5" fill="#f472b6" stroke="#0d1117" stroke-width="1"/>
+  <text x="370.2" y="137.5" text-anchor="start" fill="#f472b6" font-size="8" font-weight="600">2</text>
+  <circle cx="346.6" cy="122.1" r="3.5" fill="#f472b6" stroke="#0d1117" stroke-width="1"/>
+  <circle cx="327.6" cy="117.0" r="3.5" fill="#f472b6" stroke="#0d1117" stroke-width="1"/>
+  <text x="333.6" y="117.0" text-anchor="start" fill="#f472b6" font-size="8" font-weight="600">4</text>
   <circle cx="202.6" cy="212.6" r="3.5" fill="#4ade80" stroke="#0d1117" stroke-width="1"/>
   <text x="208.6" y="212.6" text-anchor="start" fill="#4ade80" font-size="8" font-weight="600">L1</text>
   <circle cx="509.3" cy="230.7" r="3.5" fill="#c084fc" stroke="#0d1117" stroke-width="1"/>
@@ -141,24 +141,24 @@
   <text x="302.8" y="410.9" text-anchor="start" fill="#60a5fa" font-size="8" font-weight="600">3</text>
   <circle cx="293.3" cy="407.3" r="3.5" fill="#60a5fa" stroke="#0d1117" stroke-width="1"/>
   <text x="287.3" y="407.3" text-anchor="end" fill="#60a5fa" font-size="8" font-weight="600">4</text>
-  <path d="M358.1,576.2L342.8,551.5L333.8,539.7L330.6,533.7L327.1,525.8L321.4,513.4L316.9,502.9L311.6,491.8L297.1,474.7L284.6,461.7L258.6,456.2L249.6,448.2" fill="none" stroke="#f87171" stroke-width="1.5" stroke-opacity="0.6"/>
-  <circle cx="358.1" cy="576.2" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
-  <text x="364.1" y="576.2" text-anchor="start" fill="#f87171" font-size="8" font-weight="600">-8</text>
-  <circle cx="342.8" cy="551.5" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
-  <circle cx="333.8" cy="539.7" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
-  <circle cx="330.6" cy="533.7" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
-  <text x="336.6" y="533.7" text-anchor="start" fill="#f87171" font-size="8" font-weight="600">-5</text>
-  <circle cx="327.1" cy="525.8" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
-  <circle cx="321.4" cy="513.4" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
-  <circle cx="316.9" cy="502.9" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
-  <text x="322.9" y="502.9" text-anchor="start" fill="#f87171" font-size="8" font-weight="600">-2</text>
-  <circle cx="311.6" cy="491.8" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
-  <circle cx="297.1" cy="474.7" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
-  <circle cx="284.6" cy="461.7" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
-  <text x="290.6" y="461.7" text-anchor="start" fill="#f87171" font-size="8" font-weight="600">2</text>
-  <circle cx="258.6" cy="456.2" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
-  <circle cx="249.6" cy="448.2" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
-  <text x="255.6" y="448.2" text-anchor="start" fill="#f87171" font-size="8" font-weight="600">4</text>
+  <path d="M351.8,576.2L337.8,551.5L329.2,539.7L325.8,533.7L322.6,525.8L316.9,513.4L312.5,502.9L307.4,491.8L294.9,474.7L279.8,461.7L253.3,456.2L203.4,448.2" fill="none" stroke="#f87171" stroke-width="1.5" stroke-opacity="0.6"/>
+  <circle cx="351.8" cy="576.2" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
+  <text x="357.8" y="576.2" text-anchor="start" fill="#f87171" font-size="8" font-weight="600">-8</text>
+  <circle cx="337.8" cy="551.5" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
+  <circle cx="329.2" cy="539.7" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
+  <circle cx="325.8" cy="533.7" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
+  <text x="331.8" y="533.7" text-anchor="start" fill="#f87171" font-size="8" font-weight="600">-5</text>
+  <circle cx="322.6" cy="525.8" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
+  <circle cx="316.9" cy="513.4" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
+  <circle cx="312.5" cy="502.9" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
+  <text x="318.5" y="502.9" text-anchor="start" fill="#f87171" font-size="8" font-weight="600">-2</text>
+  <circle cx="307.4" cy="491.8" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
+  <circle cx="294.9" cy="474.7" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
+  <circle cx="279.8" cy="461.7" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
+  <text x="285.8" y="461.7" text-anchor="start" fill="#f87171" font-size="8" font-weight="600">2</text>
+  <circle cx="253.3" cy="456.2" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
+  <circle cx="203.4" cy="448.2" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
+  <text x="209.4" y="448.2" text-anchor="start" fill="#f87171" font-size="8" font-weight="600">4</text>
   <path d="M338.2,573.0L335.0,567.5L328.8,559.8L322.6,548.8L315.2,537.2L308.7,525.9L300.2,513.9L286.2,445.5L265.7,426.1L202.3,412.4L201.6,407.6" fill="none" stroke="#f59e0b" stroke-width="1.5" stroke-opacity="0.6"/>
   <circle cx="338.2" cy="573.0" r="3.5" fill="#f59e0b" stroke="#0d1117" stroke-width="1"/>
   <text x="344.2" y="573.0" text-anchor="start" fill="#f59e0b" font-size="8" font-weight="600">-7</text>
@@ -176,24 +176,24 @@
   <text x="208.3" y="412.4" text-anchor="start" fill="#f59e0b" font-size="8" font-weight="600">3</text>
   <circle cx="201.6" cy="407.6" r="3.5" fill="#f59e0b" stroke="#0d1117" stroke-width="1"/>
   <text x="195.6" y="407.6" text-anchor="end" fill="#f59e0b" font-size="8" font-weight="600">4</text>
-  <path d="M315.3,576.2L307.1,551.5L297.9,539.7L294.3,533.7L289.8,525.8L284.8,513.4L280.6,502.9L275.0,491.8L254.6,474.7L244.9,461.7L222.5,456.2L213.9,448.2" fill="none" stroke="#f472b6" stroke-width="1.5" stroke-opacity="0.6"/>
-  <circle cx="315.3" cy="576.2" r="3.5" fill="#f472b6" stroke="#0d1117" stroke-width="1"/>
-  <text x="321.3" y="576.2" text-anchor="start" fill="#f472b6" font-size="8" font-weight="600">-8</text>
-  <circle cx="307.1" cy="551.5" r="3.5" fill="#f472b6" stroke="#0d1117" stroke-width="1"/>
-  <circle cx="297.9" cy="539.7" r="3.5" fill="#f472b6" stroke="#0d1117" stroke-width="1"/>
-  <circle cx="294.3" cy="533.7" r="3.5" fill="#f472b6" stroke="#0d1117" stroke-width="1"/>
-  <text x="300.3" y="533.7" text-anchor="start" fill="#f472b6" font-size="8" font-weight="600">-5</text>
-  <circle cx="289.8" cy="525.8" r="3.5" fill="#f472b6" stroke="#0d1117" stroke-width="1"/>
-  <circle cx="284.8" cy="513.4" r="3.5" fill="#f472b6" stroke="#0d1117" stroke-width="1"/>
-  <circle cx="280.6" cy="502.9" r="3.5" fill="#f472b6" stroke="#0d1117" stroke-width="1"/>
-  <text x="286.6" y="502.9" text-anchor="start" fill="#f472b6" font-size="8" font-weight="600">-2</text>
-  <circle cx="275.0" cy="491.8" r="3.5" fill="#f472b6" stroke="#0d1117" stroke-width="1"/>
-  <circle cx="254.6" cy="474.7" r="3.5" fill="#f472b6" stroke="#0d1117" stroke-width="1"/>
-  <circle cx="244.9" cy="461.7" r="3.5" fill="#f472b6" stroke="#0d1117" stroke-width="1"/>
-  <text x="250.9" y="461.7" text-anchor="start" fill="#f472b6" font-size="8" font-weight="600">2</text>
-  <circle cx="222.5" cy="456.2" r="3.5" fill="#f472b6" stroke="#0d1117" stroke-width="1"/>
-  <circle cx="213.9" cy="448.2" r="3.5" fill="#f472b6" stroke="#0d1117" stroke-width="1"/>
-  <text x="219.9" y="448.2" text-anchor="start" fill="#f472b6" font-size="8" font-weight="600">4</text>
+  <path d="M310.0,576.2L302.6,551.5L293.7,539.7L290.2,533.7L286.4,525.8L279.2,513.4L276.6,502.9L271.0,491.8L251.4,474.7L239.6,461.7L216.9,456.2L178.9,448.2" fill="none" stroke="#f472b6" stroke-width="1.5" stroke-opacity="0.6"/>
+  <circle cx="310.0" cy="576.2" r="3.5" fill="#f472b6" stroke="#0d1117" stroke-width="1"/>
+  <text x="316.0" y="576.2" text-anchor="start" fill="#f472b6" font-size="8" font-weight="600">-8</text>
+  <circle cx="302.6" cy="551.5" r="3.5" fill="#f472b6" stroke="#0d1117" stroke-width="1"/>
+  <circle cx="293.7" cy="539.7" r="3.5" fill="#f472b6" stroke="#0d1117" stroke-width="1"/>
+  <circle cx="290.2" cy="533.7" r="3.5" fill="#f472b6" stroke="#0d1117" stroke-width="1"/>
+  <text x="296.2" y="533.7" text-anchor="start" fill="#f472b6" font-size="8" font-weight="600">-5</text>
+  <circle cx="286.4" cy="525.8" r="3.5" fill="#f472b6" stroke="#0d1117" stroke-width="1"/>
+  <circle cx="279.2" cy="513.4" r="3.5" fill="#f472b6" stroke="#0d1117" stroke-width="1"/>
+  <circle cx="276.6" cy="502.9" r="3.5" fill="#f472b6" stroke="#0d1117" stroke-width="1"/>
+  <text x="282.6" y="502.9" text-anchor="start" fill="#f472b6" font-size="8" font-weight="600">-2</text>
+  <circle cx="271.0" cy="491.8" r="3.5" fill="#f472b6" stroke="#0d1117" stroke-width="1"/>
+  <circle cx="251.4" cy="474.7" r="3.5" fill="#f472b6" stroke="#0d1117" stroke-width="1"/>
+  <circle cx="239.6" cy="461.7" r="3.5" fill="#f472b6" stroke="#0d1117" stroke-width="1"/>
+  <text x="245.6" y="461.7" text-anchor="start" fill="#f472b6" font-size="8" font-weight="600">2</text>
+  <circle cx="216.9" cy="456.2" r="3.5" fill="#f472b6" stroke="#0d1117" stroke-width="1"/>
+  <circle cx="178.9" cy="448.2" r="3.5" fill="#f472b6" stroke="#0d1117" stroke-width="1"/>
+  <text x="184.9" y="448.2" text-anchor="start" fill="#f472b6" font-size="8" font-weight="600">4</text>
   <circle cx="135.3" cy="512.1" r="3.5" fill="#4ade80" stroke="#0d1117" stroke-width="1"/>
   <text x="141.3" y="512.1" text-anchor="start" fill="#4ade80" font-size="8" font-weight="600">L1</text>
   <circle cx="426.9" cy="579.3" r="3.5" fill="#c084fc" stroke="#0d1117" stroke-width="1"/>
@@ -244,24 +244,24 @@
   <text x="241.3" y="767.6" text-anchor="start" fill="#60a5fa" font-size="8" font-weight="600">3</text>
   <circle cx="224.1" cy="742.4" r="3.5" fill="#60a5fa" stroke="#0d1117" stroke-width="1"/>
   <text x="230.1" y="742.4" text-anchor="start" fill="#60a5fa" font-size="8" font-weight="600">4</text>
-  <path d="M659.0,913.3L596.6,909.7L549.5,902.9L535.1,899.3L516.5,897.3L495.9,895.2L450.8,891.5L420.2,884.7L336.0,857.8L271.8,817.1L248.8,807.1L221.3,782.7" fill="none" stroke="#f87171" stroke-width="1.5" stroke-opacity="0.6"/>
-  <circle cx="659.0" cy="913.3" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
-  <text x="665.0" y="913.3" text-anchor="start" fill="#f87171" font-size="8" font-weight="600">-8</text>
-  <circle cx="596.6" cy="909.7" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
-  <circle cx="549.5" cy="902.9" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
-  <circle cx="535.1" cy="899.3" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
-  <text x="541.1" y="899.3" text-anchor="start" fill="#f87171" font-size="8" font-weight="600">-5</text>
-  <circle cx="516.5" cy="897.3" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
-  <circle cx="495.9" cy="895.2" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
-  <circle cx="450.8" cy="891.5" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
-  <text x="456.8" y="891.5" text-anchor="start" fill="#f87171" font-size="8" font-weight="600">-2</text>
-  <circle cx="420.2" cy="884.7" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
-  <circle cx="336.0" cy="857.8" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
-  <circle cx="271.8" cy="817.1" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
-  <text x="277.8" y="817.1" text-anchor="start" fill="#f87171" font-size="8" font-weight="600">2</text>
-  <circle cx="248.8" cy="807.1" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
-  <circle cx="221.3" cy="782.7" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
-  <text x="227.3" y="782.7" text-anchor="start" fill="#f87171" font-size="8" font-weight="600">4</text>
+  <path d="M649.0,913.3L591.9,909.7L545.6,902.9L530.6,899.3L513.2,897.3L492.8,895.2L448.9,891.5L418.9,884.7L334.6,857.8L262.2,817.1L238.4,807.1L144.4,782.7" fill="none" stroke="#f87171" stroke-width="1.5" stroke-opacity="0.6"/>
+  <circle cx="649.0" cy="913.3" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
+  <text x="655.0" y="913.3" text-anchor="start" fill="#f87171" font-size="8" font-weight="600">-8</text>
+  <circle cx="591.9" cy="909.7" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
+  <circle cx="545.6" cy="902.9" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
+  <circle cx="530.6" cy="899.3" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
+  <text x="536.6" y="899.3" text-anchor="start" fill="#f87171" font-size="8" font-weight="600">-5</text>
+  <circle cx="513.2" cy="897.3" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
+  <circle cx="492.8" cy="895.2" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
+  <circle cx="448.9" cy="891.5" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
+  <text x="454.9" y="891.5" text-anchor="start" fill="#f87171" font-size="8" font-weight="600">-2</text>
+  <circle cx="418.9" cy="884.7" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
+  <circle cx="334.6" cy="857.8" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
+  <circle cx="262.2" cy="817.1" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
+  <text x="268.2" y="817.1" text-anchor="start" fill="#f87171" font-size="8" font-weight="600">2</text>
+  <circle cx="238.4" cy="807.1" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
+  <circle cx="144.4" cy="782.7" r="3.5" fill="#f87171" stroke="#0d1117" stroke-width="1"/>
+  <text x="150.4" y="782.7" text-anchor="start" fill="#f87171" font-size="8" font-weight="600">4</text>
   <path d="M553.1,904.5L540.8,900.9L531.4,901.7L524.9,899.3L509.1,897.2L491.8,894.5L473.4,892.0L312.3,828.8L269.4,806.3L148.6,776.3L139.6,752.6" fill="none" stroke="#f59e0b" stroke-width="1.5" stroke-opacity="0.6"/>
   <circle cx="553.1" cy="904.5" r="3.5" fill="#f59e0b" stroke="#0d1117" stroke-width="1"/>
   <text x="559.1" y="904.5" text-anchor="start" fill="#f59e0b" font-size="8" font-weight="600">-7</text>
@@ -279,24 +279,24 @@
   <text x="154.6" y="776.3" text-anchor="start" fill="#f59e0b" font-size="8" font-weight="600">3</text>
   <circle cx="139.6" cy="752.6" r="3.5" fill="#f59e0b" stroke="#0d1117" stroke-width="1"/>
   <text x="145.6" y="752.6" text-anchor="start" fill="#f59e0b" font-size="8" font-weight="600">4</text>
-  <path d="M622.4,913.3L568.5,909.7L520.0,902.9L505.9,899.3L485.0,897.3L464.4,895.2L418.6,891.5L385.7,884.7L292.7,857.8L232.8,817.1L212.0,807.1L180.1,782.7" fill="none" stroke="#f472b6" stroke-width="1.5" stroke-opacity="0.6"/>
-  <circle cx="622.4" cy="913.3" r="3.5" fill="#f472b6" stroke="#0d1117" stroke-width="1"/>
-  <text x="628.4" y="913.3" text-anchor="start" fill="#f472b6" font-size="8" font-weight="600">-8</text>
-  <circle cx="568.5" cy="909.7" r="3.5" fill="#f472b6" stroke="#0d1117" stroke-width="1"/>
-  <circle cx="520.0" cy="902.9" r="3.5" fill="#f472b6" stroke="#0d1117" stroke-width="1"/>
-  <circle cx="505.9" cy="899.3" r="3.5" fill="#f472b6" stroke="#0d1117" stroke-width="1"/>
-  <text x="511.9" y="899.3" text-anchor="start" fill="#f472b6" font-size="8" font-weight="600">-5</text>
-  <circle cx="485.0" cy="897.3" r="3.5" fill="#f472b6" stroke="#0d1117" stroke-width="1"/>
-  <circle cx="464.4" cy="895.2" r="3.5" fill="#f472b6" stroke="#0d1117" stroke-width="1"/>
-  <circle cx="418.6" cy="891.5" r="3.5" fill="#f472b6" stroke="#0d1117" stroke-width="1"/>
-  <text x="424.6" y="891.5" text-anchor="start" fill="#f472b6" font-size="8" font-weight="600">-2</text>
-  <circle cx="385.7" cy="884.7" r="3.5" fill="#f472b6" stroke="#0d1117" stroke-width="1"/>
-  <circle cx="292.7" cy="857.8" r="3.5" fill="#f472b6" stroke="#0d1117" stroke-width="1"/>
-  <circle cx="232.8" cy="817.1" r="3.5" fill="#f472b6" stroke="#0d1117" stroke-width="1"/>
-  <text x="238.8" y="817.1" text-anchor="start" fill="#f472b6" font-size="8" font-weight="600">2</text>
-  <circle cx="212.0" cy="807.1" r="3.5" fill="#f472b6" stroke="#0d1117" stroke-width="1"/>
-  <circle cx="180.1" cy="782.7" r="3.5" fill="#f472b6" stroke="#0d1117" stroke-width="1"/>
-  <text x="186.1" y="782.7" text-anchor="start" fill="#f472b6" font-size="8" font-weight="600">4</text>
+  <path d="M617.4,913.3L564.1,909.7L516.2,902.9L501.3,899.3L480.7,897.3L460.0,895.2L414.5,891.5L382.2,884.7L288.9,857.8L226.8,817.1L204.5,807.1L130.8,782.7" fill="none" stroke="#f472b6" stroke-width="1.5" stroke-opacity="0.6"/>
+  <circle cx="617.4" cy="913.3" r="3.5" fill="#f472b6" stroke="#0d1117" stroke-width="1"/>
+  <text x="623.4" y="913.3" text-anchor="start" fill="#f472b6" font-size="8" font-weight="600">-8</text>
+  <circle cx="564.1" cy="909.7" r="3.5" fill="#f472b6" stroke="#0d1117" stroke-width="1"/>
+  <circle cx="516.2" cy="902.9" r="3.5" fill="#f472b6" stroke="#0d1117" stroke-width="1"/>
+  <circle cx="501.3" cy="899.3" r="3.5" fill="#f472b6" stroke="#0d1117" stroke-width="1"/>
+  <text x="507.3" y="899.3" text-anchor="start" fill="#f472b6" font-size="8" font-weight="600">-5</text>
+  <circle cx="480.7" cy="897.3" r="3.5" fill="#f472b6" stroke="#0d1117" stroke-width="1"/>
+  <circle cx="460.0" cy="895.2" r="3.5" fill="#f472b6" stroke="#0d1117" stroke-width="1"/>
+  <circle cx="414.5" cy="891.5" r="3.5" fill="#f472b6" stroke="#0d1117" stroke-width="1"/>
+  <text x="420.5" y="891.5" text-anchor="start" fill="#f472b6" font-size="8" font-weight="600">-2</text>
+  <circle cx="382.2" cy="884.7" r="3.5" fill="#f472b6" stroke="#0d1117" stroke-width="1"/>
+  <circle cx="288.9" cy="857.8" r="3.5" fill="#f472b6" stroke="#0d1117" stroke-width="1"/>
+  <circle cx="226.8" cy="817.1" r="3.5" fill="#f472b6" stroke="#0d1117" stroke-width="1"/>
+  <text x="232.8" y="817.1" text-anchor="start" fill="#f472b6" font-size="8" font-weight="600">2</text>
+  <circle cx="204.5" cy="807.1" r="3.5" fill="#f472b6" stroke="#0d1117" stroke-width="1"/>
+  <circle cx="130.8" cy="782.7" r="3.5" fill="#f472b6" stroke="#0d1117" stroke-width="1"/>
+  <text x="136.8" y="782.7" text-anchor="start" fill="#f472b6" font-size="8" font-weight="600">4</text>
   <circle cx="88.1" cy="842.5" r="3.5" fill="#4ade80" stroke="#0d1117" stroke-width="1"/>
   <text x="94.1" y="842.5" text-anchor="start" fill="#4ade80" font-size="8" font-weight="600">L1</text>
   <circle cx="712.6" cy="911.7" r="3.5" fill="#c084fc" stroke="#0d1117" stroke-width="1"/>

--- a/doc/charts/x86_64/small_decode.svg
+++ b/doc/charts/x86_64/small_decode.svg
@@ -40,26 +40,26 @@
   <circle cx="586.3" cy="104.4" r="2.5" fill="#60a5fa" stroke="#0d1117" stroke-width="0.8"/>
   <circle cx="664.3" cy="90.2" r="2.5" fill="#60a5fa" stroke="#0d1117" stroke-width="0.8"/>
   <circle cx="742.4" cy="83.7" r="2.5" fill="#60a5fa" stroke="#0d1117" stroke-width="0.8"/>
-  <path d="M117.8,219.2L195.9,195.4L274.0,181.3L352.0,170.5L430.1,161.0L508.2,160.0L586.3,159.2L664.3,180.1L742.4,176.9" fill="none" stroke="#f87171" stroke-width="1.8"/>
-  <circle cx="117.8" cy="219.2" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="195.9" cy="195.4" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="274.0" cy="181.3" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="352.0" cy="170.5" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="430.1" cy="161.0" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="508.2" cy="160.0" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
+  <path d="M117.8,220.3L195.9,196.7L274.0,184.4L352.0,175.0L430.1,166.8L508.2,166.1L586.3,159.2L664.3,180.0L742.4,177.1" fill="none" stroke="#f87171" stroke-width="1.8"/>
+  <circle cx="117.8" cy="220.3" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="195.9" cy="196.7" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="274.0" cy="184.4" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="352.0" cy="175.0" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="430.1" cy="166.8" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="508.2" cy="166.1" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
   <circle cx="586.3" cy="159.2" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="664.3" cy="180.1" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="742.4" cy="176.9" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
-  <path d="M117.8,221.4L195.9,201.3L274.0,194.3L352.0,190.8L430.1,187.2L508.2,192.9L586.3,196.9L664.3,204.1L742.4,203.6" fill="none" stroke="#f472b6" stroke-width="1.8"/>
-  <circle cx="117.8" cy="221.4" r="2.5" fill="#f472b6" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="195.9" cy="201.3" r="2.5" fill="#f472b6" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="274.0" cy="194.3" r="2.5" fill="#f472b6" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="352.0" cy="190.8" r="2.5" fill="#f472b6" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="430.1" cy="187.2" r="2.5" fill="#f472b6" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="508.2" cy="192.9" r="2.5" fill="#f472b6" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="586.3" cy="196.9" r="2.5" fill="#f472b6" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="664.3" cy="204.1" r="2.5" fill="#f472b6" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="742.4" cy="203.6" r="2.5" fill="#f472b6" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="664.3" cy="180.0" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="742.4" cy="177.1" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
+  <path d="M117.8,223.3L195.9,204.0L274.0,196.0L352.0,191.7L430.1,188.0L508.2,194.5L586.3,196.4L664.3,203.4L742.4,202.4" fill="none" stroke="#f472b6" stroke-width="1.8"/>
+  <circle cx="117.8" cy="223.3" r="2.5" fill="#f472b6" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="195.9" cy="204.0" r="2.5" fill="#f472b6" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="274.0" cy="196.0" r="2.5" fill="#f472b6" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="352.0" cy="191.7" r="2.5" fill="#f472b6" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="430.1" cy="188.0" r="2.5" fill="#f472b6" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="508.2" cy="194.5" r="2.5" fill="#f472b6" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="586.3" cy="196.4" r="2.5" fill="#f472b6" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="664.3" cy="203.4" r="2.5" fill="#f472b6" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="742.4" cy="202.4" r="2.5" fill="#f472b6" stroke="#0d1117" stroke-width="0.8"/>
   <path d="M117.8,249.9L195.9,233.0L274.0,226.0L352.0,207.6L430.1,195.1L508.2,193.0L586.3,174.3L664.3,168.7L742.4,164.9" fill="none" stroke="#f59e0b" stroke-width="1.8"/>
   <circle cx="117.8" cy="249.9" r="2.5" fill="#f59e0b" stroke="#0d1117" stroke-width="0.8"/>
   <circle cx="195.9" cy="233.0" r="2.5" fill="#f59e0b" stroke="#0d1117" stroke-width="0.8"/>
@@ -122,26 +122,26 @@
   <circle cx="586.3" cy="364.3" r="2.5" fill="#60a5fa" stroke="#0d1117" stroke-width="0.8"/>
   <circle cx="664.3" cy="353.7" r="2.5" fill="#60a5fa" stroke="#0d1117" stroke-width="0.8"/>
   <circle cx="742.4" cy="371.7" r="2.5" fill="#60a5fa" stroke="#0d1117" stroke-width="0.8"/>
-  <path d="M117.8,528.1L195.9,515.5L274.0,495.5L352.0,470.8L430.1,442.8L508.2,416.7L586.3,407.2L664.3,388.1L742.4,403.2" fill="none" stroke="#f87171" stroke-width="1.8"/>
-  <circle cx="117.8" cy="528.1" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="195.9" cy="515.5" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="274.0" cy="495.5" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="352.0" cy="470.8" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="430.1" cy="442.8" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="508.2" cy="416.7" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="586.3" cy="407.2" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="664.3" cy="388.1" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="742.4" cy="403.2" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
-  <path d="M117.8,528.5L195.9,516.2L274.0,497.2L352.0,475.6L430.1,452.4L508.2,431.7L586.3,418.1L664.3,413.7L742.4,427.7" fill="none" stroke="#f472b6" stroke-width="1.8"/>
-  <circle cx="117.8" cy="528.5" r="2.5" fill="#f472b6" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="195.9" cy="516.2" r="2.5" fill="#f472b6" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="274.0" cy="497.2" r="2.5" fill="#f472b6" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="352.0" cy="475.6" r="2.5" fill="#f472b6" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="430.1" cy="452.4" r="2.5" fill="#f472b6" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="508.2" cy="431.7" r="2.5" fill="#f472b6" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="586.3" cy="418.1" r="2.5" fill="#f472b6" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="664.3" cy="413.7" r="2.5" fill="#f472b6" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="742.4" cy="427.7" r="2.5" fill="#f472b6" stroke="#0d1117" stroke-width="0.8"/>
+  <path d="M117.8,528.2L195.9,516.0L274.0,496.3L352.0,472.7L430.1,446.6L508.2,419.9L586.3,401.7L664.3,393.0L742.4,405.1" fill="none" stroke="#f87171" stroke-width="1.8"/>
+  <circle cx="117.8" cy="528.2" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="195.9" cy="516.0" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="274.0" cy="496.3" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="352.0" cy="472.7" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="430.1" cy="446.6" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="508.2" cy="419.9" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="586.3" cy="401.7" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="664.3" cy="393.0" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="742.4" cy="405.1" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
+  <path d="M117.8,529.1L195.9,517.7L274.0,499.3L352.0,478.5L430.1,454.0L508.2,432.4L586.3,417.7L664.3,411.8L742.4,426.9" fill="none" stroke="#f472b6" stroke-width="1.8"/>
+  <circle cx="117.8" cy="529.1" r="2.5" fill="#f472b6" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="195.9" cy="517.7" r="2.5" fill="#f472b6" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="274.0" cy="499.3" r="2.5" fill="#f472b6" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="352.0" cy="478.5" r="2.5" fill="#f472b6" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="430.1" cy="454.0" r="2.5" fill="#f472b6" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="508.2" cy="432.4" r="2.5" fill="#f472b6" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="586.3" cy="417.7" r="2.5" fill="#f472b6" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="664.3" cy="411.8" r="2.5" fill="#f472b6" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="742.4" cy="426.9" r="2.5" fill="#f472b6" stroke="#0d1117" stroke-width="0.8"/>
   <path d="M117.8,537.8L195.9,531.2L274.0,521.0L352.0,513.1L430.1,490.5L508.2,464.1L586.3,439.1L664.3,433.6L742.4,435.6" fill="none" stroke="#f59e0b" stroke-width="1.8"/>
   <circle cx="117.8" cy="537.8" r="2.5" fill="#f59e0b" stroke="#0d1117" stroke-width="0.8"/>
   <circle cx="195.9" cy="531.2" r="2.5" fill="#f59e0b" stroke="#0d1117" stroke-width="0.8"/>
@@ -198,26 +198,26 @@
   <circle cx="586.3" cy="704.1" r="2.5" fill="#60a5fa" stroke="#0d1117" stroke-width="0.8"/>
   <circle cx="664.3" cy="655.2" r="2.5" fill="#60a5fa" stroke="#0d1117" stroke-width="0.8"/>
   <circle cx="742.4" cy="623.7" r="2.5" fill="#60a5fa" stroke="#0d1117" stroke-width="0.8"/>
-  <path d="M117.8,802.4L195.9,795.2L274.0,787.3L352.0,778.6L430.1,773.1L508.2,753.8L586.3,715.5L664.3,673.4L742.4,638.1" fill="none" stroke="#f87171" stroke-width="1.8"/>
-  <circle cx="117.8" cy="802.4" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="195.9" cy="795.2" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="274.0" cy="787.3" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="352.0" cy="778.6" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="430.1" cy="773.1" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="508.2" cy="753.8" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="586.3" cy="715.5" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="664.3" cy="673.4" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="742.4" cy="638.1" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
-  <path d="M117.8,803.3L195.9,797.3L274.0,791.2L352.0,785.3L430.1,781.6L508.2,765.9L586.3,733.8L664.3,699.5L742.4,674.1" fill="none" stroke="#f472b6" stroke-width="1.8"/>
-  <circle cx="117.8" cy="803.3" r="2.5" fill="#f472b6" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="195.9" cy="797.3" r="2.5" fill="#f472b6" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="274.0" cy="791.2" r="2.5" fill="#f472b6" stroke="#0d1117" stroke-width="0.8"/>
+  <path d="M117.8,802.7L195.9,795.7L274.0,788.2L352.0,780.4L430.1,775.2L508.2,756.4L586.3,719.4L664.3,680.0L742.4,642.9" fill="none" stroke="#f87171" stroke-width="1.8"/>
+  <circle cx="117.8" cy="802.7" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="195.9" cy="795.7" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="274.0" cy="788.2" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="352.0" cy="780.4" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="430.1" cy="775.2" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="508.2" cy="756.4" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="586.3" cy="719.4" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="664.3" cy="680.0" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="742.4" cy="642.9" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
+  <path d="M117.8,803.5L195.9,797.7L274.0,791.3L352.0,785.3L430.1,781.3L508.2,765.2L586.3,733.3L664.3,698.7L742.4,674.8" fill="none" stroke="#f472b6" stroke-width="1.8"/>
+  <circle cx="117.8" cy="803.5" r="2.5" fill="#f472b6" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="195.9" cy="797.7" r="2.5" fill="#f472b6" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="274.0" cy="791.3" r="2.5" fill="#f472b6" stroke="#0d1117" stroke-width="0.8"/>
   <circle cx="352.0" cy="785.3" r="2.5" fill="#f472b6" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="430.1" cy="781.6" r="2.5" fill="#f472b6" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="508.2" cy="765.9" r="2.5" fill="#f472b6" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="586.3" cy="733.8" r="2.5" fill="#f472b6" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="664.3" cy="699.5" r="2.5" fill="#f472b6" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="742.4" cy="674.1" r="2.5" fill="#f472b6" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="430.1" cy="781.3" r="2.5" fill="#f472b6" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="508.2" cy="765.2" r="2.5" fill="#f472b6" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="586.3" cy="733.3" r="2.5" fill="#f472b6" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="664.3" cy="698.7" r="2.5" fill="#f472b6" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="742.4" cy="674.8" r="2.5" fill="#f472b6" stroke="#0d1117" stroke-width="0.8"/>
   <path d="M117.8,809.8L195.9,806.8L274.0,801.9L352.0,795.2L430.1,789.3L508.2,774.4L586.3,750.5L664.3,720.3L742.4,694.1" fill="none" stroke="#f59e0b" stroke-width="1.8"/>
   <circle cx="117.8" cy="809.8" r="2.5" fill="#f59e0b" stroke="#0d1117" stroke-width="0.8"/>
   <circle cx="195.9" cy="806.8" r="2.5" fill="#f59e0b" stroke="#0d1117" stroke-width="0.8"/>
@@ -278,26 +278,26 @@
   <circle cx="586.3" cy="893.7" r="2.5" fill="#60a5fa" stroke="#0d1117" stroke-width="0.8"/>
   <circle cx="664.3" cy="908.1" r="2.5" fill="#60a5fa" stroke="#0d1117" stroke-width="0.8"/>
   <circle cx="742.4" cy="917.3" r="2.5" fill="#60a5fa" stroke="#0d1117" stroke-width="0.8"/>
-  <path d="M117.8,1033.4L195.9,1013.3L274.0,996.6L352.0,984.9L430.1,978.7L508.2,976.5L586.3,973.4L664.3,976.6L742.4,989.5" fill="none" stroke="#f87171" stroke-width="1.8"/>
-  <circle cx="117.8" cy="1033.4" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="195.9" cy="1013.3" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="274.0" cy="996.6" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="352.0" cy="984.9" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="430.1" cy="978.7" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="508.2" cy="976.5" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="586.3" cy="973.4" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="664.3" cy="976.6" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="742.4" cy="989.5" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
-  <path d="M117.8,1034.2L195.9,1013.3L274.0,997.5L352.0,986.1L430.1,981.2L508.2,981.5L586.3,978.6L664.3,988.3L742.4,998.2" fill="none" stroke="#f472b6" stroke-width="1.8"/>
-  <circle cx="117.8" cy="1034.2" r="2.5" fill="#f472b6" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="195.9" cy="1013.3" r="2.5" fill="#f472b6" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="274.0" cy="997.5" r="2.5" fill="#f472b6" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="352.0" cy="986.1" r="2.5" fill="#f472b6" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="430.1" cy="981.2" r="2.5" fill="#f472b6" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="508.2" cy="981.5" r="2.5" fill="#f472b6" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="586.3" cy="978.6" r="2.5" fill="#f472b6" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="664.3" cy="988.3" r="2.5" fill="#f472b6" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="742.4" cy="998.2" r="2.5" fill="#f472b6" stroke="#0d1117" stroke-width="0.8"/>
+  <path d="M117.8,1033.7L195.9,1013.7L274.0,997.5L352.0,985.9L430.1,979.6L508.2,977.9L586.3,973.8L664.3,977.8L742.4,990.5" fill="none" stroke="#f87171" stroke-width="1.8"/>
+  <circle cx="117.8" cy="1033.7" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="195.9" cy="1013.7" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="274.0" cy="997.5" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="352.0" cy="985.9" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="430.1" cy="979.6" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="508.2" cy="977.9" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="586.3" cy="973.8" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="664.3" cy="977.8" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="742.4" cy="990.5" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
+  <path d="M117.8,1036.4L195.9,1018.4L274.0,1004.6L352.0,994.9L430.1,990.8L508.2,990.6L586.3,987.8L664.3,995.1L742.4,1003.7" fill="none" stroke="#f472b6" stroke-width="1.8"/>
+  <circle cx="117.8" cy="1036.4" r="2.5" fill="#f472b6" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="195.9" cy="1018.4" r="2.5" fill="#f472b6" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="274.0" cy="1004.6" r="2.5" fill="#f472b6" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="352.0" cy="994.9" r="2.5" fill="#f472b6" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="430.1" cy="990.8" r="2.5" fill="#f472b6" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="508.2" cy="990.6" r="2.5" fill="#f472b6" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="586.3" cy="987.8" r="2.5" fill="#f472b6" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="664.3" cy="995.1" r="2.5" fill="#f472b6" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="742.4" cy="1003.7" r="2.5" fill="#f472b6" stroke="#0d1117" stroke-width="0.8"/>
   <path d="M117.8,1066.6L195.9,1051.3L274.0,1028.8L352.0,1006.6L430.1,992.9L508.2,974.2L586.3,954.6L664.3,964.7L742.4,969.6" fill="none" stroke="#f59e0b" stroke-width="1.8"/>
   <circle cx="117.8" cy="1066.6" r="2.5" fill="#f59e0b" stroke="#0d1117" stroke-width="0.8"/>
   <circle cx="195.9" cy="1051.3" r="2.5" fill="#f59e0b" stroke="#0d1117" stroke-width="0.8"/>

--- a/doc/charts/x86_64/small_encode.svg
+++ b/doc/charts/x86_64/small_encode.svg
@@ -75,45 +75,45 @@
   <circle cx="717.6" cy="160.6" r="2.5" fill="#60a5fa" stroke="#0d1117" stroke-width="0.8"/>
   <circle cx="778.2" cy="161.5" r="2.5" fill="#60a5fa" stroke="#0d1117" stroke-width="0.8"/>
   <text x="784.2" y="164.5" text-anchor="start" fill="#60a5fa" font-size="7" font-weight="600">L4</text>
-  <path d="M111.6,103.5L172.2,101.9L232.8,85.8L293.4,81.5L354.0,80.0L414.6,92.7L475.2,122.5L535.8,132.3L596.4,137.9L657.0,141.7L717.6,144.9L778.2,145.7" fill="none" stroke="#f87171" stroke-width="0.7" stroke-opacity="0.35"/>
-  <path d="M111.6,100.3L172.2,93.2L232.8,79.1L293.4,71.1L354.0,73.3L414.6,90.6L475.2,131.4L535.8,139.4L596.4,143.1L657.0,145.9L717.6,148.5L778.2,149.3" fill="none" stroke="#f87171" stroke-width="0.7" stroke-opacity="0.35"/>
-  <path d="M111.6,103.5L172.2,101.8L232.8,85.5L293.4,81.3L354.0,80.0L414.6,123.0L475.2,135.5L535.8,142.6L596.4,145.2L657.0,147.7L717.6,150.1L778.2,150.7" fill="none" stroke="#f87171" stroke-width="0.7" stroke-opacity="0.35"/>
-  <path d="M111.6,105.9L172.2,104.2L232.8,89.7L293.4,86.6L354.0,86.1L414.6,129.9L475.2,140.0L535.8,146.2L596.4,148.2L657.0,150.1L717.6,152.1L778.2,152.4" fill="none" stroke="#f87171" stroke-width="0.7" stroke-opacity="0.35"/>
-  <path d="M111.6,112.7L172.2,104.6L232.8,95.5L293.4,93.3L354.0,92.5L414.6,137.1L475.2,144.4L535.8,149.9L596.4,151.1L657.0,152.5L717.6,154.3L778.2,154.6" fill="none" stroke="#f87171" stroke-width="0.7" stroke-opacity="0.35"/>
-  <path d="M111.6,118.1L172.2,115.1L232.8,103.3L293.4,100.4L354.0,101.0L414.6,143.8L475.2,149.5L535.8,153.6L596.4,154.2L657.0,155.1L717.6,156.4L778.2,157.2" fill="none" stroke="#f87171" stroke-width="0.7" stroke-opacity="0.35"/>
-  <path d="M111.6,123.1L172.2,121.6L232.8,112.9L293.4,110.9L354.0,110.5L414.6,149.0L475.2,153.8L535.8,157.0L596.4,156.7L657.0,157.2L717.6,158.3L778.2,158.6" fill="none" stroke="#f87171" stroke-width="0.7" stroke-opacity="0.35"/>
-  <text x="784.2" y="161.6" text-anchor="start" fill="#f87171" font-size="7" font-weight="600" fill-opacity="0.5">L−1</text>
-  <path d="M111.6,193.0L172.2,175.9L232.8,171.8L293.4,164.0L354.0,162.6L414.6,164.7L475.2,163.6L535.8,162.2L596.4,159.2L657.0,157.7L717.6,158.3L778.2,158.1" fill="none" stroke="#f87171" stroke-width="0.7" stroke-opacity="0.35"/>
-  <path d="M111.6,193.0L172.2,176.3L232.8,172.0L293.4,163.6L354.0,163.0L414.6,164.8L475.2,164.8L535.8,164.5L596.4,165.1L657.0,163.2L717.6,161.8L778.2,161.3" fill="none" stroke="#f87171" stroke-width="0.7" stroke-opacity="0.35"/>
-  <path d="M111.6,199.6L172.2,184.0L232.8,181.3L293.4,174.0L354.0,170.3L414.6,177.1L475.2,179.1L535.8,180.8L596.4,181.7L657.0,180.3L717.6,178.3L778.2,177.2" fill="none" stroke="#f87171" stroke-width="0.7" stroke-opacity="0.35"/>
-  <path d="M111.6,100.3L172.2,93.2L232.8,79.1L293.4,70.4L354.0,72.8L414.6,83.8L475.2,112.6L535.8,126.1L596.4,133.4L657.0,136.2L717.6,138.5L778.2,138.4" fill="none" stroke="#f87171" stroke-width="1.5"/>
-  <circle cx="111.6" cy="100.3" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="172.2" cy="93.2" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="232.8" cy="79.1" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="293.4" cy="70.4" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="354.0" cy="72.8" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="414.6" cy="83.8" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="475.2" cy="112.6" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="535.8" cy="126.1" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="596.4" cy="133.4" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="657.0" cy="136.2" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="717.6" cy="138.5" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
+  <path d="M111.6,103.8L172.2,102.2L232.8,86.2L293.4,81.6L354.0,80.3L414.6,93.8L475.2,123.2L535.8,132.2L596.4,138.9L657.0,143.6L717.6,144.5L778.2,145.4" fill="none" stroke="#f87171" stroke-width="0.7" stroke-opacity="0.35"/>
+  <path d="M111.6,100.4L172.2,93.9L232.8,79.9L293.4,71.2L354.0,73.2L414.6,90.5L475.2,131.8L535.8,139.4L596.4,144.5L657.0,148.0L717.6,148.2L778.2,149.1" fill="none" stroke="#f87171" stroke-width="0.7" stroke-opacity="0.35"/>
+  <path d="M111.6,103.8L172.2,102.5L232.8,86.2L293.4,81.6L354.0,80.3L414.6,123.1L475.2,135.8L535.8,142.5L596.4,146.6L657.0,150.0L717.6,149.7L778.2,150.5" fill="none" stroke="#f87171" stroke-width="0.7" stroke-opacity="0.35"/>
+  <path d="M111.6,106.3L172.2,105.4L232.8,90.2L293.4,86.7L354.0,86.5L414.6,130.1L475.2,140.2L535.8,145.9L596.4,148.7L657.0,152.1L717.6,151.5L778.2,152.2" fill="none" stroke="#f87171" stroke-width="0.7" stroke-opacity="0.35"/>
+  <path d="M111.6,113.1L172.2,105.2L232.8,96.1L293.4,93.1L354.0,93.0L414.6,136.7L475.2,144.6L535.8,149.5L596.4,151.7L657.0,154.7L717.6,153.8L778.2,154.4" fill="none" stroke="#f87171" stroke-width="0.7" stroke-opacity="0.35"/>
+  <path d="M111.6,118.6L172.2,115.6L232.8,103.7L293.4,100.5L354.0,101.0L414.6,143.9L475.2,149.8L535.8,153.3L596.4,154.9L657.0,157.3L717.6,155.7L778.2,156.5" fill="none" stroke="#f87171" stroke-width="0.7" stroke-opacity="0.35"/>
+  <path d="M111.6,123.4L172.2,122.1L232.8,113.2L293.4,111.2L354.0,111.2L414.6,148.9L475.2,154.1L535.8,156.6L596.4,157.2L657.0,159.3L717.6,157.7L778.2,158.5" fill="none" stroke="#f87171" stroke-width="0.7" stroke-opacity="0.35"/>
+  <text x="784.2" y="161.5" text-anchor="start" fill="#f87171" font-size="7" font-weight="600" fill-opacity="0.5">L−1</text>
+  <path d="M111.6,192.7L172.2,177.1L232.8,171.6L293.4,163.1L354.0,163.9L414.6,165.2L475.2,163.9L535.8,162.0L596.4,159.8L657.0,160.0L717.6,157.5L778.2,157.9" fill="none" stroke="#f87171" stroke-width="0.7" stroke-opacity="0.35"/>
+  <path d="M111.6,192.6L172.2,177.5L232.8,171.6L293.4,163.2L354.0,163.9L414.6,165.1L475.2,165.4L535.8,164.8L596.4,166.0L657.0,164.3L717.6,161.6L778.2,161.4" fill="none" stroke="#f87171" stroke-width="0.7" stroke-opacity="0.35"/>
+  <path d="M111.6,198.8L172.2,184.3L232.8,180.9L293.4,173.4L354.0,170.5L414.6,177.5L475.2,179.9L535.8,181.8L596.4,183.2L657.0,182.0L717.6,178.5L778.2,177.4" fill="none" stroke="#f87171" stroke-width="0.7" stroke-opacity="0.35"/>
+  <path d="M111.6,100.4L172.2,93.6L232.8,79.8L293.4,71.2L354.0,73.2L414.6,84.1L475.2,113.9L535.8,126.5L596.4,133.6L657.0,137.1L717.6,138.4L778.2,138.4" fill="none" stroke="#f87171" stroke-width="1.5"/>
+  <circle cx="111.6" cy="100.4" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="172.2" cy="93.6" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="232.8" cy="79.8" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="293.4" cy="71.2" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="354.0" cy="73.2" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="414.6" cy="84.1" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="475.2" cy="113.9" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="535.8" cy="126.5" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="596.4" cy="133.6" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="657.0" cy="137.1" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="717.6" cy="138.4" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
   <circle cx="778.2" cy="138.4" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
   <text x="784.2" y="141.4" text-anchor="start" fill="#f87171" font-size="7" font-weight="600">L−8</text>
-  <path d="M111.6,202.7L172.2,185.9L232.8,182.4L293.4,175.6L354.0,171.6L414.6,177.9L475.2,179.4L535.8,181.5L596.4,181.7L657.0,180.3L717.6,179.5L778.2,193.7" fill="none" stroke="#f87171" stroke-width="1.5" stroke-dasharray="4,3"/>
-  <circle cx="111.6" cy="202.7" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
+  <path d="M111.6,201.5L172.2,185.9L232.8,181.9L293.4,174.8L354.0,172.2L414.6,177.9L475.2,180.8L535.8,182.8L596.4,183.8L657.0,182.0L717.6,179.7L778.2,196.6" fill="none" stroke="#f87171" stroke-width="1.5" stroke-dasharray="4,3"/>
+  <circle cx="111.6" cy="201.5" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
   <circle cx="172.2" cy="185.9" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="232.8" cy="182.4" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="293.4" cy="175.6" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="354.0" cy="171.6" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="232.8" cy="181.9" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="293.4" cy="174.8" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="354.0" cy="172.2" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
   <circle cx="414.6" cy="177.9" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="475.2" cy="179.4" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="535.8" cy="181.5" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="596.4" cy="181.7" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="657.0" cy="180.3" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="717.6" cy="179.5" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="778.2" cy="193.7" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
-  <text x="784.2" y="196.7" text-anchor="start" fill="#f87171" font-size="7" font-weight="600">L4</text>
+  <circle cx="475.2" cy="180.8" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="535.8" cy="182.8" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="596.4" cy="183.8" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="657.0" cy="182.0" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="717.6" cy="179.7" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="778.2" cy="196.6" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
+  <text x="784.2" y="199.6" text-anchor="start" fill="#f87171" font-size="7" font-weight="600">L4</text>
   <path d="M111.6,155.2L172.2,134.8L232.8,123.7L293.4,116.6L354.0,109.6L414.6,125.2L475.2,137.9L535.8,141.2L596.4,142.1L657.0,152.4L717.6,135.4L778.2,134.6" fill="none" stroke="#f59e0b" stroke-width="0.7" stroke-opacity="0.35"/>
   <path d="M111.6,158.0L172.2,134.9L232.8,126.4L293.4,119.2L354.0,114.4L414.6,130.0L475.2,141.4L535.8,143.3L596.4,143.9L657.0,154.0L717.6,136.9L778.2,136.1" fill="none" stroke="#f59e0b" stroke-width="0.7" stroke-opacity="0.35"/>
   <path d="M111.6,148.2L172.2,134.7L232.8,129.0L293.4,122.8L354.0,120.7L414.6,139.1L475.2,146.9L535.8,148.4L596.4,148.1L657.0,157.2L717.6,141.2L778.2,140.4" fill="none" stroke="#f59e0b" stroke-width="0.7" stroke-opacity="0.35"/>
@@ -228,45 +228,45 @@
   <circle cx="717.6" cy="368.6" r="2.5" fill="#60a5fa" stroke="#0d1117" stroke-width="0.8"/>
   <circle cx="778.2" cy="368.0" r="2.5" fill="#60a5fa" stroke="#0d1117" stroke-width="0.8"/>
   <text x="784.2" y="371.0" text-anchor="start" fill="#60a5fa" font-size="7" font-weight="600">L4</text>
-  <path d="M111.6,412.1L172.2,404.1L232.8,386.3L293.4,370.8L354.0,358.5L414.6,347.5L475.2,360.7L535.8,356.6L596.4,355.9L657.0,357.3L717.6,356.1L778.2,355.4" fill="none" stroke="#f87171" stroke-width="0.7" stroke-opacity="0.35"/>
-  <path d="M111.6,408.4L172.2,400.6L232.8,380.2L293.4,364.5L354.0,353.5L414.6,344.6L475.2,360.2L535.8,360.9L596.4,361.3L657.0,361.2L717.6,362.4L778.2,361.3" fill="none" stroke="#f87171" stroke-width="0.7" stroke-opacity="0.35"/>
-  <path d="M111.6,412.1L172.2,404.1L232.8,386.4L293.4,371.3L354.0,358.5L414.6,383.3L475.2,365.0L535.8,367.1L596.4,365.3L657.0,365.3L717.6,365.7L778.2,365.8" fill="none" stroke="#f87171" stroke-width="0.7" stroke-opacity="0.35"/>
-  <path d="M111.6,412.4L172.2,408.7L232.8,385.5L293.4,370.1L354.0,357.4L414.6,382.4L475.2,364.1L535.8,364.0L596.4,366.1L657.0,366.7L717.6,367.2L778.2,367.6" fill="none" stroke="#f87171" stroke-width="0.7" stroke-opacity="0.35"/>
-  <path d="M111.6,416.5L172.2,409.6L232.8,387.9L293.4,370.4L354.0,358.4L414.6,380.3L475.2,370.1L535.8,364.9L596.4,365.3L657.0,367.0L717.6,367.9L778.2,368.1" fill="none" stroke="#f87171" stroke-width="0.7" stroke-opacity="0.35"/>
-  <path d="M111.6,419.7L172.2,407.8L232.8,384.3L293.4,369.3L354.0,358.3L414.6,379.2L475.2,369.6L535.8,365.5L596.4,365.4L657.0,368.0L717.6,368.3L778.2,369.3" fill="none" stroke="#f87171" stroke-width="0.7" stroke-opacity="0.35"/>
-  <path d="M111.6,425.7L172.2,413.4L232.8,389.2L293.4,372.9L354.0,361.3L414.6,380.6L475.2,371.3L535.8,367.7L596.4,367.6L657.0,369.6L717.6,370.6L778.2,371.6" fill="none" stroke="#f87171" stroke-width="0.7" stroke-opacity="0.35"/>
-  <text x="784.2" y="374.6" text-anchor="start" fill="#f87171" font-size="7" font-weight="600" fill-opacity="0.5">L−1</text>
-  <path d="M111.6,491.5L172.2,465.4L232.8,435.9L293.4,425.2L354.0,400.1L414.6,382.6L475.2,376.5L535.8,379.9L596.4,375.9L657.0,379.0L717.6,377.7L778.2,377.7" fill="none" stroke="#f87171" stroke-width="0.7" stroke-opacity="0.35"/>
-  <path d="M111.6,491.4L172.2,465.4L232.8,435.7L293.4,427.6L354.0,400.1L414.6,383.5L475.2,376.7L535.8,384.1L596.4,381.1L657.0,381.4L717.6,379.8L778.2,378.3" fill="none" stroke="#f87171" stroke-width="0.7" stroke-opacity="0.35"/>
-  <path d="M111.6,493.5L172.2,469.7L232.8,440.4L293.4,431.6L354.0,406.6L414.6,391.4L475.2,387.0L535.8,393.5L596.4,390.1L657.0,391.7L717.6,388.3L778.2,385.7" fill="none" stroke="#f87171" stroke-width="0.7" stroke-opacity="0.35"/>
-  <path d="M111.6,408.4L172.2,400.6L232.8,380.2L293.4,364.5L354.0,353.5L414.6,342.8L475.2,339.8L535.8,343.9L596.4,349.6L657.0,351.6L717.6,350.7L778.2,350.8" fill="none" stroke="#f87171" stroke-width="1.5"/>
+  <path d="M111.6,412.5L172.2,404.4L232.8,386.3L293.4,370.6L354.0,359.0L414.6,347.6L475.2,360.8L535.8,356.8L596.4,355.4L657.0,356.7L717.6,356.2L778.2,355.6" fill="none" stroke="#f87171" stroke-width="0.7" stroke-opacity="0.35"/>
+  <path d="M111.6,408.5L172.2,400.9L232.8,380.3L293.4,364.7L354.0,354.2L414.6,344.3L475.2,360.4L535.8,360.4L596.4,360.7L657.0,361.7L717.6,362.5L778.2,361.7" fill="none" stroke="#f87171" stroke-width="0.7" stroke-opacity="0.35"/>
+  <path d="M111.6,412.7L172.2,404.5L232.8,386.4L293.4,370.7L354.0,359.1L414.6,383.7L475.2,363.8L535.8,365.9L596.4,365.3L657.0,365.9L717.6,365.8L778.2,366.4" fill="none" stroke="#f87171" stroke-width="0.7" stroke-opacity="0.35"/>
+  <path d="M111.6,412.9L172.2,409.1L232.8,385.7L293.4,369.9L354.0,357.6L414.6,382.2L475.2,363.6L535.8,365.6L596.4,365.9L657.0,367.4L717.6,367.3L778.2,368.0" fill="none" stroke="#f87171" stroke-width="0.7" stroke-opacity="0.35"/>
+  <path d="M111.6,417.1L172.2,410.1L232.8,387.9L293.4,370.4L354.0,359.0L414.6,380.5L475.2,370.6L535.8,366.3L596.4,366.3L657.0,367.6L717.6,368.1L778.2,368.6" fill="none" stroke="#f87171" stroke-width="0.7" stroke-opacity="0.35"/>
+  <path d="M111.6,420.2L172.2,408.3L232.8,384.4L293.4,369.3L354.0,358.9L414.6,379.5L475.2,369.7L535.8,365.5L596.4,366.3L657.0,368.4L717.6,368.4L778.2,369.6" fill="none" stroke="#f87171" stroke-width="0.7" stroke-opacity="0.35"/>
+  <path d="M111.6,426.2L172.2,413.7L232.8,389.2L293.4,372.8L354.0,361.6L414.6,381.1L475.2,371.3L535.8,368.0L596.4,368.4L657.0,369.6L717.6,370.4L778.2,371.7" fill="none" stroke="#f87171" stroke-width="0.7" stroke-opacity="0.35"/>
+  <text x="784.2" y="374.7" text-anchor="start" fill="#f87171" font-size="7" font-weight="600" fill-opacity="0.5">L−1</text>
+  <path d="M111.6,494.9L172.2,465.4L232.8,435.3L293.4,426.4L354.0,400.8L414.6,382.2L475.2,377.8L535.8,380.2L596.4,376.4L657.0,378.0L717.6,377.6L778.2,378.0" fill="none" stroke="#f87171" stroke-width="0.7" stroke-opacity="0.35"/>
+  <path d="M111.6,494.7L172.2,465.3L232.8,435.8L293.4,425.9L354.0,400.7L414.6,383.5L475.2,377.1L535.8,384.6L596.4,381.8L657.0,381.4L717.6,379.6L778.2,378.3" fill="none" stroke="#f87171" stroke-width="0.7" stroke-opacity="0.35"/>
+  <path d="M111.6,496.1L172.2,469.4L232.8,439.5L293.4,429.6L354.0,406.9L414.6,391.0L475.2,388.1L535.8,394.4L596.4,391.3L657.0,391.5L717.6,388.2L778.2,385.9" fill="none" stroke="#f87171" stroke-width="0.7" stroke-opacity="0.35"/>
+  <path d="M111.6,408.4L172.2,400.8L232.8,380.3L293.4,364.7L354.0,354.2L414.6,343.6L475.2,339.5L535.8,343.9L596.4,348.5L657.0,350.6L717.6,350.5L778.2,350.8" fill="none" stroke="#f87171" stroke-width="1.5"/>
   <circle cx="111.6" cy="408.4" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="172.2" cy="400.6" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="232.8" cy="380.2" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="293.4" cy="364.5" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="354.0" cy="353.5" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="414.6" cy="342.8" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="475.2" cy="339.8" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="172.2" cy="400.8" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="232.8" cy="380.3" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="293.4" cy="364.7" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="354.0" cy="354.2" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="414.6" cy="343.6" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="475.2" cy="339.5" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
   <circle cx="535.8" cy="343.9" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="596.4" cy="349.6" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="657.0" cy="351.6" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="717.6" cy="350.7" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="596.4" cy="348.5" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="657.0" cy="350.6" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="717.6" cy="350.5" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
   <circle cx="778.2" cy="350.8" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
   <text x="784.2" y="353.8" text-anchor="start" fill="#f87171" font-size="7" font-weight="600">L−8</text>
-  <path d="M111.6,497.8L172.2,471.9L232.8,442.1L293.4,433.3L354.0,407.7L414.6,392.6L475.2,387.5L535.8,393.5L596.4,390.4L657.0,391.8L717.6,390.9L778.2,398.2" fill="none" stroke="#f87171" stroke-width="1.5" stroke-dasharray="4,3"/>
-  <circle cx="111.6" cy="497.8" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="172.2" cy="471.9" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="232.8" cy="442.1" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="293.4" cy="433.3" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="354.0" cy="407.7" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="414.6" cy="392.6" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="475.2" cy="387.5" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="535.8" cy="393.5" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="596.4" cy="390.4" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="657.0" cy="391.8" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
+  <path d="M111.6,500.6L172.2,472.4L232.8,442.4L293.4,431.9L354.0,407.8L414.6,392.2L475.2,388.6L535.8,394.7L596.4,391.6L657.0,391.7L717.6,390.9L778.2,398.1" fill="none" stroke="#f87171" stroke-width="1.5" stroke-dasharray="4,3"/>
+  <circle cx="111.6" cy="500.6" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="172.2" cy="472.4" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="232.8" cy="442.4" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="293.4" cy="431.9" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="354.0" cy="407.8" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="414.6" cy="392.2" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="475.2" cy="388.6" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="535.8" cy="394.7" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="596.4" cy="391.6" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="657.0" cy="391.7" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
   <circle cx="717.6" cy="390.9" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="778.2" cy="398.2" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
-  <text x="784.2" y="401.2" text-anchor="start" fill="#f87171" font-size="7" font-weight="600">L4</text>
+  <circle cx="778.2" cy="398.1" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
+  <text x="784.2" y="401.1" text-anchor="start" fill="#f87171" font-size="7" font-weight="600">L4</text>
   <path d="M111.6,451.0L172.2,434.1L232.8,424.4L293.4,401.6L354.0,388.8L414.6,379.2L475.2,372.9L535.8,373.6L596.4,374.8L657.0,375.7L717.6,373.9L778.2,372.9" fill="none" stroke="#f59e0b" stroke-width="0.7" stroke-opacity="0.35"/>
   <path d="M111.6,459.4L172.2,435.3L232.8,426.1L293.4,402.4L354.0,389.0L414.6,374.9L475.2,375.5L535.8,378.5L596.4,379.4L657.0,380.8L717.6,377.8L778.2,377.5" fill="none" stroke="#f59e0b" stroke-width="0.7" stroke-opacity="0.35"/>
   <path d="M111.6,461.5L172.2,436.7L232.8,425.3L293.4,402.8L354.0,390.0L414.6,376.9L475.2,376.2L535.8,379.0L596.4,380.0L657.0,382.1L717.6,378.8L778.2,378.6" fill="none" stroke="#f59e0b" stroke-width="0.7" stroke-opacity="0.35"/>
@@ -381,45 +381,45 @@
   <circle cx="717.6" cy="612.0" r="2.5" fill="#60a5fa" stroke="#0d1117" stroke-width="0.8"/>
   <circle cx="778.2" cy="615.1" r="2.5" fill="#60a5fa" stroke="#0d1117" stroke-width="0.8"/>
   <text x="784.2" y="618.1" text-anchor="start" fill="#60a5fa" font-size="7" font-weight="600">L4</text>
-  <path d="M111.6,689.6L172.2,687.4L232.8,675.3L293.4,668.0L354.0,664.3L414.6,654.6L475.2,657.7L535.8,644.1L596.4,631.0L657.0,627.0L717.6,624.7L778.2,627.1" fill="none" stroke="#f87171" stroke-width="0.7" stroke-opacity="0.35"/>
-  <path d="M111.6,685.7L172.2,683.0L232.8,672.7L293.4,666.8L354.0,662.7L414.6,653.9L475.2,656.8L535.8,645.9L596.4,632.7L657.0,627.8L717.6,625.8L778.2,627.9" fill="none" stroke="#f87171" stroke-width="0.7" stroke-opacity="0.35"/>
-  <path d="M111.6,689.7L172.2,687.3L232.8,675.4L293.4,668.0L354.0,664.3L414.6,674.5L475.2,658.6L535.8,646.9L596.4,633.7L657.0,628.3L717.6,625.8L778.2,628.2" fill="none" stroke="#f87171" stroke-width="0.7" stroke-opacity="0.35"/>
-  <path d="M111.6,689.0L172.2,686.1L232.8,677.2L293.4,670.1L354.0,667.4L414.6,681.5L475.2,664.7L535.8,647.0L596.4,633.3L657.0,629.7L717.6,627.1L778.2,629.2" fill="none" stroke="#f87171" stroke-width="0.7" stroke-opacity="0.35"/>
-  <path d="M111.6,692.7L172.2,689.4L232.8,680.1L293.4,671.3L354.0,667.0L414.6,679.5L475.2,664.8L535.8,650.3L596.4,633.7L657.0,630.2L717.6,626.9L778.2,629.4" fill="none" stroke="#f87171" stroke-width="0.7" stroke-opacity="0.35"/>
-  <path d="M111.6,695.7L172.2,692.5L232.8,681.5L293.4,672.5L354.0,668.8L414.6,681.2L475.2,666.0L535.8,651.2L596.4,634.3L657.0,630.5L717.6,626.5L778.2,629.2" fill="none" stroke="#f87171" stroke-width="0.7" stroke-opacity="0.35"/>
-  <path d="M111.6,698.3L172.2,694.1L232.8,682.1L293.4,675.2L354.0,671.1L414.6,679.8L475.2,663.0L535.8,648.7L596.4,634.9L657.0,630.6L717.6,626.8L778.2,628.8" fill="none" stroke="#f87171" stroke-width="0.7" stroke-opacity="0.35"/>
-  <text x="784.2" y="631.8" text-anchor="start" fill="#f87171" font-size="7" font-weight="600" fill-opacity="0.5">L−1</text>
-  <path d="M111.6,746.9L172.2,742.0L232.8,722.1L293.4,704.1L354.0,696.9L414.6,685.0L475.2,667.3L535.8,651.4L596.4,637.1L657.0,633.2L717.6,629.8L778.2,632.3" fill="none" stroke="#f87171" stroke-width="0.7" stroke-opacity="0.35"/>
-  <path d="M111.6,746.9L172.2,741.3L232.8,722.4L293.4,704.0L354.0,696.8L414.6,685.1L475.2,667.4L535.8,654.0L596.4,640.8L657.0,635.5L717.6,631.5L778.2,633.5" fill="none" stroke="#f87171" stroke-width="0.7" stroke-opacity="0.35"/>
-  <path d="M111.6,752.0L172.2,745.0L232.8,726.2L293.4,709.9L354.0,702.8L414.6,689.7L475.2,673.7L535.8,658.1L596.4,643.5L657.0,637.9L717.6,631.0L778.2,631.7" fill="none" stroke="#f87171" stroke-width="0.7" stroke-opacity="0.35"/>
-  <path d="M111.6,684.5L172.2,682.5L232.8,672.5L293.4,666.8L354.0,662.7L414.6,652.8L475.2,640.7L535.8,633.5L596.4,624.8L657.0,620.2L717.6,618.8L778.2,620.8" fill="none" stroke="#f87171" stroke-width="1.5"/>
+  <path d="M111.6,690.2L172.2,686.6L232.8,675.1L293.4,668.3L354.0,664.2L414.6,654.7L475.2,656.9L535.8,645.1L596.4,631.9L657.0,628.2L717.6,625.9L778.2,628.3" fill="none" stroke="#f87171" stroke-width="0.7" stroke-opacity="0.35"/>
+  <path d="M111.6,684.5L172.2,682.4L232.8,672.7L293.4,666.9L354.0,663.2L414.6,653.6L475.2,655.6L535.8,645.8L596.4,633.4L657.0,629.1L717.6,627.0L778.2,628.1" fill="none" stroke="#f87171" stroke-width="0.7" stroke-opacity="0.35"/>
+  <path d="M111.6,689.8L172.2,686.5L232.8,675.2L293.4,668.2L354.0,664.2L414.6,674.5L475.2,658.0L535.8,646.8L596.4,634.4L657.0,629.5L717.6,627.0L778.2,628.4" fill="none" stroke="#f87171" stroke-width="0.7" stroke-opacity="0.35"/>
+  <path d="M111.6,688.9L172.2,686.2L232.8,677.2L293.4,670.4L354.0,666.6L414.6,681.8L475.2,664.4L535.8,647.1L596.4,634.2L657.0,631.0L717.6,628.5L778.2,629.6" fill="none" stroke="#f87171" stroke-width="0.7" stroke-opacity="0.35"/>
+  <path d="M111.6,692.8L172.2,689.6L232.8,680.5L293.4,671.7L354.0,666.4L414.6,679.1L475.2,664.5L535.8,650.3L596.4,634.4L657.0,631.5L717.6,628.2L778.2,629.7" fill="none" stroke="#f87171" stroke-width="0.7" stroke-opacity="0.35"/>
+  <path d="M111.6,695.9L172.2,692.2L232.8,681.3L293.4,672.8L354.0,668.4L414.6,681.7L475.2,665.7L535.8,651.3L596.4,635.0L657.0,631.6L717.6,627.8L778.2,629.5" fill="none" stroke="#f87171" stroke-width="0.7" stroke-opacity="0.35"/>
+  <path d="M111.6,698.0L172.2,694.1L232.8,682.0L293.4,673.9L354.0,670.5L414.6,679.9L475.2,662.9L535.8,648.8L596.4,635.7L657.0,631.7L717.6,628.1L778.2,629.1" fill="none" stroke="#f87171" stroke-width="0.7" stroke-opacity="0.35"/>
+  <text x="784.2" y="632.1" text-anchor="start" fill="#f87171" font-size="7" font-weight="600" fill-opacity="0.5">L−1</text>
+  <path d="M111.6,746.2L172.2,740.8L232.8,722.1L293.4,704.7L354.0,696.5L414.6,685.5L475.2,667.2L535.8,651.5L596.4,637.1L657.0,634.1L717.6,630.8L778.2,632.3" fill="none" stroke="#f87171" stroke-width="0.7" stroke-opacity="0.35"/>
+  <path d="M111.6,746.4L172.2,740.7L232.8,722.1L293.4,704.4L354.0,696.2L414.6,685.1L475.2,667.1L535.8,653.9L596.4,640.7L657.0,636.6L717.6,632.5L778.2,633.5" fill="none" stroke="#f87171" stroke-width="0.7" stroke-opacity="0.35"/>
+  <path d="M111.6,752.0L172.2,744.6L232.8,725.9L293.4,710.2L354.0,702.2L414.6,690.0L475.2,674.3L535.8,658.1L596.4,643.7L657.0,638.0L717.6,631.8L778.2,631.8" fill="none" stroke="#f87171" stroke-width="0.7" stroke-opacity="0.35"/>
+  <path d="M111.6,684.5L172.2,682.4L232.8,672.7L293.4,666.9L354.0,663.2L414.6,653.0L475.2,640.4L535.8,633.4L596.4,625.5L657.0,621.1L717.6,619.0L778.2,621.9" fill="none" stroke="#f87171" stroke-width="1.5"/>
   <circle cx="111.6" cy="684.5" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="172.2" cy="682.5" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="232.8" cy="672.5" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="293.4" cy="666.8" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="354.0" cy="662.7" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="414.6" cy="652.8" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="475.2" cy="640.7" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="535.8" cy="633.5" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="596.4" cy="624.8" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="657.0" cy="620.2" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="717.6" cy="618.8" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="778.2" cy="620.8" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
-  <text x="784.2" y="623.8" text-anchor="start" fill="#f87171" font-size="7" font-weight="600">L−8</text>
-  <path d="M111.6,752.9L172.2,745.8L232.8,726.4L293.4,710.3L354.0,702.8L414.6,689.7L475.2,673.7L535.8,658.1L596.4,644.1L657.0,637.9L717.6,634.6L778.2,643.9" fill="none" stroke="#f87171" stroke-width="1.5" stroke-dasharray="4,3"/>
-  <circle cx="111.6" cy="752.9" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="172.2" cy="745.8" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="232.8" cy="726.4" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="293.4" cy="710.3" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="354.0" cy="702.8" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="414.6" cy="689.7" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="475.2" cy="673.7" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="535.8" cy="658.1" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="596.4" cy="644.1" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="657.0" cy="637.9" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="717.6" cy="634.6" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="778.2" cy="643.9" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
-  <text x="784.2" y="646.9" text-anchor="start" fill="#f87171" font-size="7" font-weight="600">L4</text>
+  <circle cx="172.2" cy="682.4" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="232.8" cy="672.7" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="293.4" cy="666.9" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="354.0" cy="663.2" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="414.6" cy="653.0" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="475.2" cy="640.4" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="535.8" cy="633.4" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="596.4" cy="625.5" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="657.0" cy="621.1" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="717.6" cy="619.0" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="778.2" cy="621.9" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
+  <text x="784.2" y="624.9" text-anchor="start" fill="#f87171" font-size="7" font-weight="600">L−8</text>
+  <path d="M111.6,752.1L172.2,745.6L232.8,726.6L293.4,710.2L354.0,702.2L414.6,690.0L475.2,674.3L535.8,658.7L596.4,644.3L657.0,638.0L717.6,635.4L778.2,643.7" fill="none" stroke="#f87171" stroke-width="1.5" stroke-dasharray="4,3"/>
+  <circle cx="111.6" cy="752.1" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="172.2" cy="745.6" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="232.8" cy="726.6" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="293.4" cy="710.2" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="354.0" cy="702.2" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="414.6" cy="690.0" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="475.2" cy="674.3" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="535.8" cy="658.7" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="596.4" cy="644.3" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="657.0" cy="638.0" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="717.6" cy="635.4" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="778.2" cy="643.7" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
+  <text x="784.2" y="646.7" text-anchor="start" fill="#f87171" font-size="7" font-weight="600">L4</text>
   <path d="M111.6,727.6L172.2,738.5L232.8,720.4L293.4,705.6L354.0,694.1L414.6,680.7L475.2,669.0L535.8,659.7L596.4,646.3L657.0,642.2L717.6,635.6L778.2,639.2" fill="none" stroke="#f59e0b" stroke-width="0.7" stroke-opacity="0.35"/>
   <path d="M111.6,756.6L172.2,740.3L232.8,721.1L293.4,705.9L354.0,694.6L414.6,682.4L475.2,670.0L535.8,659.9L596.4,646.7L657.0,643.1L717.6,636.0L778.2,639.7" fill="none" stroke="#f59e0b" stroke-width="0.7" stroke-opacity="0.35"/>
   <path d="M111.6,758.2L172.2,742.0L232.8,722.9L293.4,707.6L354.0,697.9L414.6,687.1L475.2,673.1L535.8,662.6L596.4,648.4L657.0,643.1L717.6,635.3L778.2,638.6" fill="none" stroke="#f59e0b" stroke-width="0.7" stroke-opacity="0.35"/>
@@ -485,133 +485,133 @@
   <text x="717.6" y="1099" text-anchor="middle" fill="#7d8590" font-size="9">512K</text>
   <line x1="778.2" y1="865" x2="778.2" y2="1085" stroke="#21262d" stroke-width="1"/>
   <text x="778.2" y="1099" text-anchor="middle" fill="#7d8590" font-size="9">1M</text>
-  <line x1="90" y1="1051.9" x2="790" y2="1051.9" stroke="#21262d" stroke-width="1"/>
-  <text x="82" y="1051.9" text-anchor="end" dominant-baseline="middle" fill="#7d8590" font-size="9">50</text>
-  <line x1="90" y1="1025.6" x2="790" y2="1025.6" stroke="#21262d" stroke-width="1"/>
-  <text x="82" y="1025.6" text-anchor="end" dominant-baseline="middle" fill="#7d8590" font-size="9">100</text>
-  <line x1="90" y1="999.3" x2="790" y2="999.3" stroke="#21262d" stroke-width="1"/>
-  <text x="82" y="999.3" text-anchor="end" dominant-baseline="middle" fill="#7d8590" font-size="9">200</text>
-  <line x1="90" y1="964.6" x2="790" y2="964.6" stroke="#21262d" stroke-width="1"/>
-  <text x="82" y="964.6" text-anchor="end" dominant-baseline="middle" fill="#7d8590" font-size="9">500</text>
-  <line x1="90" y1="938.3" x2="790" y2="938.3" stroke="#21262d" stroke-width="1"/>
-  <text x="82" y="938.3" text-anchor="end" dominant-baseline="middle" fill="#7d8590" font-size="9">1000</text>
-  <line x1="90" y1="912.0" x2="790" y2="912.0" stroke="#21262d" stroke-width="1"/>
-  <text x="82" y="912.0" text-anchor="end" dominant-baseline="middle" fill="#7d8590" font-size="9">2000</text>
-  <line x1="90" y1="877.3" x2="790" y2="877.3" stroke="#21262d" stroke-width="1"/>
-  <text x="82" y="877.3" text-anchor="end" dominant-baseline="middle" fill="#7d8590" font-size="9">5000</text>
-  <path d="M111.6,997.1L172.2,975.1L232.8,954.2L293.4,934.0L354.0,921.8L414.6,916.1L475.2,907.6L535.8,909.5L596.4,915.3L657.0,939.6L717.6,883.4L778.2,889.2" fill="none" stroke="#60a5fa" stroke-width="0.7" stroke-opacity="0.35"/>
-  <path d="M111.6,1001.1L172.2,979.1L232.8,957.5L293.4,937.6L354.0,917.6L414.6,908.4L475.2,901.8L535.8,910.5L596.4,918.4L657.0,940.5L717.6,883.9L778.2,887.9" fill="none" stroke="#60a5fa" stroke-width="0.7" stroke-opacity="0.35"/>
-  <path d="M111.6,1002.0L172.2,981.4L232.8,960.9L293.4,940.1L354.0,920.4L414.6,909.1L475.2,900.7L535.8,907.7L596.4,913.5L657.0,947.0L717.6,875.5L778.2,887.6" fill="none" stroke="#60a5fa" stroke-width="0.7" stroke-opacity="0.35"/>
-  <path d="M111.6,1002.0L172.2,980.6L232.8,959.6L293.4,939.4L354.0,930.2L414.6,919.3L475.2,919.1L535.8,925.1L596.4,926.2L657.0,954.1L717.6,881.8L778.2,890.1" fill="none" stroke="#60a5fa" stroke-width="0.7" stroke-opacity="0.35"/>
-  <path d="M111.6,1000.9L172.2,979.8L232.8,960.5L293.4,947.8L354.0,928.0L414.6,908.1L475.2,923.3L535.8,933.5L596.4,933.1L657.0,960.0L717.6,875.1L778.2,891.9" fill="none" stroke="#60a5fa" stroke-width="0.7" stroke-opacity="0.35"/>
-  <path d="M111.6,1005.4L172.2,984.4L232.8,964.2L293.4,943.3L354.0,922.5L414.6,903.6L475.2,913.4L535.8,936.2L596.4,941.3L657.0,966.6L717.6,886.8L778.2,894.6" fill="none" stroke="#60a5fa" stroke-width="0.7" stroke-opacity="0.35"/>
-  <path d="M111.6,1008.0L172.2,988.1L232.8,967.4L293.4,946.0L354.0,944.1L414.6,951.9L475.2,953.2L535.8,960.0L596.4,961.1L657.0,979.7L717.6,893.6L778.2,898.3" fill="none" stroke="#60a5fa" stroke-width="0.7" stroke-opacity="0.35"/>
-  <text x="784.2" y="901.3" text-anchor="start" fill="#60a5fa" font-size="7" font-weight="600" fill-opacity="0.5">L−1</text>
-  <path d="M111.6,1038.8L172.2,1020.9L232.8,1001.1L293.4,984.2L354.0,976.4L414.6,978.9L475.2,949.9L535.8,948.6L596.4,945.2L657.0,949.6L717.6,960.5L778.2,959.7" fill="none" stroke="#60a5fa" stroke-width="0.7" stroke-opacity="0.35"/>
-  <path d="M111.6,1038.8L172.2,1021.7L232.8,1001.2L293.4,984.1L354.0,977.3L414.6,981.4L475.2,985.6L535.8,990.9L596.4,995.1L657.0,1007.4L717.6,979.3L778.2,988.9" fill="none" stroke="#60a5fa" stroke-width="0.7" stroke-opacity="0.35"/>
-  <path d="M111.6,1043.1L172.2,1028.5L232.8,1015.2L293.4,1008.2L354.0,1005.2L414.6,1007.9L475.2,1002.0L535.8,1009.6L596.4,1013.9L657.0,1026.0L717.6,1025.5L778.2,1027.0" fill="none" stroke="#60a5fa" stroke-width="0.7" stroke-opacity="0.35"/>
-  <path d="M111.6,997.1L172.2,975.1L232.8,954.2L293.4,934.0L354.0,917.6L414.6,903.6L475.2,900.7L535.8,907.7L596.4,913.5L657.0,939.6L717.6,875.1L778.2,887.6" fill="none" stroke="#60a5fa" stroke-width="1.5"/>
-  <circle cx="111.6" cy="997.1" r="2.5" fill="#60a5fa" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="172.2" cy="975.1" r="2.5" fill="#60a5fa" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="232.8" cy="954.2" r="2.5" fill="#60a5fa" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="293.4" cy="934.0" r="2.5" fill="#60a5fa" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="354.0" cy="917.6" r="2.5" fill="#60a5fa" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="414.6" cy="903.6" r="2.5" fill="#60a5fa" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="475.2" cy="900.7" r="2.5" fill="#60a5fa" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="535.8" cy="907.7" r="2.5" fill="#60a5fa" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="596.4" cy="913.5" r="2.5" fill="#60a5fa" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="657.0" cy="939.6" r="2.5" fill="#60a5fa" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="717.6" cy="875.1" r="2.5" fill="#60a5fa" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="778.2" cy="887.6" r="2.5" fill="#60a5fa" stroke="#0d1117" stroke-width="0.8"/>
-  <text x="784.2" y="890.6" text-anchor="start" fill="#60a5fa" font-size="7" font-weight="600">L−7</text>
-  <path d="M111.6,1054.6L172.2,1045.4L232.8,1038.0L293.4,1035.9L354.0,1039.0L414.6,1046.5L475.2,1013.3L535.8,1019.4L596.4,1024.1L657.0,1043.5L717.6,1026.9L778.2,1028.6" fill="none" stroke="#60a5fa" stroke-width="1.5" stroke-dasharray="4,3"/>
-  <circle cx="111.6" cy="1054.6" r="2.5" fill="#60a5fa" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="172.2" cy="1045.4" r="2.5" fill="#60a5fa" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="232.8" cy="1038.0" r="2.5" fill="#60a5fa" stroke="#0d1117" stroke-width="0.8"/>
+  <line x1="90" y1="1051.8" x2="790" y2="1051.8" stroke="#21262d" stroke-width="1"/>
+  <text x="82" y="1051.8" text-anchor="end" dominant-baseline="middle" fill="#7d8590" font-size="9">50</text>
+  <line x1="90" y1="1025.5" x2="790" y2="1025.5" stroke="#21262d" stroke-width="1"/>
+  <text x="82" y="1025.5" text-anchor="end" dominant-baseline="middle" fill="#7d8590" font-size="9">100</text>
+  <line x1="90" y1="999.2" x2="790" y2="999.2" stroke="#21262d" stroke-width="1"/>
+  <text x="82" y="999.2" text-anchor="end" dominant-baseline="middle" fill="#7d8590" font-size="9">200</text>
+  <line x1="90" y1="964.4" x2="790" y2="964.4" stroke="#21262d" stroke-width="1"/>
+  <text x="82" y="964.4" text-anchor="end" dominant-baseline="middle" fill="#7d8590" font-size="9">500</text>
+  <line x1="90" y1="938.1" x2="790" y2="938.1" stroke="#21262d" stroke-width="1"/>
+  <text x="82" y="938.1" text-anchor="end" dominant-baseline="middle" fill="#7d8590" font-size="9">1000</text>
+  <line x1="90" y1="911.8" x2="790" y2="911.8" stroke="#21262d" stroke-width="1"/>
+  <text x="82" y="911.8" text-anchor="end" dominant-baseline="middle" fill="#7d8590" font-size="9">2000</text>
+  <line x1="90" y1="877.0" x2="790" y2="877.0" stroke="#21262d" stroke-width="1"/>
+  <text x="82" y="877.0" text-anchor="end" dominant-baseline="middle" fill="#7d8590" font-size="9">5000</text>
+  <path d="M111.6,997.0L172.2,975.0L232.8,954.1L293.4,933.8L354.0,921.6L414.6,915.8L475.2,907.3L535.8,909.3L596.4,915.1L657.0,939.5L717.6,883.1L778.2,889.0" fill="none" stroke="#60a5fa" stroke-width="0.7" stroke-opacity="0.35"/>
+  <path d="M111.6,1001.0L172.2,978.9L232.8,957.4L293.4,937.4L354.0,917.4L414.6,908.2L475.2,901.5L535.8,910.3L596.4,918.2L657.0,940.3L717.6,883.7L778.2,887.6" fill="none" stroke="#60a5fa" stroke-width="0.7" stroke-opacity="0.35"/>
+  <path d="M111.6,1001.9L172.2,981.3L232.8,960.7L293.4,939.9L354.0,920.2L414.6,908.9L475.2,900.5L535.8,907.5L596.4,913.3L657.0,946.9L717.6,875.2L778.2,887.4" fill="none" stroke="#60a5fa" stroke-width="0.7" stroke-opacity="0.35"/>
+  <path d="M111.6,1001.9L172.2,980.5L232.8,959.4L293.4,939.2L354.0,930.0L414.6,919.1L475.2,918.9L535.8,924.9L596.4,926.0L657.0,954.0L717.6,881.6L778.2,889.9" fill="none" stroke="#60a5fa" stroke-width="0.7" stroke-opacity="0.35"/>
+  <path d="M111.6,1000.8L172.2,979.7L232.8,960.3L293.4,947.7L354.0,927.8L414.6,907.9L475.2,923.1L535.8,933.4L596.4,933.0L657.0,959.9L717.6,874.8L778.2,891.7" fill="none" stroke="#60a5fa" stroke-width="0.7" stroke-opacity="0.35"/>
+  <path d="M111.6,1005.3L172.2,984.2L232.8,964.1L293.4,943.1L354.0,922.3L414.6,903.4L475.2,913.2L535.8,936.0L596.4,941.1L657.0,966.5L717.6,886.6L778.2,894.4" fill="none" stroke="#60a5fa" stroke-width="0.7" stroke-opacity="0.35"/>
+  <path d="M111.6,1007.9L172.2,988.0L232.8,967.3L293.4,945.9L354.0,944.0L414.6,951.8L475.2,953.1L535.8,959.8L596.4,960.9L657.0,979.6L717.6,893.4L778.2,898.0" fill="none" stroke="#60a5fa" stroke-width="0.7" stroke-opacity="0.35"/>
+  <text x="784.2" y="901.0" text-anchor="start" fill="#60a5fa" font-size="7" font-weight="600" fill-opacity="0.5">L−1</text>
+  <path d="M111.6,1038.8L172.2,1020.8L232.8,1001.0L293.4,984.1L354.0,976.2L414.6,978.7L475.2,949.7L535.8,948.4L596.4,945.0L657.0,949.4L717.6,960.3L778.2,959.6" fill="none" stroke="#60a5fa" stroke-width="0.7" stroke-opacity="0.35"/>
+  <path d="M111.6,1038.8L172.2,1021.6L232.8,1001.1L293.4,984.0L354.0,977.2L414.6,981.2L475.2,985.5L535.8,990.8L596.4,995.0L657.0,1007.3L717.6,979.2L778.2,988.8" fill="none" stroke="#60a5fa" stroke-width="0.7" stroke-opacity="0.35"/>
+  <path d="M111.6,1043.0L172.2,1028.4L232.8,1015.1L293.4,1008.1L354.0,1005.1L414.6,1007.8L475.2,1001.9L535.8,1009.5L596.4,1013.8L657.0,1025.9L717.6,1025.5L778.2,1027.0" fill="none" stroke="#60a5fa" stroke-width="0.7" stroke-opacity="0.35"/>
+  <path d="M111.6,997.0L172.2,975.0L232.8,954.1L293.4,933.8L354.0,917.4L414.6,903.4L475.2,900.5L535.8,907.5L596.4,913.3L657.0,939.5L717.6,874.8L778.2,887.4" fill="none" stroke="#60a5fa" stroke-width="1.5"/>
+  <circle cx="111.6" cy="997.0" r="2.5" fill="#60a5fa" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="172.2" cy="975.0" r="2.5" fill="#60a5fa" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="232.8" cy="954.1" r="2.5" fill="#60a5fa" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="293.4" cy="933.8" r="2.5" fill="#60a5fa" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="354.0" cy="917.4" r="2.5" fill="#60a5fa" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="414.6" cy="903.4" r="2.5" fill="#60a5fa" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="475.2" cy="900.5" r="2.5" fill="#60a5fa" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="535.8" cy="907.5" r="2.5" fill="#60a5fa" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="596.4" cy="913.3" r="2.5" fill="#60a5fa" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="657.0" cy="939.5" r="2.5" fill="#60a5fa" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="717.6" cy="874.8" r="2.5" fill="#60a5fa" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="778.2" cy="887.4" r="2.5" fill="#60a5fa" stroke="#0d1117" stroke-width="0.8"/>
+  <text x="784.2" y="890.4" text-anchor="start" fill="#60a5fa" font-size="7" font-weight="600">L−7</text>
+  <path d="M111.6,1054.5L172.2,1045.3L232.8,1037.9L293.4,1035.9L354.0,1039.0L414.6,1046.5L475.2,1013.2L535.8,1019.4L596.4,1024.1L657.0,1043.4L717.6,1026.8L778.2,1028.6" fill="none" stroke="#60a5fa" stroke-width="1.5" stroke-dasharray="4,3"/>
+  <circle cx="111.6" cy="1054.5" r="2.5" fill="#60a5fa" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="172.2" cy="1045.3" r="2.5" fill="#60a5fa" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="232.8" cy="1037.9" r="2.5" fill="#60a5fa" stroke="#0d1117" stroke-width="0.8"/>
   <circle cx="293.4" cy="1035.9" r="2.5" fill="#60a5fa" stroke="#0d1117" stroke-width="0.8"/>
   <circle cx="354.0" cy="1039.0" r="2.5" fill="#60a5fa" stroke="#0d1117" stroke-width="0.8"/>
   <circle cx="414.6" cy="1046.5" r="2.5" fill="#60a5fa" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="475.2" cy="1013.3" r="2.5" fill="#60a5fa" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="475.2" cy="1013.2" r="2.5" fill="#60a5fa" stroke="#0d1117" stroke-width="0.8"/>
   <circle cx="535.8" cy="1019.4" r="2.5" fill="#60a5fa" stroke="#0d1117" stroke-width="0.8"/>
   <circle cx="596.4" cy="1024.1" r="2.5" fill="#60a5fa" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="657.0" cy="1043.5" r="2.5" fill="#60a5fa" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="717.6" cy="1026.9" r="2.5" fill="#60a5fa" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="657.0" cy="1043.4" r="2.5" fill="#60a5fa" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="717.6" cy="1026.8" r="2.5" fill="#60a5fa" stroke="#0d1117" stroke-width="0.8"/>
   <circle cx="778.2" cy="1028.6" r="2.5" fill="#60a5fa" stroke="#0d1117" stroke-width="0.8"/>
   <text x="784.2" y="1031.6" text-anchor="start" fill="#60a5fa" font-size="7" font-weight="600">L4</text>
-  <path d="M111.6,983.0L172.2,977.2L232.8,958.2L293.4,940.6L354.0,918.7L414.6,899.4L475.2,885.4L535.8,877.6L596.4,870.9L657.0,877.6L717.6,889.4L778.2,904.3" fill="none" stroke="#f87171" stroke-width="0.7" stroke-opacity="0.35"/>
-  <path d="M111.6,979.2L172.2,974.7L232.8,955.7L293.4,938.7L354.0,917.6L414.6,902.2L475.2,889.4L535.8,886.0L596.4,886.1L657.0,889.0L717.6,899.4L778.2,910.5" fill="none" stroke="#f87171" stroke-width="0.7" stroke-opacity="0.35"/>
-  <path d="M111.6,983.0L172.2,978.2L232.8,958.2L293.4,940.6L354.0,918.7L414.6,903.2L475.2,886.8L535.8,880.4L596.4,880.0L657.0,887.0L717.6,900.4L778.2,911.5" fill="none" stroke="#f87171" stroke-width="0.7" stroke-opacity="0.35"/>
-  <path d="M111.6,985.1L172.2,981.7L232.8,961.9L293.4,944.7L354.0,921.9L414.6,905.7L475.2,888.7L535.8,881.2L596.4,875.7L657.0,887.4L717.6,903.9L778.2,914.7" fill="none" stroke="#f87171" stroke-width="0.7" stroke-opacity="0.35"/>
-  <path d="M111.6,984.0L172.2,980.3L232.8,959.6L293.4,942.8L354.0,920.9L414.6,904.8L475.2,895.2L535.8,893.3L596.4,895.1L657.0,899.8L717.6,948.7L778.2,943.6" fill="none" stroke="#f87171" stroke-width="0.7" stroke-opacity="0.35"/>
-  <path d="M111.6,986.6L172.2,982.5L232.8,961.8L293.4,951.4L354.0,928.3L414.6,910.7L475.2,893.6L535.8,880.8L596.4,894.5L657.0,902.2L717.6,972.6L778.2,985.6" fill="none" stroke="#f87171" stroke-width="0.7" stroke-opacity="0.35"/>
-  <path d="M111.6,991.0L172.2,986.3L232.8,965.4L293.4,947.4L354.0,924.5L414.6,907.7L475.2,890.2L535.8,878.3L596.4,870.3L657.0,900.4L717.6,977.6L778.2,990.8" fill="none" stroke="#f87171" stroke-width="0.7" stroke-opacity="0.35"/>
-  <text x="784.2" y="993.8" text-anchor="start" fill="#f87171" font-size="7" font-weight="600" fill-opacity="0.5">L−1</text>
-  <path d="M111.6,1003.5L172.2,1002.0L232.8,992.4L293.4,987.6L354.0,952.1L414.6,929.4L475.2,927.3L535.8,927.6L596.4,930.5L657.0,989.8L717.6,1005.1L778.2,1009.9" fill="none" stroke="#f87171" stroke-width="0.7" stroke-opacity="0.35"/>
-  <path d="M111.6,1003.5L172.2,1002.0L232.8,992.4L293.4,986.6L354.0,952.1L414.6,929.4L475.2,928.6L535.8,933.6L596.4,941.8L657.0,1001.9L717.6,1021.2L778.2,1029.4" fill="none" stroke="#f87171" stroke-width="0.7" stroke-opacity="0.35"/>
-  <path d="M111.6,1003.6L172.2,994.2L232.8,977.5L293.4,964.2L354.0,925.6L414.6,911.2L475.2,927.1L535.8,942.4L596.4,954.8L657.0,913.7L717.6,1006.0L778.2,1023.4" fill="none" stroke="#f87171" stroke-width="0.7" stroke-opacity="0.35"/>
-  <path d="M111.6,979.2L172.2,974.7L232.8,955.7L293.4,938.7L354.0,917.6L414.6,898.3L475.2,885.4L535.8,877.6L596.4,870.3L657.0,877.6L717.6,889.4L778.2,900.4" fill="none" stroke="#f87171" stroke-width="1.5"/>
+  <path d="M111.6,983.2L172.2,977.2L232.8,957.7L293.4,940.4L354.0,918.8L414.6,897.8L475.2,885.3L535.8,878.1L596.4,871.0L657.0,878.3L717.6,889.5L778.2,903.1" fill="none" stroke="#f87171" stroke-width="0.7" stroke-opacity="0.35"/>
+  <path d="M111.6,979.3L172.2,974.6L232.8,955.5L293.4,938.5L354.0,917.6L414.6,899.9L475.2,889.4L535.8,886.3L596.4,886.0L657.0,889.3L717.6,899.6L778.2,909.2" fill="none" stroke="#f87171" stroke-width="0.7" stroke-opacity="0.35"/>
+  <path d="M111.6,983.2L172.2,977.3L232.8,957.8L293.4,940.4L354.0,918.8L414.6,900.9L475.2,886.5L535.8,880.8L596.4,880.2L657.0,887.2L717.6,900.4L778.2,910.3" fill="none" stroke="#f87171" stroke-width="0.7" stroke-opacity="0.35"/>
+  <path d="M111.6,985.0L172.2,980.4L232.8,961.8L293.4,944.5L354.0,921.9L414.6,903.4L475.2,888.4L535.8,881.5L596.4,875.7L657.0,887.9L717.6,903.8L778.2,913.6" fill="none" stroke="#f87171" stroke-width="0.7" stroke-opacity="0.35"/>
+  <path d="M111.6,984.1L172.2,978.9L232.8,959.7L293.4,942.5L354.0,921.0L414.6,902.6L475.2,895.2L535.8,893.5L596.4,895.1L657.0,900.2L717.6,949.2L778.2,942.7" fill="none" stroke="#f87171" stroke-width="0.7" stroke-opacity="0.35"/>
+  <path d="M111.6,986.3L172.2,980.7L232.8,961.6L293.4,951.4L354.0,928.4L414.6,908.8L475.2,893.4L535.8,881.2L596.4,894.6L657.0,902.7L717.6,972.9L778.2,985.1" fill="none" stroke="#f87171" stroke-width="0.7" stroke-opacity="0.35"/>
+  <path d="M111.6,991.0L172.2,984.3L232.8,965.3L293.4,946.9L354.0,924.5L414.6,905.6L475.2,890.0L535.8,878.8L596.4,870.3L657.0,900.7L717.6,977.9L778.2,990.5" fill="none" stroke="#f87171" stroke-width="0.7" stroke-opacity="0.35"/>
+  <text x="784.2" y="993.5" text-anchor="start" fill="#f87171" font-size="7" font-weight="600" fill-opacity="0.5">L−1</text>
+  <path d="M111.6,1002.2L172.2,1000.6L232.8,992.1L293.4,986.5L354.0,952.2L414.6,928.1L475.2,927.1L535.8,927.4L596.4,930.4L657.0,990.2L717.6,1005.6L778.2,1009.7" fill="none" stroke="#f87171" stroke-width="0.7" stroke-opacity="0.35"/>
+  <path d="M111.6,1002.2L172.2,1000.5L232.8,991.9L293.4,986.2L354.0,951.4L414.6,928.2L475.2,927.2L535.8,933.6L596.4,942.4L657.0,1002.1L717.6,1022.1L778.2,1030.4" fill="none" stroke="#f87171" stroke-width="0.7" stroke-opacity="0.35"/>
+  <path d="M111.6,1003.4L172.2,994.2L232.8,977.6L293.4,964.3L354.0,925.3L414.6,911.3L475.2,927.5L535.8,942.4L596.4,955.7L657.0,914.4L717.6,1006.4L778.2,1023.6" fill="none" stroke="#f87171" stroke-width="0.7" stroke-opacity="0.35"/>
+  <path d="M111.6,979.2L172.2,974.6L232.8,955.5L293.4,938.5L354.0,917.6L414.6,896.8L475.2,885.3L535.8,878.1L596.4,870.3L657.0,878.3L717.6,889.5L778.2,900.1" fill="none" stroke="#f87171" stroke-width="1.5"/>
   <circle cx="111.6" cy="979.2" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="172.2" cy="974.7" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="232.8" cy="955.7" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="293.4" cy="938.7" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="172.2" cy="974.6" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="232.8" cy="955.5" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="293.4" cy="938.5" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
   <circle cx="354.0" cy="917.6" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="414.6" cy="898.3" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="475.2" cy="885.4" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="535.8" cy="877.6" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="414.6" cy="896.8" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="475.2" cy="885.3" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="535.8" cy="878.1" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
   <circle cx="596.4" cy="870.3" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="657.0" cy="877.6" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="717.6" cy="889.4" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="778.2" cy="900.4" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
-  <text x="784.2" y="903.4" text-anchor="start" fill="#f87171" font-size="7" font-weight="600">L−8</text>
-  <path d="M111.6,1012.4L172.2,1010.9L232.8,1004.9L293.4,1000.4L354.0,969.3L414.6,947.2L475.2,952.3L535.8,958.0L596.4,963.0L657.0,1008.6L717.6,1026.2L778.2,1049.0" fill="none" stroke="#f87171" stroke-width="1.5" stroke-dasharray="4,3"/>
-  <circle cx="111.6" cy="1012.4" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="657.0" cy="878.3" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="717.6" cy="889.5" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="778.2" cy="900.1" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
+  <text x="784.2" y="903.1" text-anchor="start" fill="#f87171" font-size="7" font-weight="600">L−8</text>
+  <path d="M111.6,1012.2L172.2,1010.9L232.8,1004.8L293.4,1000.3L354.0,969.3L414.6,947.7L475.2,951.7L535.8,957.4L596.4,963.8L657.0,1008.2L717.6,1026.0L778.2,1047.7" fill="none" stroke="#f87171" stroke-width="1.5" stroke-dasharray="4,3"/>
+  <circle cx="111.6" cy="1012.2" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
   <circle cx="172.2" cy="1010.9" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="232.8" cy="1004.9" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="293.4" cy="1000.4" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="232.8" cy="1004.8" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="293.4" cy="1000.3" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
   <circle cx="354.0" cy="969.3" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="414.6" cy="947.2" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="475.2" cy="952.3" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="535.8" cy="958.0" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="596.4" cy="963.0" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="657.0" cy="1008.6" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="717.6" cy="1026.2" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="778.2" cy="1049.0" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
-  <text x="784.2" y="1052.0" text-anchor="start" fill="#f87171" font-size="7" font-weight="600">L4</text>
-  <path d="M111.6,1010.2L172.2,988.5L232.8,967.4L293.4,948.6L354.0,940.0L414.6,929.4L475.2,911.6L535.8,924.4L596.4,937.1L657.0,963.2L717.6,906.5L778.2,911.7" fill="none" stroke="#f59e0b" stroke-width="0.7" stroke-opacity="0.35"/>
-  <path d="M111.6,1014.3L172.2,992.1L232.8,971.2L293.4,951.9L354.0,929.7L414.6,916.9L475.2,906.9L535.8,926.5L596.4,940.2L657.0,964.2L717.6,908.4L778.2,910.2" fill="none" stroke="#f59e0b" stroke-width="0.7" stroke-opacity="0.35"/>
-  <path d="M111.6,1015.7L172.2,994.9L232.8,974.4L293.4,955.1L354.0,932.0L414.6,917.6L475.2,911.3L535.8,921.6L596.4,935.1L657.0,970.1L717.6,905.4L778.2,912.4" fill="none" stroke="#f59e0b" stroke-width="0.7" stroke-opacity="0.35"/>
-  <path d="M111.6,1027.1L172.2,1003.6L232.8,981.4L293.4,960.7L354.0,937.6L414.6,925.1L475.2,929.7L535.8,947.3L596.4,946.8L657.0,975.3L717.6,907.5L778.2,911.7" fill="none" stroke="#f59e0b" stroke-width="0.7" stroke-opacity="0.35"/>
-  <path d="M111.6,1015.1L172.2,993.8L232.8,972.7L293.4,967.6L354.0,944.4L414.6,923.4L475.2,934.7L535.8,956.8L596.4,952.0L657.0,979.7L717.6,915.3L778.2,918.3" fill="none" stroke="#f59e0b" stroke-width="0.7" stroke-opacity="0.35"/>
-  <path d="M111.6,1017.4L172.2,995.9L232.8,975.0L293.4,955.4L354.0,932.9L414.6,912.5L475.2,922.2L535.8,959.4L596.4,959.7L657.0,985.7L717.6,920.1L778.2,917.0" fill="none" stroke="#f59e0b" stroke-width="0.7" stroke-opacity="0.35"/>
-  <path d="M111.6,1019.8L172.2,998.7L232.8,978.6L293.4,958.2L354.0,957.5L414.6,966.4L475.2,977.2L535.8,980.3L596.4,978.1L657.0,996.7L717.6,914.3L778.2,919.9" fill="none" stroke="#f59e0b" stroke-width="0.7" stroke-opacity="0.35"/>
-  <text x="784.2" y="922.9" text-anchor="start" fill="#f59e0b" font-size="7" font-weight="600" fill-opacity="0.5">L−1</text>
-  <path d="M111.6,1064.0L172.2,1048.4L232.8,1028.5L293.4,1010.2L354.0,999.7L414.6,996.5L475.2,970.8L535.8,965.7L596.4,962.9L657.0,983.3L717.6,991.9L778.2,993.9" fill="none" stroke="#f59e0b" stroke-width="0.7" stroke-opacity="0.35"/>
-  <path d="M111.6,1064.3L172.2,1049.0L232.8,1029.0L293.4,1010.7L354.0,1001.2L414.6,1003.5L475.2,1011.5L535.8,1018.8L596.4,1017.8L657.0,1038.7L717.6,1002.9L778.2,1009.8" fill="none" stroke="#f59e0b" stroke-width="0.7" stroke-opacity="0.35"/>
-  <path d="M111.6,1070.4L172.2,1055.7L232.8,1042.3L293.4,1030.1L354.0,1023.9L414.6,1014.2L475.2,1025.0L535.8,1039.1L596.4,1042.4L657.0,1050.0L717.6,1052.9L778.2,1052.6" fill="none" stroke="#f59e0b" stroke-width="0.7" stroke-opacity="0.35"/>
-  <path d="M111.6,1010.2L172.2,988.5L232.8,967.4L293.4,948.6L354.0,929.7L414.6,912.5L475.2,906.9L535.8,921.6L596.4,935.1L657.0,963.2L717.6,905.4L778.2,910.2" fill="none" stroke="#f59e0b" stroke-width="1.5"/>
-  <circle cx="111.6" cy="1010.2" r="2.5" fill="#f59e0b" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="172.2" cy="988.5" r="2.5" fill="#f59e0b" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="232.8" cy="967.4" r="2.5" fill="#f59e0b" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="293.4" cy="948.6" r="2.5" fill="#f59e0b" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="354.0" cy="929.7" r="2.5" fill="#f59e0b" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="414.6" cy="912.5" r="2.5" fill="#f59e0b" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="475.2" cy="906.9" r="2.5" fill="#f59e0b" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="535.8" cy="921.6" r="2.5" fill="#f59e0b" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="596.4" cy="935.1" r="2.5" fill="#f59e0b" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="657.0" cy="963.2" r="2.5" fill="#f59e0b" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="717.6" cy="905.4" r="2.5" fill="#f59e0b" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="778.2" cy="910.2" r="2.5" fill="#f59e0b" stroke="#0d1117" stroke-width="0.8"/>
-  <text x="784.2" y="913.2" text-anchor="start" fill="#f59e0b" font-size="7" font-weight="600">L−7</text>
-  <path d="M111.6,1079.7L172.2,1069.9L232.8,1059.5L293.4,1056.5L354.0,1055.7L414.6,1062.7L475.2,1025.0L535.8,1040.6L596.4,1048.2L657.0,1062.8L717.6,1056.8L778.2,1057.1" fill="none" stroke="#f59e0b" stroke-width="1.5" stroke-dasharray="4,3"/>
+  <circle cx="414.6" cy="947.7" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="475.2" cy="951.7" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="535.8" cy="957.4" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="596.4" cy="963.8" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="657.0" cy="1008.2" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="717.6" cy="1026.0" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="778.2" cy="1047.7" r="2.5" fill="#f87171" stroke="#0d1117" stroke-width="0.8"/>
+  <text x="784.2" y="1050.7" text-anchor="start" fill="#f87171" font-size="7" font-weight="600">L4</text>
+  <path d="M111.6,1010.1L172.2,988.3L232.8,967.3L293.4,948.4L354.0,939.8L414.6,929.2L475.2,911.4L535.8,924.2L596.4,936.9L657.0,963.1L717.6,906.3L778.2,911.5" fill="none" stroke="#f59e0b" stroke-width="0.7" stroke-opacity="0.35"/>
+  <path d="M111.6,1014.2L172.2,992.0L232.8,971.0L293.4,951.8L354.0,929.5L414.6,916.7L475.2,906.7L535.8,926.3L596.4,940.1L657.0,964.0L717.6,908.2L778.2,910.0" fill="none" stroke="#f59e0b" stroke-width="0.7" stroke-opacity="0.35"/>
+  <path d="M111.6,1015.6L172.2,994.8L232.8,974.2L293.4,954.9L354.0,931.8L414.6,917.4L475.2,911.1L535.8,921.4L596.4,935.0L657.0,969.9L717.6,905.2L778.2,912.2" fill="none" stroke="#f59e0b" stroke-width="0.7" stroke-opacity="0.35"/>
+  <path d="M111.6,1027.0L172.2,1003.5L232.8,981.2L293.4,960.5L354.0,937.4L414.6,924.9L475.2,929.5L535.8,947.1L596.4,946.6L657.0,975.1L717.6,907.3L778.2,911.5" fill="none" stroke="#f59e0b" stroke-width="0.7" stroke-opacity="0.35"/>
+  <path d="M111.6,1015.0L172.2,993.7L232.8,972.6L293.4,967.5L354.0,944.2L414.6,923.2L475.2,934.6L535.8,956.7L596.4,951.9L657.0,979.6L717.6,915.1L778.2,918.1" fill="none" stroke="#f59e0b" stroke-width="0.7" stroke-opacity="0.35"/>
+  <path d="M111.6,1017.3L172.2,995.8L232.8,974.9L293.4,955.2L354.0,932.7L414.6,912.3L475.2,922.0L535.8,959.2L596.4,959.5L657.0,985.6L717.6,919.9L778.2,916.8" fill="none" stroke="#f59e0b" stroke-width="0.7" stroke-opacity="0.35"/>
+  <path d="M111.6,1019.7L172.2,998.6L232.8,978.5L293.4,958.1L354.0,957.3L414.6,966.3L475.2,977.0L535.8,980.2L596.4,978.0L657.0,996.6L717.6,914.1L778.2,919.7" fill="none" stroke="#f59e0b" stroke-width="0.7" stroke-opacity="0.35"/>
+  <text x="784.2" y="922.7" text-anchor="start" fill="#f59e0b" font-size="7" font-weight="600" fill-opacity="0.5">L−1</text>
+  <path d="M111.6,1064.0L172.2,1048.4L232.8,1028.5L293.4,1010.1L354.0,999.6L414.6,996.4L475.2,970.7L535.8,965.5L596.4,962.8L657.0,983.2L717.6,991.8L778.2,993.8" fill="none" stroke="#f59e0b" stroke-width="0.7" stroke-opacity="0.35"/>
+  <path d="M111.6,1064.3L172.2,1049.0L232.8,1028.9L293.4,1010.6L354.0,1001.1L414.6,1003.4L475.2,1011.4L535.8,1018.7L596.4,1017.8L657.0,1038.6L717.6,1002.8L778.2,1009.7" fill="none" stroke="#f59e0b" stroke-width="0.7" stroke-opacity="0.35"/>
+  <path d="M111.6,1070.3L172.2,1055.6L232.8,1042.3L293.4,1030.0L354.0,1023.8L414.6,1014.1L475.2,1024.9L535.8,1039.1L596.4,1042.3L657.0,1050.0L717.6,1052.9L778.2,1052.5" fill="none" stroke="#f59e0b" stroke-width="0.7" stroke-opacity="0.35"/>
+  <path d="M111.6,1010.1L172.2,988.3L232.8,967.3L293.4,948.4L354.0,929.5L414.6,912.3L475.2,906.7L535.8,921.4L596.4,935.0L657.0,963.1L717.6,905.2L778.2,910.0" fill="none" stroke="#f59e0b" stroke-width="1.5"/>
+  <circle cx="111.6" cy="1010.1" r="2.5" fill="#f59e0b" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="172.2" cy="988.3" r="2.5" fill="#f59e0b" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="232.8" cy="967.3" r="2.5" fill="#f59e0b" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="293.4" cy="948.4" r="2.5" fill="#f59e0b" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="354.0" cy="929.5" r="2.5" fill="#f59e0b" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="414.6" cy="912.3" r="2.5" fill="#f59e0b" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="475.2" cy="906.7" r="2.5" fill="#f59e0b" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="535.8" cy="921.4" r="2.5" fill="#f59e0b" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="596.4" cy="935.0" r="2.5" fill="#f59e0b" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="657.0" cy="963.1" r="2.5" fill="#f59e0b" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="717.6" cy="905.2" r="2.5" fill="#f59e0b" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="778.2" cy="910.0" r="2.5" fill="#f59e0b" stroke="#0d1117" stroke-width="0.8"/>
+  <text x="784.2" y="913.0" text-anchor="start" fill="#f59e0b" font-size="7" font-weight="600">L−7</text>
+  <path d="M111.6,1079.7L172.2,1069.9L232.8,1059.5L293.4,1056.4L354.0,1055.7L414.6,1062.7L475.2,1024.9L535.8,1040.6L596.4,1048.1L657.0,1062.8L717.6,1056.8L778.2,1057.1" fill="none" stroke="#f59e0b" stroke-width="1.5" stroke-dasharray="4,3"/>
   <circle cx="111.6" cy="1079.7" r="2.5" fill="#f59e0b" stroke="#0d1117" stroke-width="0.8"/>
   <circle cx="172.2" cy="1069.9" r="2.5" fill="#f59e0b" stroke="#0d1117" stroke-width="0.8"/>
   <circle cx="232.8" cy="1059.5" r="2.5" fill="#f59e0b" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="293.4" cy="1056.5" r="2.5" fill="#f59e0b" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="293.4" cy="1056.4" r="2.5" fill="#f59e0b" stroke="#0d1117" stroke-width="0.8"/>
   <circle cx="354.0" cy="1055.7" r="2.5" fill="#f59e0b" stroke="#0d1117" stroke-width="0.8"/>
   <circle cx="414.6" cy="1062.7" r="2.5" fill="#f59e0b" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="475.2" cy="1025.0" r="2.5" fill="#f59e0b" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="475.2" cy="1024.9" r="2.5" fill="#f59e0b" stroke="#0d1117" stroke-width="0.8"/>
   <circle cx="535.8" cy="1040.6" r="2.5" fill="#f59e0b" stroke="#0d1117" stroke-width="0.8"/>
-  <circle cx="596.4" cy="1048.2" r="2.5" fill="#f59e0b" stroke="#0d1117" stroke-width="0.8"/>
+  <circle cx="596.4" cy="1048.1" r="2.5" fill="#f59e0b" stroke="#0d1117" stroke-width="0.8"/>
   <circle cx="657.0" cy="1062.8" r="2.5" fill="#f59e0b" stroke="#0d1117" stroke-width="0.8"/>
   <circle cx="717.6" cy="1056.8" r="2.5" fill="#f59e0b" stroke="#0d1117" stroke-width="0.8"/>
   <circle cx="778.2" cy="1057.1" r="2.5" fill="#f59e0b" stroke="#0d1117" stroke-width="0.8"/>

--- a/doc/charts/x86_64/summary.svg
+++ b/doc/charts/x86_64/summary.svg
@@ -14,17 +14,17 @@
   <rect x="111.0" y="257.9" width="80.0" height="23.4" fill="#4680c4" rx="1"/>
   <rect x="111.0" y="250.8" width="80.0" height="7.1" fill="#60a5fa" rx="1"/>
   <text x="151.0" y="321" text-anchor="middle" fill="#e6edf3" font-size="10" font-weight="600">C zstd</text>
-  <rect x="223.0" y="267.4" width="80.0" height="37.6" fill="#f87171" rx="1"/>
-  <rect x="223.0" y="241.5" width="80.0" height="25.9" fill="#c45050" rx="1"/>
-  <rect x="223.0" y="227.6" width="80.0" height="13.9" fill="#f87171" rx="1"/>
+  <rect x="223.0" y="266.7" width="80.0" height="38.3" fill="#f87171" rx="1"/>
+  <rect x="223.0" y="240.8" width="80.0" height="25.9" fill="#c45050" rx="1"/>
+  <rect x="223.0" y="226.6" width="80.0" height="14.2" fill="#f87171" rx="1"/>
   <text x="263.0" y="321" text-anchor="middle" fill="#e6edf3" font-size="10" font-weight="600">zrip</text>
   <rect x="335.0" y="261.9" width="80.0" height="43.1" fill="#f59e0b" rx="1"/>
   <rect x="335.0" y="238.4" width="80.0" height="23.4" fill="#c47d08" rx="1"/>
   <rect x="335.0" y="227.7" width="80.0" height="10.7" fill="#f59e0b" rx="1"/>
   <text x="375.0" y="321" text-anchor="middle" fill="#e6edf3" font-size="10" font-weight="600">structured-zstd</text>
-  <rect x="447.0" y="253.5" width="80.0" height="51.5" fill="#f472b6" rx="1"/>
-  <rect x="447.0" y="227.6" width="80.0" height="25.9" fill="#c05a92" rx="1"/>
-  <rect x="447.0" y="209.9" width="80.0" height="17.7" fill="#f472b6" rx="1"/>
+  <rect x="447.0" y="252.3" width="80.0" height="52.7" fill="#f472b6" rx="1"/>
+  <rect x="447.0" y="226.4" width="80.0" height="25.9" fill="#c05a92" rx="1"/>
+  <rect x="447.0" y="208.6" width="80.0" height="17.8" fill="#f472b6" rx="1"/>
   <text x="487.0" y="321" text-anchor="middle" fill="#e6edf3" font-size="10" font-weight="600">zrip paranoid</text>
   <rect x="559.0" y="153.5" width="80.0" height="151.5" fill="#4ade80" rx="1"/>
   <rect x="559.0" y="122.8" width="80.0" height="30.7" fill="#3aaf60" rx="1"/>

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -76,6 +76,7 @@
 //! - **`nightly`**: `#[optimize]` attributes for hot paths.
 
 #![cfg_attr(not(feature = "std"), no_std)]
+#![deny(unsafe_op_in_unsafe_fn)]
 #![cfg_attr(feature = "paranoid", forbid(unsafe_code))]
 
 #[cfg(feature = "alloc")]


### PR DESCRIPTION
- Add `#![deny(unsafe_op_in_unsafe_fn)]` to all four crate roots
- Mark 4 safe functions with hidden contracts `unsafe fn` in default builds:
  - `bulk_rounds` in xxhash (`debug_assert`-only len guard)
  - `decode_single_stream_bmi2_safe`, `decode_4_streams_core_bmi2_safe` (`#[target_feature]` contract)
  - `SeqTable::get` (`assume_init` on `MaybeUninit`)
- Add `paranoid_unsafe_call!(...)` macro to core, encode, decode crates: expands to `unsafe { expr }` in default builds, passthrough in paranoid builds
- Collapse 22 duplicated cfg-conditional wrapper macros in `fast.rs`/`dfast.rs` into 11 single definitions using `paranoid_unsafe_call!`
- Relax `#![forbid(unsafe_code)]` to `#![cfg_attr(feature = "paranoid", forbid(unsafe_code))]` in `exec.rs` and `huffman/decode.rs` so `paranoid_unsafe_call!` works in default builds while paranoid mode still forbids all unsafe