### PR TITLE
Bound zstd frame windows and clean SIMD detection

### DIFF
--- a/bench/Cargo.toml
+++ b/bench/Cargo.toml
@@ -11,8 +11,8 @@ paranoid = ["zrip/paranoid"]
 zrip = { path = "..", features = ["dict_builder", "ldm"] }
 zstd = "0.13"
 zstd-safe = "7"
-lz4rip = "0.10.1"
-ruzstd = "0.8"
+lz4rip = "0.11.3"
+ruzstd = "0.9"
 structured-zstd = "0.0.49"
 libc = "0.2"
 plotters = { version = "0.3", default-features = false, features = ["svg_backend", "line_series"] }

--- a/bench/wasm/Cargo.toml
+++ b/bench/wasm/Cargo.toml
@@ -7,8 +7,8 @@ publish = false
 [dependencies]
 zrip = { path = "../.." }
 zstd = { version = "0.13", optional = true }
-ruzstd = { version = "0.8", optional = true }
-structured-zstd = { version = "0.0.48", optional = true }
+ruzstd = { version = "0.9", optional = true }
+structured-zstd = { version = "0.0.49", optional = true }
 
 [features]
 default = []

--- a/crates/core/src/bitstream/reader.rs
+++ b/crates/core/src/bitstream/reader.rs
@@ -119,7 +119,7 @@ mod tests {
         assert_eq!(r.read_bits(1).unwrap(), 1);
         assert_eq!(r.read_bits(1).unwrap(), 0);
         assert_eq!(r.read_bits(1).unwrap(), 1);
-        assert!(r.is_empty());
+        assert_eq!(r.bits_remaining(), 0);
     }
 
     #[test]

