### PR TITLE
Upgrade fearless_simd and simplify SIMD detection

### DIFF
--- a/crates/core/src/huffman/decode.rs
+++ b/crates/core/src/huffman/decode.rs
@@ -79,8 +79,8 @@ pub fn decode_single_stream_vec(
     prepare_output(output, output_size);
     #[cfg(all(target_arch = "x86_64", not(feature = "paranoid")))]
     {
-        if crate::simd::cpu_tier() >= crate::simd::CpuTier::Bmi2 {
-            // SAFETY: cpu_tier() >= Bmi2 proves BMI2 is available.
+        if crate::simd::has_bmi2() {
+            // SAFETY: has_bmi2() proves BMI2 is available.
             let result = unsafe {
                 super::decode_4stream::decode_single_stream_bmi2_safe(
                     table, table_log, data, output,
@@ -122,8 +122,8 @@ pub fn decode_4_streams_into(
     prepare_output(output, output_size);
     #[cfg(all(target_arch = "x86_64", not(feature = "paranoid")))]
     {
-        if crate::simd::cpu_tier() >= crate::simd::CpuTier::Bmi2 {
-            // SAFETY: cpu_tier() >= Bmi2 proves BMI2 is available.
+        if crate::simd::has_bmi2() {
+            // SAFETY: has_bmi2() proves BMI2 is available.
             let result = unsafe {
                 super::decode_4stream::decode_4_streams_core_bmi2_safe(
                     table,

--- a/crates/core/src/huffman/decode_4stream.rs
+++ b/crates/core/src/huffman/decode_4stream.rs
@@ -22,7 +22,7 @@ pub(super) unsafe fn decode_single_stream_bmi2_safe(
     data: &[u8],
     output: &mut [u8],
 ) -> Result<(), DecompressError> {
-    // SAFETY: The caller verifies BMI2 availability via cpu_tier() >= CpuTier::Bmi2.
+    // SAFETY: The caller verifies BMI2 availability via has_bmi2().
     unsafe { decode_single_stream_bmi2(table, table_log, data, output) }
 }
 
@@ -46,7 +46,7 @@ pub(super) unsafe fn decode_4_streams_core_bmi2_safe(
     output_size: usize,
     output: &mut [u8],
 ) -> Result<(), DecompressError> {
-    // SAFETY: The caller verifies BMI2 availability via cpu_tier() >= CpuTier::Bmi2.
+    // SAFETY: The caller verifies BMI2 availability via has_bmi2().
     unsafe { decode_4_streams_core_bmi2(table, table_log, data, output_size, output) }
 }
 

--- a/crates/core/src/simd/mod.rs
+++ b/crates/core/src/simd/mod.rs
@@ -1,62 +1,39 @@
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
-pub enum CpuTier {
-    Scalar,
-    #[cfg(target_arch = "x86_64")]
-    Bmi2,
-    #[cfg(target_arch = "x86_64")]
-    Avx2,
-}
+#[cfg(feature = "std")]
+static HAS_BMI2: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
 
 #[cfg(feature = "std")]
-static CPU_TIER: std::sync::OnceLock<CpuTier> = std::sync::OnceLock::new();
-
-#[cfg(feature = "std")]
-pub fn cpu_tier() -> CpuTier {
+pub fn has_bmi2() -> bool {
     if cfg!(miri) {
-        return CpuTier::Scalar;
+        return false;
     }
-    *CPU_TIER.get_or_init(detect_cpu_tier)
+    *HAS_BMI2.get_or_init(detect_bmi2)
 }
 
 #[cfg(not(feature = "std"))]
-pub fn cpu_tier() -> CpuTier {
-    compile_time_tier()
+pub fn has_bmi2() -> bool {
+    compile_time_bmi2()
 }
 
 #[cfg(feature = "std")]
-fn detect_cpu_tier() -> CpuTier {
+fn detect_bmi2() -> bool {
     #[cfg(target_arch = "x86_64")]
     {
-        if std::arch::is_x86_feature_detected!("avx2")
-            && std::arch::is_x86_feature_detected!("bmi2")
-        {
-            return CpuTier::Avx2;
-        }
-        if std::arch::is_x86_feature_detected!("bmi2") {
-            return CpuTier::Bmi2;
-        }
-        CpuTier::Scalar
+        std::arch::is_x86_feature_detected!("bmi2")
     }
     #[cfg(not(target_arch = "x86_64"))]
     {
-        CpuTier::Scalar
+        false
     }
 }
 
 #[cfg(not(feature = "std"))]
-fn compile_time_tier() -> CpuTier {
+fn compile_time_bmi2() -> bool {
     #[cfg(target_arch = "x86_64")]
     {
-        if cfg!(target_feature = "avx2") && cfg!(target_feature = "bmi2") {
-            CpuTier::Avx2
-        } else if cfg!(target_feature = "bmi2") {
-            CpuTier::Bmi2
-        } else {
-            CpuTier::Scalar
-        }
+        cfg!(target_feature = "bmi2")
     }
     #[cfg(not(target_arch = "x86_64"))]
     {
-        CpuTier::Scalar
+        false
     }
 }

--- a/crates/decode/Cargo.toml
+++ b/crates/decode/Cargo.toml
@@ -22,7 +22,7 @@ paranoid = ["zrip-core/paranoid"]
 
 [dependencies]
 zrip-core = { version = "0.9.1", path = "../core", default-features = false }
-fearless_simd = { version = "0.6", optional = true }
+fearless_simd = { version = "0.7.0", optional = true }
 
 [dev-dependencies]
 zrip = { path = "../.." }

--- a/crates/decode/src/lib.rs
+++ b/crates/decode/src/lib.rs
@@ -570,9 +570,7 @@ pub(crate) fn decode_sequences_dispatch(
 
     #[cfg(all(feature = "std", feature = "simd"))]
     {
-        use std::sync::OnceLock;
-        static LEVEL: OnceLock<fearless_simd::Level> = OnceLock::new();
-        let level = *LEVEL.get_or_init(fearless_simd::Level::new);
+        let level = fearless_simd::Level::new();
         return fearless_simd::dispatch!(level, _simd => {
             if scope.history.is_empty() {
                 decode_execute_sequences::<false>(


### PR DESCRIPTION
- Upgrade optional decode SIMD dependency to fearless_simd 0.7.0.
- Use fearless_simd cached x86 Level::new detection directly instead of a local OnceLock.
- Replace generic CpuTier detection with exact has_bmi2 gate for handwritten Huffman BMI2 decode paths.