### PR TITLE
Write compress_into output directly

### DIFF
--- a/crates/encode/src/block_encoder.rs
+++ b/crates/encode/src/block_encoder.rs
@@ -3,9 +3,11 @@
 #[cfg(feature = "alloc")]
 use alloc::vec::Vec;
 
+use crate::output::OutputSink;
 use crate::primitives;
 use zrip_core::Sequence;
 use zrip_core::bitstream::writer::BitWriter;
+use zrip_core::error::CompressError;
 use zrip_core::fse::{
     FseDecodeEntry, LL_BASELINE_TABLE, LL_BITS_TABLE, LL_DEFAULT_ACCURACY, LL_DEFAULT_DIST,
     ML_BASELINE_TABLE, ML_BITS_TABLE, ML_DEFAULT_ACCURACY, ML_DEFAULT_DIST, OF_DEFAULT_ACCURACY,
@@ -375,13 +377,17 @@ impl PredefinedEncodeTables {
     }
 }
 
-pub fn encode_raw_block(data: &[u8], last: bool, output: &mut Vec<u8>) {
+pub fn encode_raw_block(
+    data: &[u8],
+    last: bool,
+    output: &mut impl OutputSink,
+) -> Result<(), CompressError> {
     let block_size = data.len() as u32;
     let header = (block_size << 3) | if last { 1 } else { 0 };
-    output.push(header as u8);
-    output.push((header >> 8) as u8);
-    output.push((header >> 16) as u8);
-    output.extend_from_slice(data);
+    output.push(header as u8)?;
+    output.push((header >> 8) as u8)?;
+    output.push((header >> 16) as u8)?;
+    output.extend_from_slice(data)
 }
 
 pub(crate) fn encode_compressed_block(
@@ -389,20 +395,18 @@ pub(crate) fn encode_compressed_block(
     sequences: &[Sequence],
     rep_offsets: &mut [u32; 3],
     last: bool,
-    output: &mut Vec<u8>,
+    output: &mut impl OutputSink,
     workspace: &mut BlockEncodeWorkspace,
     use_custom_sequence_tables: bool,
-) {
+) -> Result<(), CompressError> {
     if sequences.is_empty() {
-        encode_raw_block(src, last, output);
-        return;
+        return encode_raw_block(src, last, output);
     }
 
     let n = sequences.len();
     let total_match: usize = sequences.iter().map(|s| s.match_length as usize).sum();
     if total_match <= n * 3 {
-        encode_raw_block(src, last, output);
-        return;
+        return encode_raw_block(src, last, output);
     }
 
     let saved_rep = *rep_offsets;
@@ -491,20 +495,19 @@ pub(crate) fn encode_compressed_block(
     let block_len = literal_section_len + seq_data.len();
     if block_len >= src.len() {
         *rep_offsets = saved_rep;
-        encode_raw_block(src, last, output);
-        return;
+        return encode_raw_block(src, last, output);
     }
 
     let block_size = block_len as u32;
     let header = (block_size << 3) | 0x04 | if last { 1 } else { 0 };
-    output.push(header as u8);
-    output.push((header >> 8) as u8);
-    output.push((header >> 16) as u8);
-    output.extend_from_slice(&workspace.lit_section);
+    output.push(header as u8)?;
+    output.push((header >> 8) as u8)?;
+    output.push((header >> 16) as u8)?;
+    output.extend_from_slice(&workspace.lit_section)?;
     if raw_literals {
-        output.extend_from_slice(&workspace.lit_buf);
+        output.extend_from_slice(&workspace.lit_buf)?;
     }
-    output.extend_from_slice(seq_data);
+    output.extend_from_slice(seq_data)
 }
 
 pub(crate) fn encode_compressed_block_raw(
@@ -512,19 +515,17 @@ pub(crate) fn encode_compressed_block_raw(
     sequences: &[Sequence],
     rep_offsets: &mut [u32; 3],
     last: bool,
-    output: &mut Vec<u8>,
+    output: &mut impl OutputSink,
     workspace: &mut BlockEncodeWorkspace,
-) {
+) -> Result<(), CompressError> {
     if sequences.is_empty() {
-        encode_raw_block(src, last, output);
-        return;
+        return encode_raw_block(src, last, output);
     }
 
     let n = sequences.len();
     let total_match: usize = sequences.iter().map(|s| s.match_length as usize).sum();
     if total_match <= n * 3 {
-        encode_raw_block(src, last, output);
-        return;
+        return encode_raw_block(src, last, output);
     }
 
     let saved_rep = *rep_offsets;
@@ -544,18 +545,17 @@ pub(crate) fn encode_compressed_block_raw(
         workspace.lit_section.len() + workspace.lit_buf.len() + workspace.pred_seq.len();
     if block_len >= src.len() {
         *rep_offsets = saved_rep;
-        encode_raw_block(src, last, output);
-        return;
+        return encode_raw_block(src, last, output);
     }
 
     let block_size = block_len as u32;
     let header = (block_size << 3) | 0x04 | if last { 1 } else { 0 };
-    output.push(header as u8);
-    output.push((header >> 8) as u8);
-    output.push((header >> 16) as u8);
-    output.extend_from_slice(&workspace.lit_section);
-    output.extend_from_slice(&workspace.lit_buf);
-    output.extend_from_slice(&workspace.pred_seq);
+    output.push(header as u8)?;
+    output.push((header >> 8) as u8)?;
+    output.push((header >> 16) as u8)?;
+    output.extend_from_slice(&workspace.lit_section)?;
+    output.extend_from_slice(&workspace.lit_buf)?;
+    output.extend_from_slice(&workspace.pred_seq)
 }
 
 fn pack_sequences_and_literals(

--- a/crates/encode/src/context.rs
+++ b/crates/encode/src/context.rs
@@ -314,10 +314,10 @@ impl CompressContext {
 
         self.output.clear();
         self.output.reserve(input.len() + 32);
-        write_frame_header(&mut self.output, input.len(), Some(dict_id));
+        write_frame_header(&mut self.output, input.len(), Some(dict_id))?;
 
         if input.is_empty() {
-            block_encoder::encode_raw_block(&[], true, &mut self.output);
+            block_encoder::encode_raw_block(&[], true, &mut self.output)?;
         } else if use_attached {
             let input_hash_log = if input.len() >= 2 {
                 let src_log = 32 - ((input.len() as u32) - 1).leading_zeros();
@@ -352,7 +352,7 @@ impl CompressContext {
                     true,
                     &mut self.output,
                     &mut self.workspace,
-                );
+                )?;
             } else {
                 block_encoder::encode_compressed_block(
                     input,
@@ -362,7 +362,7 @@ impl CompressContext {
                     &mut self.output,
                     &mut self.workspace,
                     strategy::use_custom_sequence_tables(&params, input.len()),
-                );
+                )?;
             }
         } else {
             let combined = &prep.combined;
@@ -402,7 +402,7 @@ impl CompressContext {
                         true,
                         &mut self.output,
                         &mut self.workspace,
-                    );
+                    )?;
                 } else {
                     block_encoder::encode_compressed_block(
                         input,
@@ -412,7 +412,7 @@ impl CompressContext {
                         &mut self.output,
                         &mut self.workspace,
                         strategy::use_custom_sequence_tables(&params, input.len()),
-                    );
+                    )?;
                 }
             } else {
                 let mut offset = 0;
@@ -452,7 +452,7 @@ impl CompressContext {
                             is_last,
                             &mut self.output,
                             &mut self.workspace,
-                        );
+                        )?;
                     } else {
                         block_encoder::encode_compressed_block(
                             &input[offset..offset + chunk_size],
@@ -462,7 +462,7 @@ impl CompressContext {
                             &mut self.output,
                             &mut self.workspace,
                             strategy::use_custom_sequence_tables(&params, input.len()),
-                        );
+                        )?;
                     }
                     offset += chunk_size;
                 }
@@ -552,10 +552,10 @@ fn compress_core(
 
     output.clear();
     output.reserve(input.len() + 32);
-    write_frame_header(output, input.len(), dict_id);
+    write_frame_header(output, input.len(), dict_id)?;
 
     if input.is_empty() {
-        block_encoder::encode_raw_block(&[], true, output);
+        block_encoder::encode_raw_block(&[], true, output)?;
     } else {
         let has_prefix = !prefix.is_empty();
         let mut rep_offsets = init_rep_offsets;
@@ -589,7 +589,7 @@ fn compress_core(
                             true,
                             output,
                             workspace,
-                        );
+                        )?;
                     } else {
                         block_encoder::encode_compressed_block(
                             input,
@@ -599,7 +599,7 @@ fn compress_core(
                             output,
                             workspace,
                             strategy::use_custom_sequence_tables(&params, input.len()),
-                        );
+                        )?;
                     }
                 } else if has_prefix {
                     combined.clear();
@@ -629,7 +629,7 @@ fn compress_core(
                                 is_last,
                                 output,
                                 workspace,
-                            );
+                            )?;
                         } else {
                             block_encoder::encode_compressed_block(
                                 &input[offset..offset + chunk_size],
@@ -639,7 +639,7 @@ fn compress_core(
                                 output,
                                 workspace,
                                 strategy::use_custom_sequence_tables(&params, input.len()),
-                            );
+                            )?;
                         }
                         offset += chunk_size;
                     }
