### PR TITLE
Prepare zrip JSR 0.5.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## [Unreleased]
 
+### Changed
+
+- Bumped JSR package `@paddor/zrip` to 0.5.4.
+
+### Fixed
+
+- The JSR package now ships scalar WASM as `zrip_wasm_bg.wasm`, matching
+  wasm-bindgen glue while keeping `zrip_simd.wasm` for SIMD auto-detection.
+
 ## [0.8.4]
 
 ### Added

--- a/jsr/LICENSE
+++ b/jsr/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Patrik Wenger
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/jsr/README.md
+++ b/jsr/README.md
@@ -89,7 +89,7 @@ When you have pre-loaded WASM bytes (e.g. bundled or read from disk):
 ```ts
 import { compress, initSyncFromBytes } from "@paddor/zrip";
 
-const wasmBytes = Deno.readFileSync("path/to/zrip_simd.wasm");
+const wasmBytes = Deno.readFileSync("path/to/codec.wasm");
 initSyncFromBytes(wasmBytes);
 
 const compressed = compress(data);

--- a/jsr/build.sh
+++ b/jsr/build.sh
@@ -16,7 +16,7 @@ cd ..
 cp "$TMP/zrip_wasm.js" "$PKG/"
 cp "$TMP/zrip_wasm.d.ts" "$PKG/"
 cp "$TMP/zrip_wasm_bg.wasm.d.ts" "$PKG/"
-mv "$TMP/zrip_wasm_bg.wasm" "$PKG/zrip_scalar.wasm"
+mv "$TMP/zrip_wasm_bg.wasm" "$PKG/"
 
 echo "==> Building simd128 WASM..."
 cd wasm
@@ -33,6 +33,6 @@ fi
 
 rm -rf "$TMP"
 
-SCALAR_SIZE=$(wc -c < "$PKG/zrip_scalar.wasm")
+SCALAR_SIZE=$(wc -c < "$PKG/zrip_wasm_bg.wasm")
 SIMD_SIZE=$(wc -c < "$PKG/zrip_simd.wasm")
 echo "==> Done. scalar: ${SCALAR_SIZE} bytes, simd128: ${SIMD_SIZE} bytes"

--- a/jsr/deno.json
+++ b/jsr/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@paddor/zrip",
-  "version": "0.5.3",
+  "version": "0.5.4",
   "license": "MIT",
   "description": "Pure Rust zstd codec compiled to WebAssembly. Decodes all zstd levels, encodes -8..4, with SIMD auto-detection.",
   "exports": "./src/mod.ts",

--- a/jsr/src/mod.ts
+++ b/jsr/src/mod.ts
@@ -156,7 +156,7 @@ export async function init(): Promise<void> {
   if (initialized) return;
 
   const simd = WebAssembly.validate(SIMD_TEST);
-  const wasmFile = simd ? "zrip_simd.wasm" : "zrip_scalar.wasm";
+  const wasmFile = simd ? "zrip_simd.wasm" : "zrip_wasm_bg.wasm";
   const wasmUrl = new URL(`./pkg/${wasmFile}`, import.meta.url);
   const response = await fetch(wasmUrl);
   const bytes = await response.arrayBuffer();

--- a/jsr/wasm/Cargo.toml
+++ b/jsr/wasm/Cargo.toml
@@ -2,6 +2,9 @@
 name = "zrip-wasm"
 version = "0.1.0"
 edition = "2024"
+description = "WebAssembly bindings for zrip"
+repository = "https://github.com/paddor/zrip"
+license-file = "../../LICENSE"
 publish = false
 
 [lib]


### PR DESCRIPTION
- Bumps `@paddor/zrip` JSR metadata to `0.5.4`.
- Keeps scalar WASM at generated `zrip_wasm_bg.wasm` while leaving `zrip_simd.wasm` for runtime SIMD selection.
- Adds JSR `LICENSE` and wasm crate package metadata so publish metadata is complete.
- Updates JSR docs to keep internal WASM artifact names out of `initSyncFromBytes` examples.