--- a/crates/core/src/huffman/decode.rs
+++ b/crates/core/src/huffman/decode.rs
@@ -79,8 +79,8 @@ pub fn decode_single_stream_vec(
     prepare_output(output, output_size);
     #[cfg(all(target_arch = "x86_64", not(feature = "paranoid")))]
     {
-        if crate::simd::cpu_tier() >= crate::simd::CpuTier::Bmi2 {
-            // SAFETY: cpu_tier() >= Bmi2 proves BMI2 is available.
+        if crate::simd::has_bmi2() {
+            // SAFETY: has_bmi2() proves BMI2 is available.
             let result = unsafe {
                 super::decode_4stream::decode_single_stream_bmi2_safe(
                     table, table_log, data, output,
@@ -122,8 +122,8 @@ pub fn decode_4_streams_into(
     prepare_output(output, output_size);
     #[cfg(all(target_arch = "x86_64", not(feature = "paranoid")))]
     {
-        if crate::simd::cpu_tier() >= crate::simd::CpuTier::Bmi2 {
-            // SAFETY: cpu_tier() >= Bmi2 proves BMI2 is available.
+        if crate::simd::has_bmi2() {
+            // SAFETY: has_bmi2() proves BMI2 is available.
             let result = unsafe {
                 super::decode_4stream::decode_4_streams_core_bmi2_safe(
                     table,

--- a/crates/core/src/huffman/decode_4stream.rs
+++ b/crates/core/src/huffman/decode_4stream.rs
@@ -22,7 +22,7 @@ pub(super) unsafe fn decode_single_stream_bmi2_safe(
     data: &[u8],
     output: &mut [u8],
 ) -> Result<(), DecompressError> {
-    // SAFETY: The caller verifies BMI2 availability via cpu_tier() >= CpuTier::Bmi2.
+    // SAFETY: The caller verifies BMI2 availability via has_bmi2().
     unsafe { decode_single_stream_bmi2(table, table_log, data, output) }
 }
 
@@ -46,7 +46,7 @@ pub(super) unsafe fn decode_4_streams_core_bmi2_safe(
     output_size: usize,
     output: &mut [u8],
 ) -> Result<(), DecompressError> {
-    // SAFETY: The caller verifies BMI2 availability via cpu_tier() >= CpuTier::Bmi2.
+    // SAFETY: The caller verifies BMI2 availability via has_bmi2().
     unsafe { decode_4_streams_core_bmi2(table, table_log, data, output_size, output) }
 }
 

--- a/crates/core/src/simd/mod.rs
+++ b/crates/core/src/simd/mod.rs
@@ -1,62 +1,39 @@
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
-pub enum CpuTier {
-    Scalar,
-    #[cfg(target_arch = "x86_64")]
-    Bmi2,
-    #[cfg(target_arch = "x86_64")]
-    Avx2,
-}
+#[cfg(feature = "std")]
+static HAS_BMI2: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
 
 #[cfg(feature = "std")]
-static CPU_TIER: std::sync::OnceLock<CpuTier> = std::sync::OnceLock::new();
-
-#[cfg(feature = "std")]
-pub fn cpu_tier() -> CpuTier {
+pub fn has_bmi2() -> bool {
     if cfg!(miri) {
-        return CpuTier::Scalar;
+        return false;
     }
-    *CPU_TIER.get_or_init(detect_cpu_tier)
+    *HAS_BMI2.get_or_init(detect_bmi2)
 }
 
 #[cfg(not(feature = "std"))]
-pub fn cpu_tier() -> CpuTier {
-    compile_time_tier()
+pub fn has_bmi2() -> bool {
+    compile_time_bmi2()
 }
 
 #[cfg(feature = "std")]
-fn detect_cpu_tier() -> CpuTier {
+fn detect_bmi2() -> bool {
     #[cfg(target_arch = "x86_64")]
     {
-        if std::arch::is_x86_feature_detected!("avx2")
-            && std::arch::is_x86_feature_detected!("bmi2")
-        {
-            return CpuTier::Avx2;
-        }
-        if std::arch::is_x86_feature_detected!("bmi2") {
-            return CpuTier::Bmi2;
-        }
-        CpuTier::Scalar
+        std::arch::is_x86_feature_detected!("bmi2")
     }
     #[cfg(not(target_arch = "x86_64"))]
     {
-        CpuTier::Scalar
+        false
     }
 }
 
 #[cfg(not(feature = "std"))]
-fn compile_time_tier() -> CpuTier {
+fn compile_time_bmi2() -> bool {
     #[cfg(target_arch = "x86_64")]
     {
-        if cfg!(target_feature = "avx2") && cfg!(target_feature = "bmi2") {
-            CpuTier::Avx2
-        } else if cfg!(target_feature = "bmi2") {
-            CpuTier::Bmi2
-        } else {
-            CpuTier::Scalar
-        }
+        cfg!(target_feature = "bmi2")
     }
     #[cfg(not(target_arch = "x86_64"))]
     {
-        CpuTier::Scalar
+        false
     }
 }

--- a/crates/decode/Cargo.toml
+++ b/crates/decode/Cargo.toml
@@ -22,7 +22,7 @@ paranoid = ["zrip-core/paranoid"]
 
 [dependencies]
 zrip-core = { version = "0.9.1", path = "../core", default-features = false }
-fearless_simd = { version = "0.6", optional = true }
+fearless_simd = { version = "0.7.0", optional = true }
 
 [dev-dependencies]
 zrip = { path = "../.." }

--- a/crates/decode/src/lib.rs
+++ b/crates/decode/src/lib.rs
@@ -570,9 +570,7 @@ pub(crate) fn decode_sequences_dispatch(
 
     #[cfg(all(feature = "std", feature = "simd"))]
     {
-        use std::sync::OnceLock;
-        static LEVEL: OnceLock<fearless_simd::Level> = OnceLock::new();
-        let level = *LEVEL.get_or_init(fearless_simd::Level::new);
+        let level = fearless_simd::Level::new();
         return fearless_simd::dispatch!(level, _simd => {
             if scope.history.is_empty() {
                 decode_execute_sequences::<false>(

--- a/crates/encode/src/context.rs
+++ b/crates/encode/src/context.rs
@@ -314,7 +314,12 @@ impl CompressContext {
 
         self.output.clear();
         self.output.reserve(input.len() + 32);
-        write_frame_header(&mut self.output, input.len(), Some(dict_id))?;
+        write_frame_header(
+            &mut self.output,
+            input.len(),
+            Some(dict_id),
+            params.window_log,
+        )?;
 
         if input.is_empty() {
             block_encoder::encode_raw_block(&[], true, &mut self.output)?;
@@ -552,7 +557,7 @@ fn compress_core(
 
     output.clear();
     output.reserve(input.len() + 32);
-    write_frame_header(output, input.len(), dict_id)?;
+    write_frame_header(output, input.len(), dict_id, params.window_log)?;
 
     if input.is_empty() {
         block_encoder::encode_raw_block(&[], true, output)?;

--- a/crates/encode/src/dfast.rs
+++ b/crates/encode/src/dfast.rs
@@ -894,6 +894,6 @@ mod tests {
             &mut sequences,
         );
 
-        assert!(!sequences.is_empty());
+        assert_ne!(sequences.len(), 0);
     }
 }

--- a/crates/encode/src/fast.rs
+++ b/crates/encode/src/fast.rs
@@ -1264,6 +1264,6 @@ mod tests {
             &mut sequences,
         );
 
-        assert!(!sequences.is_empty());
+        assert_ne!(sequences.len(), 0);
     }
 }

--- a/crates/encode/src/lib.rs
+++ b/crates/encode/src/lib.rs
@@ -41,26 +41,42 @@ use alloc::vec::Vec;
 use crate::output::{OutputSink, SliceSink};
 use crate::strategy::Strategy;
 use zrip_core::error::CompressError;
-use zrip_core::frame::{MAX_BLOCK_SIZE, ZSTD_MAGIC};
+use zrip_core::frame::{MAX_BLOCK_SIZE, MAX_WINDOW_SIZE, ZSTD_MAGIC};
 use zrip_core::xxhash::xxh64;
 
 pub(crate) fn write_frame_header(
     output: &mut impl OutputSink,
     content_size: usize,
     dict_id: Option<u32>,
+    window_log: u32,
+) -> Result<(), CompressError> {
+    write_frame_header_inner(output, Some(content_size), dict_id, window_log)
+}
+
+#[cfg_attr(not(feature = "std"), allow(dead_code))]
+pub(crate) fn write_frame_header_without_content_size(
+    output: &mut impl OutputSink,
+    dict_id: Option<u32>,
+    window_log: u32,
+) -> Result<(), CompressError> {
+    write_frame_header_inner(output, None, dict_id, window_log)
+}
+
+fn write_frame_header_inner(
+    output: &mut impl OutputSink,
+    content_size: Option<usize>,
+    dict_id: Option<u32>,
+    window_log: u32,
 ) -> Result<(), CompressError> {
     output.extend_from_slice(&ZSTD_MAGIC.to_le_bytes())?;
 
-    let fcs_size = if content_size <= 255 {
-        1
-    } else if content_size <= 0xFFFF + 256 {
-        2
-    } else if content_size <= 0xFFFF_FFFF {
-        4
-    } else {
-        8
-    };
+    let single_segment =
+        dict_id.is_none() && content_size.is_some_and(|size| size as u64 <= MAX_WINDOW_SIZE);
+    let fcs_size = content_size.map_or(0, |size| {
+        frame_content_size_field_size(size, single_segment)
+    });
     let fcs_flag: u8 = match fcs_size {
+        0 => 0,
         1 => 0,
         2 => 1,
         4 => 2,
@@ -74,8 +90,12 @@ pub(crate) fn write_frame_header(
         Some(_) => 3,
     };
 
-    let descriptor = 0x20 | 0x04 | (fcs_flag << 6) | dict_id_flag;
+    let descriptor = if single_segment { 0x20 } else { 0 } | 0x04 | (fcs_flag << 6) | dict_id_flag;
     output.push(descriptor)?;
+
+    if !single_segment {
+        output.push(window_descriptor_for_log(window_log))?;
+    }
 
     match dict_id {
         Some(id) if id <= 0xFF => output.push(id as u8)?,
@@ -84,7 +104,11 @@ pub(crate) fn write_frame_header(
         None => {}
     }
 
+    let Some(content_size) = content_size else {
+        return Ok(());
+    };
     match fcs_size {
+        0 => {}
         1 => output.push(content_size as u8)?,
         2 => {
             let v = (content_size - 256) as u16;
@@ -94,6 +118,23 @@ pub(crate) fn write_frame_header(
         _ => output.extend_from_slice(&(content_size as u64).to_le_bytes())?,
     }
     Ok(())
+}
+
+fn frame_content_size_field_size(content_size: usize, single_segment: bool) -> usize {
+    if single_segment && content_size <= 255 {
+        1
+    } else if (256..=0xFFFF + 256).contains(&content_size) {
+        2
+    } else if content_size <= 0xFFFF_FFFF {
+        4
+    } else {
+        8
+    }
+}
+
+fn window_descriptor_for_log(window_log: u32) -> u8 {
+    let window_log = window_log.clamp(strategy::WINDOW_LOG_MIN, strategy::WINDOW_LOG_MAX);
+    ((window_log - 10) as u8) << 3
 }
 
 pub(crate) fn block_looks_incompressible(data: &[u8]) -> bool {
@@ -175,7 +216,7 @@ fn compress_frame(
     params: &strategy::LevelParams,
     output: &mut impl OutputSink,
 ) -> Result<(), CompressError> {
-    write_frame_header(output, input.len(), None)?;
+    write_frame_header(output, input.len(), None, params.window_log)?;
 
     if input.is_empty() {
         block_encoder::encode_raw_block(&[], true, output)?;
@@ -340,7 +381,7 @@ pub fn compress_with_dict(
     strategy::apply_raw_literals_size_override(&mut params, input.len());
 
     let mut output = Vec::with_capacity(input.len() + 32);
-    write_frame_header(&mut output, input.len(), Some(dict.id()))?;
+    write_frame_header(&mut output, input.len(), Some(dict.id()), params.window_log)?;
 
     if input.is_empty() {
         block_encoder::encode_raw_block(&[], true, &mut output)?;
@@ -502,6 +543,7 @@ pub fn compress_into(input: &[u8], output: &mut [u8], level: i32) -> Result<usiz
 #[cfg(test)]
 mod tests {
     use super::*;
+    use zrip_core::frame::header::parse_frame_header;
 
     #[test]
     fn clamp_params_normalizes_public_log_values() {
@@ -534,5 +576,66 @@ mod tests {
             let ldm = params.ldm_params.unwrap();
             assert!(ldm.hash_log >= ldm.bucket_size_log);
         }
+    }
+
+    #[test]
+    fn small_plain_frame_uses_single_segment_header() {
+        let mut output = Vec::new();
+
+        write_frame_header(&mut output, 12, None, 19).unwrap();
+        let header = parse_frame_header(&output).unwrap();
+
+        assert!(header.single_segment);
+        assert_eq!(header.frame_content_size, Some(12));
+        assert_eq!(header.window_size, 12);
+        assert_eq!(header.dict_id, None);
+        assert!(header.content_checksum);
+        assert_eq!(header.header_size, 6);
+    }
+
+    #[test]
+    fn large_plain_frame_uses_bounded_window_descriptor() {
+        let mut output = Vec::new();
+        let content_size = MAX_WINDOW_SIZE as usize + 1;
+
+        write_frame_header(&mut output, content_size, None, 19).unwrap();
+        let header = parse_frame_header(&output).unwrap();
+
+        assert!(!header.single_segment);
+        assert_eq!(header.frame_content_size, Some(content_size as u64));
+        assert_eq!(header.window_size, 1 << 19);
+        assert_eq!(header.dict_id, None);
+        assert!(header.content_checksum);
+        assert_eq!(header.header_size, 10);
+    }
+
+    #[test]
+    fn dict_frame_uses_window_descriptor_even_when_small() {
+        let mut output = Vec::new();
+
+        write_frame_header(&mut output, 12, Some(0x1234), 10).unwrap();
+        let header = parse_frame_header(&output).unwrap();
+
+        assert!(!header.single_segment);
+        assert_eq!(header.frame_content_size, Some(12));
+        assert_eq!(header.window_size, 1 << 10);
+        assert_eq!(header.dict_id, Some(0x1234));
+        assert!(header.content_checksum);
+        assert_eq!(header.header_size, 12);
+    }
+
+    #[test]
+    fn no_fcs_frame_uses_window_descriptor() {
+        let mut output = Vec::new();
+
+        write_frame_header_without_content_size(&mut output, None, 19).unwrap();
+        let header = parse_frame_header(&output).unwrap();
+
+        assert!(!header.single_segment);
+        assert_eq!(header.frame_content_size, None);
+        assert_eq!(header.window_size, 1 << 19);
+        assert_eq!(header.dict_id, None);
+        assert!(header.content_checksum);
+        assert_eq!(header.header_size, 6);
     }
 }

--- a/crates/encode/src/streaming.rs
+++ b/crates/encode/src/streaming.rs
@@ -8,10 +8,11 @@ use crate::fast;
 #[cfg(feature = "ldm")]
 use crate::ldm::LdmState;
 use crate::strategy::{self, LevelParams, Strategy};
+use crate::write_frame_header_without_content_size;
 use zrip_core::Sequence;
 use zrip_core::dict::Dictionary;
 use zrip_core::error::CompressError;
-use zrip_core::frame::{MAX_BLOCK_SIZE, ZSTD_MAGIC};
+use zrip_core::frame::MAX_BLOCK_SIZE;
 use zrip_core::xxhash::Xxh64State;
 
 /// Streaming zstd compressor implementing [`Write`].
@@ -172,41 +173,14 @@ impl<W: Write> FrameEncoder<W> {
     fn write_header(&mut self) -> io::Result<()> {
         self.header_written = true;
 
-        self.inner.write_all(&ZSTD_MAGIC.to_le_bytes())?;
-
-        let window_log = self.params.window_log;
-
-        let dict_id_flag = if let Some(ref dict) = self.dict {
-            let id = dict.id();
-            if id <= 0xFF {
-                1u8
-            } else if id <= 0xFFFF {
-                2
-            } else {
-                3
-            }
-        } else {
-            0
-        };
-
-        let descriptor = 0x04u8 | dict_id_flag;
-        self.inner.write_all(&[descriptor])?;
-
-        let mantissa = 0u8;
-        let exponent = (window_log - 10) as u8;
-        let window_descriptor = (exponent << 3) | mantissa;
-        self.inner.write_all(&[window_descriptor])?;
-
-        if let Some(ref dict) = self.dict {
-            let id = dict.id();
-            match dict_id_flag {
-                1 => self.inner.write_all(&[id as u8])?,
-                2 => self.inner.write_all(&(id as u16).to_le_bytes())?,
-                3 => self.inner.write_all(&id.to_le_bytes())?,
-                _ => unreachable!(),
-            }
-        }
-
+        self.block_out.clear();
+        write_frame_header_without_content_size(
+            &mut self.block_out,
+            self.dict.as_ref().map(Dictionary::id),
+            self.params.window_log,
+        )
+        .map_err(io::Error::other)?;
+        self.inner.write_all(&self.block_out)?;
         Ok(())
     }
 

--- a/tests/dict.rs
+++ b/tests/dict.rs
@@ -18,7 +18,7 @@ fn zrip_trained_dict_roundtrip() {
     );
 
     assert_ne!(dict.id(), 0);
-    assert!(!dict.content().is_empty());
+    assert_ne!(dict.content(), []);
 
     for sample in &samples[..20] {
         let compressed = zrip::compress_with_dict(sample, 1, &dict).unwrap();
@@ -297,7 +297,7 @@ fn streaming_dict_empty_input() {
     let mut decoder = zrip::FrameDecoder::with_dict(compressed.as_slice(), dict.clone());
     let mut decompressed = Vec::new();
     decoder.read_to_end(&mut decompressed).unwrap();
-    assert!(decompressed.is_empty());
+    assert_eq!(decompressed, Vec::<u8>::new());
 }
 
 #[cfg(feature = "dict_builder")]

--- a/tests/interop.rs
+++ b/tests/interop.rs
@@ -264,6 +264,41 @@ fn roundtrip_block_boundary_sizes_c_cross_validate() {
 }
 
 #[test]
+#[ignore = "allocates more than 128 MiB to exercise the large-frame header path"]
+fn large_plain_frame_header_has_bounded_window_and_c_decompresses() {
+    struct ZeroSink {
+        len: usize,
+    }
+
+    impl std::io::Write for ZeroSink {
+        fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+            assert!(buf.iter().all(|&b| b == 0));
+            self.len += buf.len();
+            Ok(buf.len())
+        }
+
+        fn flush(&mut self) -> std::io::Result<()> {
+            Ok(())
+        }
+    }
+
+    let size = zrip::frame::MAX_WINDOW_SIZE as usize + 1;
+    let original = vec![0u8; size];
+    let compressed = zrip::compress(&original, 1).unwrap();
+
+    let header = zrip::frame::header::parse_frame_header(&compressed).unwrap();
+    assert!(!header.single_segment);
+    assert_eq!(header.frame_content_size, Some(size as u64));
+    assert_eq!(header.window_size, 1 << 19);
+    assert!(header.content_checksum);
+
+    let mut decoder = zstd::Decoder::new(compressed.as_slice()).unwrap();
+    let mut sink = ZeroSink { len: 0 };
+    std::io::copy(&mut decoder, &mut sink).unwrap();
+    assert_eq!(sink.len, size);
+}
+
+#[test]
 fn roundtrip_single_bytes_c_cross_validate() {
     for b in 0u8..=255 {
         let original = vec![b];
@@ -959,6 +994,23 @@ fn streaming_encoder_all_levels_c_decompress() {
 }
 
 #[test]
+fn streaming_encoder_header_has_bounded_no_fcs_window() {
+    let original: Vec<u8> = b"ABCDEFGH".iter().cycle().take(10000).copied().collect();
+    let mut encoder = zrip::FrameEncoder::new(Vec::new(), 1).unwrap();
+    std::io::Write::write_all(&mut encoder, &original).unwrap();
+    let compressed = encoder.finish().unwrap();
+
+    let header = zrip::frame::header::parse_frame_header(&compressed).unwrap();
+    assert!(!header.single_segment);
+    assert_eq!(header.frame_content_size, None);
+    assert_eq!(header.window_size, 1 << 19);
+    assert!(header.content_checksum);
+
+    let decompressed = zstd::decode_all(&compressed[..]).unwrap();
+    assert_eq!(decompressed, original);
+}
+
+#[test]
 fn frame_decoder_c_zstd_data() {
     use std::io::Read;
     let data: Vec<u8> = (0..50_000).map(|i| (i % 251) as u8).collect();
@@ -1095,6 +1147,28 @@ fn roundtrip_dict_compress_c_decompress() {
         let zrip_dec = zrip::decompress_with_dict(&compressed, &dict).unwrap();
         assert_eq!(&zrip_dec, sample);
     }
+}
+
+#[test]
+fn dict_frame_header_has_bounded_window_and_c_decompresses() {
+    let (samples, dict_data) = make_dict_samples();
+    let dict = zrip::dict::Dictionary::from_bytes(&dict_data).unwrap();
+    let c_dict = zstd::dict::DecoderDictionary::copy(&dict_data);
+    let sample = &samples[0];
+
+    let compressed = zrip::compress_with_dict(sample, 1, &dict).unwrap();
+    let header = zrip::frame::header::parse_frame_header(&compressed).unwrap();
+    assert!(!header.single_segment);
+    assert_eq!(header.frame_content_size, Some(sample.len() as u64));
+    assert_eq!(header.dict_id, Some(dict.id()));
+    assert!(header.window_size <= zrip::frame::MAX_WINDOW_SIZE);
+    assert!(header.content_checksum);
+
+    let mut decoder =
+        zstd::Decoder::with_prepared_dictionary(compressed.as_slice(), &c_dict).unwrap();
+    let mut decompressed = Vec::new();
+    std::io::Read::read_to_end(&mut decoder, &mut decompressed).unwrap();
+    assert_eq!(&decompressed, sample);
 }
 
 #[test]

--- a/tests/interop.rs
+++ b/tests/interop.rs
@@ -1091,7 +1091,7 @@ fn parse_c_trained_dictionary() {
     let (_, dict_data) = make_dict_samples();
     let dict = zrip::dict::Dictionary::from_bytes(&dict_data).unwrap();
     assert_ne!(dict.id(), 0);
-    assert!(!dict.content().is_empty());
+    assert_ne!(dict.content(), []);
     assert!(dict.rep_offsets()[0] > 0);
     assert!(dict.rep_offsets()[1] > 0);
     assert!(dict.rep_offsets()[2] > 0);

--- a/tests/roundtrip.rs
+++ b/tests/roundtrip.rs
@@ -348,7 +348,7 @@ fn decompress_bad_magic() {
 #[test]
 fn decompress_empty_input() {
     let result = zrip::decompress(&[]).unwrap();
-    assert!(result.is_empty());
+    assert_eq!(result, Vec::<u8>::new());
 }
 
 #[cfg(not(miri))]


### PR DESCRIPTION
- Bump dependency constraints, including fearless_simd 0.7.0.
- Emit explicit bounded Window_Descriptor fields for large, dictionary, and no-FCS frames while keeping small plain FCS frames single-segment.
- Rely on fearless_simd 0.7 cached x86 level detection instead of a local OnceLock.
- Replace the generic CPU tier cache with an exact has_bmi2 gate for handwritten Huffman BMI2 decode paths.
- Add header-shape and C zstd interop coverage for bounded large, dictionary, and streaming no-FCS frames.