@@ -655,7 +655,7 @@ fn compress_core(
                                 &input[offset..block_end],
                                 is_last,
                                 output,
-                            );
+                            )?;
                         } else {
                             fast::compress_fast_block(
                                 input,
@@ -674,7 +674,7 @@ fn compress_core(
                                     is_last,
                                     output,
                                     workspace,
-                                );
+                                )?;
                             } else {
                                 block_encoder::encode_compressed_block(
                                     &input[offset..block_end],
@@ -684,7 +684,7 @@ fn compress_core(
                                     output,
                                     workspace,
                                     strategy::use_custom_sequence_tables(&params, input.len()),
-                                );
+                                )?;
                             }
                         }
                         offset = block_end;
@@ -714,7 +714,7 @@ fn compress_core(
                         output,
                         workspace,
                         strategy::use_custom_sequence_tables(&params, input.len()),
-                    );
+                    )?;
                 } else if has_prefix {
                     combined.clear();
                     combined.reserve(prefix.len() + input.len());
@@ -752,7 +752,7 @@ fn compress_core(
                             output,
                             workspace,
                             strategy::use_custom_sequence_tables(&params, input.len()),
-                        );
+                        )?;
                         offset += chunk_size;
                     }
                 } else {
@@ -768,7 +768,7 @@ fn compress_core(
                                 &input[offset..block_end],
                                 is_last,
                                 output,
-                            );
+                            )?;
                         } else {
                             dfast::compress_dfast_block(
                                 input,
@@ -788,7 +788,7 @@ fn compress_core(
                                 output,
                                 workspace,
                                 strategy::use_custom_sequence_tables(&params, input.len()),
-                            );
+                            )?;
                         }
                         offset = block_end;
                     }

