### PR TITLE
Document 0.8.5 changelog section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [0.8.5]
+
 ### Added
 
 - Added JSR decompression options for maximum decompressed size limits.


### PR DESCRIPTION
- Add the missing `## [0.8.5]` section below `## [Unreleased]`.
- Keep the existing 0.8.5 release notes under the released version header.