--- a/crates/encode/src/lib.rs
+++ b/crates/encode/src/lib.rs
@@ -27,6 +27,7 @@ pub(crate) mod dfast;
 pub(crate) mod fast;
 #[cfg(feature = "ldm")]
 pub(crate) mod ldm;
+mod output;
 pub(crate) mod primitives;
 pub mod strategy;
 #[cfg(feature = "std")]
@@ -37,13 +38,18 @@ use alloc::vec;
 #[cfg(feature = "alloc")]
 use alloc::vec::Vec;
 
+use crate::output::{OutputSink, SliceSink};
 use crate::strategy::Strategy;
 use zrip_core::error::CompressError;
 use zrip_core::frame::{MAX_BLOCK_SIZE, ZSTD_MAGIC};
 use zrip_core::xxhash::xxh64;
 
-pub(crate) fn write_frame_header(output: &mut Vec<u8>, content_size: usize, dict_id: Option<u32>) {
-    output.extend_from_slice(&ZSTD_MAGIC.to_le_bytes());
+pub(crate) fn write_frame_header(
+    output: &mut impl OutputSink,
+    content_size: usize,
+    dict_id: Option<u32>,
+) -> Result<(), CompressError> {
+    output.extend_from_slice(&ZSTD_MAGIC.to_le_bytes())?;
 
     let fcs_size = if content_size <= 255 {
         1
@@ -69,24 +75,25 @@ pub(crate) fn write_frame_header(output: &mut Vec<u8>, content_size: usize, dict
     };
 
     let descriptor = 0x20 | 0x04 | (fcs_flag << 6) | dict_id_flag;
-    output.push(descriptor);
+    output.push(descriptor)?;
 
     match dict_id {
-        Some(id) if id <= 0xFF => output.push(id as u8),
-        Some(id) if id <= 0xFFFF => output.extend_from_slice(&(id as u16).to_le_bytes()),
-        Some(id) => output.extend_from_slice(&id.to_le_bytes()),
+        Some(id) if id <= 0xFF => output.push(id as u8)?,
+        Some(id) if id <= 0xFFFF => output.extend_from_slice(&(id as u16).to_le_bytes())?,
+        Some(id) => output.extend_from_slice(&id.to_le_bytes())?,
         None => {}
     }
 
     match fcs_size {
-        1 => output.push(content_size as u8),
+        1 => output.push(content_size as u8)?,
         2 => {
             let v = (content_size - 256) as u16;
-            output.extend_from_slice(&v.to_le_bytes());
+            output.extend_from_slice(&v.to_le_bytes())?;
         }
-        4 => output.extend_from_slice(&(content_size as u32).to_le_bytes()),
-        _ => output.extend_from_slice(&(content_size as u64).to_le_bytes()),
+        4 => output.extend_from_slice(&(content_size as u32).to_le_bytes())?,
+        _ => output.extend_from_slice(&(content_size as u64).to_le_bytes())?,
     }
+    Ok(())
 }
 
 pub(crate) fn block_looks_incompressible(data: &[u8]) -> bool {
@@ -159,15 +166,19 @@ fn compress_inner(input: &[u8], params: &strategy::LevelParams) -> Result<Vec<u8
     let mut params = *params;
     strategy::apply_raw_literals_size_override(&mut params, input.len());
     let mut output = Vec::with_capacity(input.len() + 32);
-    compress_frame(input, &params, &mut output);
+    compress_frame(input, &params, &mut output)?;
     Ok(output)
 }
 
-fn compress_frame(input: &[u8], params: &strategy::LevelParams, output: &mut Vec<u8>) {
-    write_frame_header(output, input.len(), None);
+fn compress_frame(
+    input: &[u8],
+    params: &strategy::LevelParams,
+    output: &mut impl OutputSink,
+) -> Result<(), CompressError> {
+    write_frame_header(output, input.len(), None)?;
 
     if input.is_empty() {
-        block_encoder::encode_raw_block(&[], true, output);
+        block_encoder::encode_raw_block(&[], true, output)?;
     } else {
         let mut rep_offsets = [1u32, 4, 8];
         let mut offset = 0;
@@ -187,7 +198,11 @@ fn compress_frame(input: &[u8], params: &strategy::LevelParams, output: &mut Vec
                     let is_last = block_end >= input.len();
 
                     if block_looks_incompressible(&input[offset..block_end]) {
-                        block_encoder::encode_raw_block(&input[offset..block_end], is_last, output);
+                        block_encoder::encode_raw_block(
+                            &input[offset..block_end],
+                            is_last,
+                            output,
+                        )?;
                     } else {
                         #[cfg(feature = "ldm")]
                         let used_ldm = if let Some(ref mut ldm) = ldm_state {
@@ -228,7 +243,7 @@ fn compress_frame(input: &[u8], params: &strategy::LevelParams, output: &mut Vec
                                 is_last,
                                 output,
                                 &mut workspace,
-                            );
+                            )?;
                         } else {
                             block_encoder::encode_compressed_block(
                                 &input[offset..block_end],
@@ -238,7 +253,7 @@ fn compress_frame(input: &[u8], params: &strategy::LevelParams, output: &mut Vec
                                 output,
                                 &mut workspace,
                                 strategy::use_custom_sequence_tables(params, input.len()),
-                            );
+                            )?;
                         }
                     }
                     offset = block_end;
@@ -255,7 +270,11 @@ fn compress_frame(input: &[u8], params: &strategy::LevelParams, output: &mut Vec
                     let is_last = block_end >= input.len();
 
                     if block_looks_incompressible(&input[offset..block_end]) {
-                        block_encoder::encode_raw_block(&input[offset..block_end], is_last, output);
+                        block_encoder::encode_raw_block(
+                            &input[offset..block_end],
+                            is_last,
+                            output,
+                        )?;
                     } else {
                         #[cfg(feature = "ldm")]
                         let used_ldm = if let Some(ref mut ldm) = ldm_state {
@@ -296,7 +315,7 @@ fn compress_frame(input: &[u8], params: &strategy::LevelParams, output: &mut Vec
                             output,
                             &mut workspace,
                             strategy::use_custom_sequence_tables(params, input.len()),
-                        );
+                        )?;
                     }
                     offset = block_end;
                 }
@@ -306,7 +325,8 @@ fn compress_frame(input: &[u8], params: &strategy::LevelParams, output: &mut Vec
 
     let hash = xxh64(input, 0);
     let checksum = (hash & 0xFFFF_FFFF) as u32;
-    output.extend_from_slice(&checksum.to_le_bytes());
+    output.extend_from_slice(&checksum.to_le_bytes())?;
+    Ok(())
 }
 
 pub fn compress_with_dict(
@@ -320,10 +340,10 @@ pub fn compress_with_dict(
     strategy::apply_raw_literals_size_override(&mut params, input.len());
 
     let mut output = Vec::with_capacity(input.len() + 32);
-    write_frame_header(&mut output, input.len(), Some(dict.id()));
+    write_frame_header(&mut output, input.len(), Some(dict.id()))?;
 
     if input.is_empty() {
-        block_encoder::encode_raw_block(&[], true, &mut output);
+        block_encoder::encode_raw_block(&[], true, &mut output)?;
     } else {
         let prefix = dict.content();
         let mut rep_offsets = *dict.rep_offsets();
@@ -359,7 +379,7 @@ pub fn compress_with_dict(
                     true,
                     &mut output,
                     &mut workspace,
-                );
+                )?;
             } else {
                 block_encoder::encode_compressed_block(
                     input,
@@ -369,7 +389,7 @@ pub fn compress_with_dict(
                     &mut output,
                     &mut workspace,
                     strategy::use_custom_sequence_tables(&params, input.len()),
-                );
+                )?;
             }
         } else {
             let mut combined = Vec::with_capacity(prefix.len() + input.len());
@@ -404,7 +424,7 @@ pub fn compress_with_dict(
                                 is_last,
                                 &mut output,
                                 &mut workspace,
-                            );
+                            )?;
                         } else {
                             block_encoder::encode_compressed_block(
                                 &input[offset..offset + chunk_size],
@@ -414,7 +434,7 @@ pub fn compress_with_dict(
                                 &mut output,
                                 &mut workspace,
                                 strategy::use_custom_sequence_tables(&params, input.len()),
-                            );
+                            )?;
                         }
                         offset += chunk_size;
                     }
@@ -455,7 +475,7 @@ pub fn compress_with_dict(
                             &mut output,
                             &mut workspace,
                             strategy::use_custom_sequence_tables(&params, input.len()),
-                        );
+                        )?;
                         offset += chunk_size;
                     }
                 }
@@ -474,13 +494,9 @@ pub fn compress_into(input: &[u8], output: &mut [u8], level: i32) -> Result<usiz
     let mut params = strategy::level_params_for_size(level, input.len())
         .ok_or(CompressError::InvalidLevel(level))?;
     strategy::apply_raw_literals_size_override(&mut params, input.len());
-    let mut buf = Vec::with_capacity(output.len());
-    compress_frame(input, &params, &mut buf);
-    if buf.len() > output.len() {
-        return Err(CompressError::OutputTooSmall);
-    }
-    output[..buf.len()].copy_from_slice(&buf);
-    Ok(buf.len())
+    let mut sink = SliceSink::new(output);
+    compress_frame(input, &params, &mut sink)?;
+    Ok(sink.pos())
 }
 
 #[cfg(test)]

--- a/crates/encode/src/output.rs
+++ b/crates/encode/src/output.rs
@@ -1,0 +1,69 @@
+#![forbid(unsafe_code)]
+
+use zrip_core::error::CompressError;
+
+#[cfg(feature = "alloc")]
+use alloc::vec::Vec;
+
+pub(crate) trait OutputSink {
+    fn push(&mut self, byte: u8) -> Result<(), CompressError>;
+    fn extend_from_slice(&mut self, data: &[u8]) -> Result<(), CompressError>;
+}
+
+#[cfg(feature = "alloc")]
+impl OutputSink for Vec<u8> {
+    #[inline]
+    fn push(&mut self, byte: u8) -> Result<(), CompressError> {
+        Vec::push(self, byte);
+        Ok(())
+    }
+
+    #[inline]
+    fn extend_from_slice(&mut self, data: &[u8]) -> Result<(), CompressError> {
+        Vec::extend_from_slice(self, data);
+        Ok(())
+    }
+}
+
+pub(crate) struct SliceSink<'a> {
+    output: &'a mut [u8],
+    pos: usize,
+}
+
+impl<'a> SliceSink<'a> {
+    #[inline]
+    pub(crate) fn new(output: &'a mut [u8]) -> Self {
+        Self { output, pos: 0 }
+    }
+
+    #[inline]
+    pub(crate) fn pos(&self) -> usize {
+        self.pos
+    }
+}
+
+impl OutputSink for SliceSink<'_> {
+    #[inline]
+    fn push(&mut self, byte: u8) -> Result<(), CompressError> {
+        if self.pos >= self.output.len() {
+            return Err(CompressError::OutputTooSmall);
+        }
+        self.output[self.pos] = byte;
+        self.pos += 1;
+        Ok(())
+    }
+
+    #[inline]
+    fn extend_from_slice(&mut self, data: &[u8]) -> Result<(), CompressError> {
+        let end = self
+            .pos
+            .checked_add(data.len())
+            .ok_or(CompressError::OutputTooSmall)?;
+        if end > self.output.len() {
+            return Err(CompressError::OutputTooSmall);
+        }
+        self.output[self.pos..end].copy_from_slice(data);
+        self.pos = end;
+        Ok(())
+    }
+}

--- a/crates/encode/src/streaming.rs
+++ b/crates/encode/src/streaming.rs
@@ -213,7 +213,8 @@ impl<W: Write> FrameEncoder<W> {
     fn flush_block(&mut self, last: bool) -> io::Result<()> {
         if self.buffer.is_empty() && last {
             self.block_out.clear();
-            block_encoder::encode_raw_block(&[], true, &mut self.block_out);
+            block_encoder::encode_raw_block(&[], true, &mut self.block_out)
+                .map_err(io::Error::other)?;
             self.inner.write_all(&self.block_out)?;
             return Ok(());
         }
@@ -231,7 +232,8 @@ impl<W: Write> FrameEncoder<W> {
         self.block_out.clear();
         self.block_out.reserve(chunk.len() + 32);
         if crate::block_looks_incompressible(&chunk) {
-            block_encoder::encode_raw_block(&chunk, last, &mut self.block_out);
+            block_encoder::encode_raw_block(&chunk, last, &mut self.block_out)
+                .map_err(io::Error::other)?;
         } else {
             if seed_dict {
                 match self.params.strategy {
@@ -317,7 +319,8 @@ impl<W: Write> FrameEncoder<W> {
                     last,
                     &mut self.block_out,
                     &mut self.workspace,
-                );
+                )
+                .map_err(io::Error::other)?;
             } else {
                 block_encoder::encode_compressed_block(
                     &chunk,
@@ -327,7 +330,8 @@ impl<W: Write> FrameEncoder<W> {
                     &mut self.block_out,
                     &mut self.workspace,
                     true,
-                );
+                )
+                .map_err(io::Error::other)?;
             }
         }
 

--- a/tests/compress_into_alloc.rs
+++ b/tests/compress_into_alloc.rs
@@ -1,0 +1,34 @@
+use std::alloc::{GlobalAlloc, Layout, System};
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+struct CountingAlloc;
+
+static LARGE_ALLOCS: AtomicUsize = AtomicUsize::new(0);
+
+unsafe impl GlobalAlloc for CountingAlloc {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        if layout.size() >= 512 * 1024 {
+            LARGE_ALLOCS.fetch_add(1, Ordering::SeqCst);
+        }
+        unsafe { System.alloc(layout) }
+    }
+
+    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+        unsafe { System.dealloc(ptr, layout) }
+    }
+}
+
+#[global_allocator]
+static ALLOC: CountingAlloc = CountingAlloc;
+
+#[test]
+fn compress_into_does_not_allocate_output_sized_temp_vec() {
+    let input = b"hello zstd frame";
+    let mut output = vec![0u8; 1024 * 1024];
+
+    LARGE_ALLOCS.store(0, Ordering::SeqCst);
+    let written = zrip::compress_into(input, &mut output, 1).unwrap();
+
+    assert_eq!(LARGE_ALLOCS.load(Ordering::SeqCst), 0);
+    assert_eq!(zrip::decompress(&output[..written]).unwrap(), input);
+}


### PR DESCRIPTION
- Add internal `OutputSink`/`SliceSink` plumbing so `compress_into` writes into the caller buffer.
- Thread fallible output writes through frame and block encoding while preserving existing `Vec` callers.
- Add a regression test that catches output-sized temporary allocation.