### PR TITLE
Accelerate low-match encoding and refresh charts

### DIFF
--- a/bench/src/bin/zrip_charts.rs
+++ b/bench/src/bin/zrip_charts.rs
@@ -25,6 +25,7 @@ const LEVEL: i32 = 1;
 const DECODE_LEVEL: i32 = 3;
 const LEVELS: &[i32] = &[3, 1, -1];
 const COLUMN_LEVELS: &[i32] = &[-1, 1, 3];
+const SUMMARY_LEVELS: &[i32] = &[-7, -6, -5, -4, -3, -2, -1, 1, 2, 3, 4];
 const BAND_LEVELS: &[i32] = &[-8, -7, -6, -5, -4, -3, -2, -1, 1, 2, 3, 4];
 const C_ZSTD_LEVELS: &[i32] = &[-7, -6, -5, -4, -3, -2, -1, 1, 2, 3, 4];
 const INTERIOR_LEVELS: &[i32] = &[-7, -6, -5, -4, -3, -2, -1, 1, 2, 3];
@@ -230,9 +231,9 @@ impl Config {
                 ),
             ];
             cfg.scatter_codecs = vec!["C zstd", "zrip", "structured-zstd", "zrip paranoid"];
-            cfg.summary_codecs = cfg.scatter_codecs.clone();
-            cfg.matrix_codecs = cfg.scatter_codecs.clone();
-            cfg.pipeline_codecs = cfg.scatter_codecs.clone();
+            cfg.summary_codecs = vec!["C zstd", "zrip", "zrip paranoid", "structured-zstd"];
+            cfg.matrix_codecs = cfg.summary_codecs.clone();
+            cfg.pipeline_codecs = cfg.summary_codecs.clone();
             cfg.small_codecs = vec!["C zstd", "zrip", "structured-zstd"];
             cfg.small_decode_codecs = cfg.scatter_codecs.clone();
         } else if profile.is_some() {
@@ -284,16 +285,22 @@ impl Config {
             summary_codecs: vec![
                 "C zstd",
                 "zrip",
-                "structured-zstd",
                 "zrip paranoid",
+                "structured-zstd",
                 "ruzstd",
             ],
-            matrix_codecs: vec!["C zstd", "zrip", "structured-zstd", "zrip paranoid"],
+            matrix_codecs: vec![
+                "C zstd",
+                "zrip",
+                "zrip paranoid",
+                "structured-zstd",
+                "ruzstd",
+            ],
             pipeline_codecs: vec![
                 "C zstd",
                 "zrip",
-                "structured-zstd",
                 "zrip paranoid",
+                "structured-zstd",
                 "ruzstd",
             ],
             small_codecs: vec!["C zstd", "zrip", "structured-zstd"],
@@ -1213,13 +1220,13 @@ fn compute_pipeline(row: &BenchRow) -> (f64, f64, f64) {
 }
 
 fn draw_summary(cfg: &Config, out_dir: &Path) -> Result<(), Box<dyn Error>> {
-    let data = load_level_data(cfg, &cfg.summary_codecs, LEVEL, 10_000, Some(MAIN_CORPUS));
+    let data = load_all_data(cfg, &cfg.summary_codecs, 10_000, Some(MAIN_CORPUS));
     let main_inputs = input_names(MAIN_CORPUS);
     require_named_rows(
         &data,
         &cfg.summary_codecs,
         &main_inputs,
-        |_| vec![LEVEL],
+        |codec| supported_chart_levels(codec, SUMMARY_LEVELS),
         "summary",
     )?;
     let mut stacks: BTreeMap<String, (f64, f64, f64)> = BTreeMap::new();
@@ -1228,8 +1235,9 @@ fn draw_summary(cfg: &Config, out_dir: &Path) -> Result<(), Box<dyn Error>> {
         let mut comp = Vec::new();
         let mut xfer = Vec::new();
         let mut decomp = Vec::new();
+        let levels = supported_chart_levels(key, SUMMARY_LEVELS);
         for row in rows {
-            if row.compress_ns <= 0.0 {
+            if row.compress_ns <= 0.0 || !levels.contains(&row.level) {
                 continue;
             }
             let (c, t, d) = compute_pipeline(&row);
@@ -1268,7 +1276,7 @@ fn draw_summary(cfg: &Config, out_dir: &Path) -> Result<(), Box<dyn Error>> {
     chart_header(
         &area,
         width,
-        "12-file Silesia: Pipeline @100 MB/s geomean, Level 1 (lower is better)",
+        "12-file Silesia: Pipeline @100 MB/s geomean, L-7..L4 (ruzstd L1)",
         cfg.hw_label.as_deref(),
         22,
     )?;

--- a/crates/encode/src/context.rs
+++ b/crates/encode/src/context.rs
@@ -654,13 +654,10 @@ fn compress_core(
                         let chunk_size = (input.len() - offset).min(MAX_BLOCK_SIZE);
                         let block_end = offset + chunk_size;
                         let is_last = block_end >= input.len();
+                        let block = &input[offset..block_end];
 
-                        if block_looks_incompressible(&input[offset..block_end]) {
-                            block_encoder::encode_raw_block(
-                                &input[offset..block_end],
-                                is_last,
-                                output,
-                            )?;
+                        if block_looks_incompressible(block) {
+                            block_encoder::encode_raw_block(block, is_last, output)?;
                         } else {
                             fast::compress_fast_block(
                                 input,
@@ -673,7 +670,7 @@ fn compress_core(
                             );
                             if params.force_raw_literals {
                                 block_encoder::encode_compressed_block_raw(
-                                    &input[offset..block_end],
+                                    block,
                                     sequences,
                                     &mut rep_offsets,
                                     is_last,
@@ -682,7 +679,7 @@ fn compress_core(
                                 )?;
                             } else {
                                 block_encoder::encode_compressed_block(
-                                    &input[offset..block_end],
+                                    block,
                                     sequences,
                                     &mut rep_offsets,
                                     is_last,
@@ -767,13 +764,10 @@ fn compress_core(
                         let chunk_size = (input.len() - offset).min(MAX_BLOCK_SIZE);
                         let block_end = offset + chunk_size;
                         let is_last = block_end >= input.len();
+                        let block = &input[offset..block_end];
 
-                        if block_looks_incompressible(&input[offset..block_end]) {
-                            block_encoder::encode_raw_block(
-                                &input[offset..block_end],
-                                is_last,
-                                output,
-                            )?;
+                        if block_looks_incompressible(block) {
+                            block_encoder::encode_raw_block(block, is_last, output)?;
                         } else {
                             dfast::compress_dfast_block(
                                 input,
@@ -786,7 +780,7 @@ fn compress_core(
                                 sequences,
                             );
                             block_encoder::encode_compressed_block(
-                                &input[offset..block_end],
+                                block,
                                 sequences,
                                 &mut rep_offsets,
                                 is_last,

--- a/crates/encode/src/dfast.rs
+++ b/crates/encode/src/dfast.rs
@@ -283,6 +283,9 @@ fn compress_dfast_block_impl<const HASH_LOG: u32, const SHORT_LOG: u32, const ML
     let acceleration = params.target_length.max(1) as usize;
     let step_size = acceleration + 1;
     let search_strength = params.search_strength as usize;
+    // Grow skips quickly across literal runs. Matches reset `anchor`, so this
+    // only accelerates after repeated misses.
+    let skip_shift = search_strength.min(3);
     let search_log = if HASH_LOG == 18 && SHORT_LOG == 18 && MLS == 4 {
         1
     } else {
@@ -712,7 +715,7 @@ fn compress_dfast_block_impl<const HASH_LOG: u32, const SHORT_LOG: u32, const ML
             hl1 = h8(rd64!(src, ip2), hash_log);
             ip0 = ip1;
             ip1 = ip2;
-            let step = step_size + ((ip0 - anchor) >> search_strength);
+            let step = step_size + ((ip0 - anchor) >> skip_shift);
             ip2 = ip0 + step;
             ip3 = ip1 + step;
 

--- a/crates/encode/src/fast.rs
+++ b/crates/encode/src/fast.rs
@@ -380,6 +380,13 @@ fn compress_fast_block_impl<const HASH_LOG: u32, const MLS: usize>(
             params.search_strength as usize,
         )
     };
+    let skip_shift = if HASH_LOG == 14 && MLS == 4 {
+        5
+    } else if params.min_match == 4 && params.target_length == 1 {
+        search_strength.min(3)
+    } else {
+        search_strength
+    };
     let ilimit = (block_end - MLS).min(src.len() - 8);
     let max_distance = if HASH_LOG == 14 && MLS == 4 {
         1usize << 19
@@ -586,7 +593,7 @@ fn compress_fast_block_impl<const HASH_LOG: u32, const MLS: usize>(
             let h_next = hash_pos::<HASH_LOG, MLS>(src, ip2, hash_log);
             ip0 = ip1;
             ip1 = ip2;
-            let step = step_size + ((ip0 - anchor) >> search_strength);
+            let step = step_size + ((ip0 - anchor) >> skip_shift);
             ip2 = ip0 + step;
 
             #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]

--- a/crates/encode/src/lib.rs
+++ b/crates/encode/src/lib.rs
@@ -237,13 +237,10 @@ fn compress_frame(
                     let chunk_size = (input.len() - offset).min(MAX_BLOCK_SIZE);
                     let block_end = offset + chunk_size;
                     let is_last = block_end >= input.len();
+                    let block = &input[offset..block_end];
 
-                    if block_looks_incompressible(&input[offset..block_end]) {
-                        block_encoder::encode_raw_block(
-                            &input[offset..block_end],
-                            is_last,
-                            output,
-                        )?;
+                    if block_looks_incompressible(block) {
+                        block_encoder::encode_raw_block(block, is_last, output)?;
                     } else {
                         #[cfg(feature = "ldm")]
                         let used_ldm = if let Some(ref mut ldm) = ldm_state {
@@ -278,7 +275,7 @@ fn compress_frame(
                         }
                         if params.force_raw_literals {
                             block_encoder::encode_compressed_block_raw(
-                                &input[offset..block_end],
+                                block,
                                 &sequences,
                                 &mut rep_offsets,
                                 is_last,
@@ -287,7 +284,7 @@ fn compress_frame(
                             )?;
                         } else {
                             block_encoder::encode_compressed_block(
-                                &input[offset..block_end],
+                                block,
                                 &sequences,
                                 &mut rep_offsets,
                                 is_last,
@@ -309,13 +306,10 @@ fn compress_frame(
                     let chunk_size = (input.len() - offset).min(MAX_BLOCK_SIZE);
                     let block_end = offset + chunk_size;
                     let is_last = block_end >= input.len();
+                    let block = &input[offset..block_end];
 
-                    if block_looks_incompressible(&input[offset..block_end]) {
-                        block_encoder::encode_raw_block(
-                            &input[offset..block_end],
-                            is_last,
-                            output,
-                        )?;
+                    if block_looks_incompressible(block) {
+                        block_encoder::encode_raw_block(block, is_last, output)?;
                     } else {
                         #[cfg(feature = "ldm")]
                         let used_ldm = if let Some(ref mut ldm) = ldm_state {
@@ -349,7 +343,7 @@ fn compress_frame(
                             );
                         }
                         block_encoder::encode_compressed_block(
-                            &input[offset..block_end],
+                            block,
                             &sequences,
                             &mut rep_offsets,
                             is_last,

--- a/crates/encode/src/streaming.rs
+++ b/crates/encode/src/streaming.rs
@@ -303,7 +303,7 @@ impl<W: Write> FrameEncoder<W> {
                     last,
                     &mut self.block_out,
                     &mut self.workspace,
-                    true,
+                    strategy::use_custom_sequence_tables(&self.params, chunk.len()),
                 )
                 .map_err(io::Error::other)?;
             }

--- a/doc/charts/x86_64/matrix.svg
+++ b/doc/charts/x86_64/matrix.svg
@@ -4,7 +4,7 @@
 12-file Silesia: Pipeline @100 MB/s by compressibility (lower is better)
 </text>
 <text x="425" y="40" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#7D8590">
-Linux VM on a 2018 Mac Mini, Intel Core i7-8700B @ 3.20GHz, performance governor, turbo off
+Linux VM on a 2018 Mac Mini, Intel Core i7-8700B @ 3.20GHz, 12 cores, performance governor, turbo off
 </text>
 <text x="22" y="461" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="9.67741935483871" opacity="1" fill="#E6EDF3" font-weight="bold" transform="rotate(270, 22, 461)">
 seconds / GB
@@ -12,187 +12,200 @@ seconds / GB
 <text x="450" y="74" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="10.483870967741936" opacity="1" fill="#E6EDF3" font-weight="bold">
 High compressibility
 </text>
-<polyline fill="none" opacity="1" stroke="#21262D" stroke-width="1" points="70,239 830,239 "/>
-<text x="62" y="239" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#7D8590">
-2.0
+<polyline fill="none" opacity="1" stroke="#21262D" stroke-width="1" points="70,237 830,237 "/>
+<text x="62" y="237" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#7D8590">
+5.0
 </text>
-<polyline fill="none" opacity="1" stroke="#21262D" stroke-width="1" points="70,195 830,195 "/>
-<text x="62" y="195" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#7D8590">
-4.0
+<polyline fill="none" opacity="1" stroke="#21262D" stroke-width="1" points="70,191 830,191 "/>
+<text x="62" y="191" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#7D8590">
+10.0
 </text>
-<polyline fill="none" opacity="1" stroke="#21262D" stroke-width="1" points="70,150 830,150 "/>
-<text x="62" y="150" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#7D8590">
-6.0
+<polyline fill="none" opacity="1" stroke="#21262D" stroke-width="1" points="70,144 830,144 "/>
+<text x="62" y="144" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#7D8590">
+15.0
 </text>
-<polyline fill="none" opacity="1" stroke="#21262D" stroke-width="1" points="70,106 830,106 "/>
-<text x="62" y="106" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#7D8590">
-8.0
+<polyline fill="none" opacity="1" stroke="#21262D" stroke-width="1" points="70,98 830,98 "/>
+<text x="62" y="98" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#7D8590">
+20.0
 </text>
 <polyline fill="none" opacity="1" stroke="#30363D" stroke-width="2" points="70,284 830,284 "/>
-<rect x="95" y="241" width="45" height="43" opacity="1" fill="#60A5FA" stroke="none"/>
-<rect x="95" y="202" width="45" height="39" opacity="1" fill="#4680C4" stroke="none"/>
-<rect x="95" y="187" width="45" height="15" opacity="1" fill="#60A5FA" stroke="none"/>
-<rect x="141" y="221" width="45" height="63" opacity="1" fill="#F87171" stroke="none"/>
-<rect x="141" y="181" width="45" height="40" opacity="1" fill="#C45050" stroke="none"/>
-<rect x="141" y="153" width="45" height="28" opacity="1" fill="#F87171" stroke="none"/>
-<rect x="187" y="208" width="45" height="76" opacity="1" fill="#F59E0B" stroke="none"/>
-<rect x="187" y="168" width="45" height="40" opacity="1" fill="#C47D08" stroke="none"/>
-<rect x="187" y="148" width="45" height="20" opacity="1" fill="#F59E0B" stroke="none"/>
-<rect x="233" y="199" width="45" height="85" opacity="1" fill="#F472B6" stroke="none"/>
-<rect x="233" y="159" width="45" height="40" opacity="1" fill="#C05A92" stroke="none"/>
-<rect x="233" y="125" width="45" height="34" opacity="1" fill="#F472B6" stroke="none"/>
+<rect x="95" y="266" width="36" height="18" opacity="1" fill="#60A5FA" stroke="none"/>
+<rect x="95" y="250" width="36" height="16" opacity="1" fill="#4680C4" stroke="none"/>
+<rect x="95" y="244" width="36" height="6" opacity="1" fill="#60A5FA" stroke="none"/>
+<rect x="132" y="258" width="35" height="26" opacity="1" fill="#F87171" stroke="none"/>
+<rect x="132" y="241" width="35" height="17" opacity="1" fill="#C45050" stroke="none"/>
+<rect x="132" y="229" width="35" height="12" opacity="1" fill="#F87171" stroke="none"/>
+<rect x="168" y="248" width="36" height="36" opacity="1" fill="#F472B6" stroke="none"/>
+<rect x="168" y="231" width="36" height="17" opacity="1" fill="#C05A92" stroke="none"/>
+<rect x="168" y="217" width="36" height="14" opacity="1" fill="#F472B6" stroke="none"/>
+<rect x="205" y="252" width="35" height="32" opacity="1" fill="#F59E0B" stroke="none"/>
+<rect x="205" y="235" width="35" height="17" opacity="1" fill="#C47D08" stroke="none"/>
+<rect x="205" y="224" width="35" height="11" opacity="1" fill="#F59E0B" stroke="none"/>
 <text x="197" y="302" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="9.67741935483871" opacity="1" fill="#E6EDF3" font-weight="bold">
 Level -1
 </text>
-<rect x="349" y="238" width="44" height="46" opacity="1" fill="#60A5FA" stroke="none"/>
-<rect x="349" y="205" width="44" height="33" opacity="1" fill="#4680C4" stroke="none"/>
-<rect x="349" y="190" width="44" height="15" opacity="1" fill="#60A5FA" stroke="none"/>
-<rect x="395" y="216" width="44" height="68" opacity="1" fill="#F87171" stroke="none"/>
-<rect x="395" y="178" width="44" height="38" opacity="1" fill="#C45050" stroke="none"/>
-<rect x="395" y="147" width="44" height="31" opacity="1" fill="#F87171" stroke="none"/>
-<rect x="441" y="205" width="44" height="79" opacity="1" fill="#F59E0B" stroke="none"/>
-<rect x="441" y="171" width="44" height="34" opacity="1" fill="#C47D08" stroke="none"/>
-<rect x="441" y="150" width="44" height="21" opacity="1" fill="#F59E0B" stroke="none"/>
-<rect x="487" y="192" width="44" height="92" opacity="1" fill="#F472B6" stroke="none"/>
-<rect x="487" y="153" width="44" height="39" opacity="1" fill="#C05A92" stroke="none"/>
-<rect x="487" y="115" width="44" height="38" opacity="1" fill="#F472B6" stroke="none"/>
+<rect x="349" y="265" width="35" height="19" opacity="1" fill="#60A5FA" stroke="none"/>
+<rect x="349" y="251" width="35" height="14" opacity="1" fill="#4680C4" stroke="none"/>
+<rect x="349" y="245" width="35" height="6" opacity="1" fill="#60A5FA" stroke="none"/>
+<rect x="385" y="256" width="36" height="28" opacity="1" fill="#F87171" stroke="none"/>
+<rect x="385" y="240" width="36" height="16" opacity="1" fill="#C45050" stroke="none"/>
+<rect x="385" y="227" width="36" height="13" opacity="1" fill="#F87171" stroke="none"/>
+<rect x="422" y="245" width="35" height="39" opacity="1" fill="#F472B6" stroke="none"/>
+<rect x="422" y="229" width="35" height="16" opacity="1" fill="#C05A92" stroke="none"/>
+<rect x="422" y="214" width="35" height="15" opacity="1" fill="#F472B6" stroke="none"/>
+<rect x="458" y="251" width="36" height="33" opacity="1" fill="#F59E0B" stroke="none"/>
+<rect x="458" y="237" width="36" height="14" opacity="1" fill="#C47D08" stroke="none"/>
+<rect x="458" y="225" width="36" height="12" opacity="1" fill="#F59E0B" stroke="none"/>
+<rect x="495" y="162" width="35" height="122" opacity="1" fill="#4ADE80" stroke="none"/>
+<rect x="495" y="141" width="35" height="21" opacity="1" fill="#3AAF60" stroke="none"/>
+<rect x="495" y="110" width="35" height="31" opacity="1" fill="#4ADE80" stroke="none"/>
 <text x="450" y="302" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="9.67741935483871" opacity="1" fill="#E6EDF3" font-weight="bold">
 Level 1
 </text>
-<rect x="602" y="223" width="44" height="61" opacity="1" fill="#60A5FA" stroke="none"/>
-<rect x="602" y="192" width="44" height="31" opacity="1" fill="#4680C4" stroke="none"/>
-<rect x="602" y="176" width="44" height="16" opacity="1" fill="#60A5FA" stroke="none"/>
-<rect x="648" y="206" width="44" height="78" opacity="1" fill="#F87171" stroke="none"/>
-<rect x="648" y="172" width="44" height="34" opacity="1" fill="#C45050" stroke="none"/>
-<rect x="648" y="144" width="44" height="28" opacity="1" fill="#F87171" stroke="none"/>
-<rect x="694" y="164" width="44" height="120" opacity="1" fill="#F59E0B" stroke="none"/>
-<rect x="694" y="133" width="44" height="31" opacity="1" fill="#C47D08" stroke="none"/>
-<rect x="694" y="110" width="44" height="23" opacity="1" fill="#F59E0B" stroke="none"/>
-<rect x="740" y="179" width="44" height="105" opacity="1" fill="#F472B6" stroke="none"/>
-<rect x="740" y="144" width="44" height="35" opacity="1" fill="#C05A92" stroke="none"/>
-<rect x="740" y="110" width="44" height="34" opacity="1" fill="#F472B6" stroke="none"/>
+<rect x="602" y="259" width="35" height="25" opacity="1" fill="#60A5FA" stroke="none"/>
+<rect x="602" y="246" width="35" height="13" opacity="1" fill="#4680C4" stroke="none"/>
+<rect x="602" y="240" width="35" height="6" opacity="1" fill="#60A5FA" stroke="none"/>
+<rect x="639" y="252" width="35" height="32" opacity="1" fill="#F87171" stroke="none"/>
+<rect x="639" y="237" width="35" height="15" opacity="1" fill="#C45050" stroke="none"/>
+<rect x="639" y="226" width="35" height="11" opacity="1" fill="#F87171" stroke="none"/>
+<rect x="675" y="239" width="36" height="45" opacity="1" fill="#F472B6" stroke="none"/>
+<rect x="675" y="225" width="36" height="14" opacity="1" fill="#C05A92" stroke="none"/>
+<rect x="675" y="211" width="36" height="14" opacity="1" fill="#F472B6" stroke="none"/>
+<rect x="712" y="232" width="35" height="52" opacity="1" fill="#F59E0B" stroke="none"/>
+<rect x="712" y="219" width="35" height="13" opacity="1" fill="#C47D08" stroke="none"/>
+<rect x="712" y="207" width="35" height="12" opacity="1" fill="#F59E0B" stroke="none"/>
 <text x="703" y="302" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="9.67741935483871" opacity="1" fill="#E6EDF3" font-weight="bold">
 Level 3
 </text>
 <text x="450" y="351" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="10.483870967741936" opacity="1" fill="#E6EDF3" font-weight="bold">
 Medium compressibility
 </text>
-<polyline fill="none" opacity="1" stroke="#21262D" stroke-width="1" points="70,510 830,510 "/>
-<text x="62" y="510" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#7D8590">
-5.0
-</text>
-<polyline fill="none" opacity="1" stroke="#21262D" stroke-width="1" points="70,459 830,459 "/>
-<text x="62" y="459" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#7D8590">
+<polyline fill="none" opacity="1" stroke="#21262D" stroke-width="1" points="70,503 830,503 "/>
+<text x="62" y="503" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#7D8590">
 10.0
 </text>
-<polyline fill="none" opacity="1" stroke="#21262D" stroke-width="1" points="70,408 830,408 "/>
-<text x="62" y="408" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#7D8590">
-15.0
+<polyline fill="none" opacity="1" stroke="#21262D" stroke-width="1" points="70,445 830,445 "/>
+<text x="62" y="445" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#7D8590">
+20.0
+</text>
+<polyline fill="none" opacity="1" stroke="#21262D" stroke-width="1" points="70,388 830,388 "/>
+<text x="62" y="388" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#7D8590">
+30.0
 </text>
 <polyline fill="none" opacity="1" stroke="#30363D" stroke-width="2" points="70,561 830,561 "/>
-<rect x="95" y="527" width="45" height="34" opacity="1" fill="#60A5FA" stroke="none"/>
-<rect x="95" y="481" width="45" height="46" opacity="1" fill="#4680C4" stroke="none"/>
-<rect x="95" y="472" width="45" height="9" opacity="1" fill="#60A5FA" stroke="none"/>
-<rect x="141" y="508" width="45" height="53" opacity="1" fill="#F87171" stroke="none"/>
-<rect x="141" y="464" width="45" height="44" opacity="1" fill="#C45050" stroke="none"/>
-<rect x="141" y="444" width="45" height="20" opacity="1" fill="#F87171" stroke="none"/>
-<rect x="187" y="505" width="45" height="56" opacity="1" fill="#F59E0B" stroke="none"/>
-<rect x="187" y="459" width="45" height="46" opacity="1" fill="#C47D08" stroke="none"/>
-<rect x="187" y="445" width="45" height="14" opacity="1" fill="#F59E0B" stroke="none"/>
-<rect x="233" y="490" width="45" height="71" opacity="1" fill="#F472B6" stroke="none"/>
-<rect x="233" y="446" width="45" height="44" opacity="1" fill="#C05A92" stroke="none"/>
-<rect x="233" y="421" width="45" height="25" opacity="1" fill="#F472B6" stroke="none"/>
+<rect x="95" y="542" width="36" height="19" opacity="1" fill="#60A5FA" stroke="none"/>
+<rect x="95" y="516" width="36" height="26" opacity="1" fill="#4680C4" stroke="none"/>
+<rect x="95" y="511" width="36" height="5" opacity="1" fill="#60A5FA" stroke="none"/>
+<rect x="132" y="531" width="35" height="30" opacity="1" fill="#F87171" stroke="none"/>
+<rect x="132" y="506" width="35" height="25" opacity="1" fill="#C45050" stroke="none"/>
+<rect x="132" y="495" width="35" height="11" opacity="1" fill="#F87171" stroke="none"/>
+<rect x="168" y="520" width="36" height="41" opacity="1" fill="#F472B6" stroke="none"/>
+<rect x="168" y="495" width="36" height="25" opacity="1" fill="#C05A92" stroke="none"/>
+<rect x="168" y="481" width="36" height="14" opacity="1" fill="#F472B6" stroke="none"/>
+<rect x="205" y="529" width="35" height="32" opacity="1" fill="#F59E0B" stroke="none"/>
+<rect x="205" y="503" width="35" height="26" opacity="1" fill="#C47D08" stroke="none"/>
+<rect x="205" y="493" width="35" height="10" opacity="1" fill="#F59E0B" stroke="none"/>
 <text x="197" y="579" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="9.67741935483871" opacity="1" fill="#E6EDF3" font-weight="bold">
 Level -1
 </text>
-<rect x="349" y="524" width="44" height="37" opacity="1" fill="#60A5FA" stroke="none"/>
-<rect x="349" y="485" width="44" height="39" opacity="1" fill="#4680C4" stroke="none"/>
-<rect x="349" y="475" width="44" height="10" opacity="1" fill="#60A5FA" stroke="none"/>
-<rect x="395" y="501" width="44" height="60" opacity="1" fill="#F87171" stroke="none"/>
-<rect x="395" y="460" width="44" height="41" opacity="1" fill="#C45050" stroke="none"/>
-<rect x="395" y="436" width="44" height="24" opacity="1" fill="#F87171" stroke="none"/>
-<rect x="441" y="499" width="44" height="62" opacity="1" fill="#F59E0B" stroke="none"/>
-<rect x="441" y="460" width="44" height="39" opacity="1" fill="#C47D08" stroke="none"/>
-<rect x="441" y="444" width="44" height="16" opacity="1" fill="#F59E0B" stroke="none"/>
-<rect x="487" y="478" width="44" height="83" opacity="1" fill="#F472B6" stroke="none"/>
-<rect x="487" y="437" width="44" height="41" opacity="1" fill="#C05A92" stroke="none"/>
-<rect x="487" y="407" width="44" height="30" opacity="1" fill="#F472B6" stroke="none"/>
+<rect x="349" y="540" width="35" height="21" opacity="1" fill="#60A5FA" stroke="none"/>
+<rect x="349" y="518" width="35" height="22" opacity="1" fill="#4680C4" stroke="none"/>
+<rect x="349" y="512" width="35" height="6" opacity="1" fill="#60A5FA" stroke="none"/>
+<rect x="385" y="527" width="36" height="34" opacity="1" fill="#F87171" stroke="none"/>
+<rect x="385" y="504" width="36" height="23" opacity="1" fill="#C45050" stroke="none"/>
+<rect x="385" y="490" width="36" height="14" opacity="1" fill="#F87171" stroke="none"/>
+<rect x="422" y="514" width="35" height="47" opacity="1" fill="#F472B6" stroke="none"/>
+<rect x="422" y="491" width="35" height="23" opacity="1" fill="#C05A92" stroke="none"/>
+<rect x="422" y="474" width="35" height="17" opacity="1" fill="#F472B6" stroke="none"/>
+<rect x="458" y="525" width="36" height="36" opacity="1" fill="#F59E0B" stroke="none"/>
+<rect x="458" y="503" width="36" height="22" opacity="1" fill="#C47D08" stroke="none"/>
+<rect x="458" y="492" width="36" height="11" opacity="1" fill="#F59E0B" stroke="none"/>
+<rect x="495" y="444" width="35" height="117" opacity="1" fill="#4ADE80" stroke="none"/>
+<rect x="495" y="417" width="35" height="27" opacity="1" fill="#3AAF60" stroke="none"/>
+<rect x="495" y="387" width="35" height="30" opacity="1" fill="#4ADE80" stroke="none"/>
 <text x="450" y="579" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="9.67741935483871" opacity="1" fill="#E6EDF3" font-weight="bold">
 Level 1
 </text>
-<rect x="602" y="498" width="44" height="63" opacity="1" fill="#60A5FA" stroke="none"/>
-<rect x="602" y="463" width="44" height="35" opacity="1" fill="#4680C4" stroke="none"/>
-<rect x="602" y="451" width="44" height="12" opacity="1" fill="#60A5FA" stroke="none"/>
-<rect x="648" y="481" width="44" height="80" opacity="1" fill="#F87171" stroke="none"/>
-<rect x="648" y="443" width="44" height="38" opacity="1" fill="#C45050" stroke="none"/>
-<rect x="648" y="422" width="44" height="21" opacity="1" fill="#F87171" stroke="none"/>
-<rect x="694" y="445" width="44" height="116" opacity="1" fill="#F59E0B" stroke="none"/>
-<rect x="694" y="410" width="44" height="35" opacity="1" fill="#C47D08" stroke="none"/>
-<rect x="694" y="391" width="44" height="19" opacity="1" fill="#F59E0B" stroke="none"/>
-<rect x="740" y="453" width="44" height="108" opacity="1" fill="#F472B6" stroke="none"/>
-<rect x="740" y="415" width="44" height="38" opacity="1" fill="#C05A92" stroke="none"/>
-<rect x="740" y="387" width="44" height="28" opacity="1" fill="#F472B6" stroke="none"/>
+<rect x="602" y="526" width="35" height="35" opacity="1" fill="#60A5FA" stroke="none"/>
+<rect x="602" y="507" width="35" height="19" opacity="1" fill="#4680C4" stroke="none"/>
+<rect x="602" y="500" width="35" height="7" opacity="1" fill="#60A5FA" stroke="none"/>
+<rect x="639" y="516" width="35" height="45" opacity="1" fill="#F87171" stroke="none"/>
+<rect x="639" y="494" width="35" height="22" opacity="1" fill="#C45050" stroke="none"/>
+<rect x="639" y="482" width="35" height="12" opacity="1" fill="#F87171" stroke="none"/>
+<rect x="675" y="500" width="36" height="61" opacity="1" fill="#F472B6" stroke="none"/>
+<rect x="675" y="479" width="36" height="21" opacity="1" fill="#C05A92" stroke="none"/>
+<rect x="675" y="463" width="36" height="16" opacity="1" fill="#F472B6" stroke="none"/>
+<rect x="712" y="493" width="35" height="68" opacity="1" fill="#F59E0B" stroke="none"/>
+<rect x="712" y="473" width="35" height="20" opacity="1" fill="#C47D08" stroke="none"/>
+<rect x="712" y="461" width="35" height="12" opacity="1" fill="#F59E0B" stroke="none"/>
 <text x="703" y="579" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="9.67741935483871" opacity="1" fill="#E6EDF3" font-weight="bold">
 Level 3
 </text>
 <text x="450" y="628" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="10.483870967741936" opacity="1" fill="#E6EDF3" font-weight="bold">
 Low compressibility
 </text>
-<polyline fill="none" opacity="1" stroke="#21262D" stroke-width="1" points="70,775 830,775 "/>
-<text x="62" y="775" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#7D8590">
+<polyline fill="none" opacity="1" stroke="#21262D" stroke-width="1" points="70,796 830,796 "/>
+<text x="62" y="796" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#7D8590">
 10.0
 </text>
-<polyline fill="none" opacity="1" stroke="#21262D" stroke-width="1" points="70,713 830,713 "/>
-<text x="62" y="713" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#7D8590">
+<polyline fill="none" opacity="1" stroke="#21262D" stroke-width="1" points="70,754 830,754 "/>
+<text x="62" y="754" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#7D8590">
 20.0
 </text>
-<polyline fill="none" opacity="1" stroke="#21262D" stroke-width="1" points="70,650 830,650 "/>
-<text x="62" y="650" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#7D8590">
+<polyline fill="none" opacity="1" stroke="#21262D" stroke-width="1" points="70,711 830,711 "/>
+<text x="62" y="711" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#7D8590">
 30.0
 </text>
+<polyline fill="none" opacity="1" stroke="#21262D" stroke-width="1" points="70,669 830,669 "/>
+<text x="62" y="669" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#7D8590">
+40.0
+</text>
 <polyline fill="none" opacity="1" stroke="#30363D" stroke-width="2" points="70,838 830,838 "/>
-<rect x="95" y="827" width="45" height="11" opacity="1" fill="#60A5FA" stroke="none"/>
-<rect x="95" y="768" width="45" height="59" opacity="1" fill="#4680C4" stroke="none"/>
-<rect x="95" y="766" width="45" height="2" opacity="1" fill="#60A5FA" stroke="none"/>
-<rect x="141" y="822" width="45" height="16" opacity="1" fill="#F87171" stroke="none"/>
-<rect x="141" y="764" width="45" height="58" opacity="1" fill="#C45050" stroke="none"/>
-<rect x="141" y="760" width="45" height="4" opacity="1" fill="#F87171" stroke="none"/>
-<rect x="187" y="823" width="45" height="15" opacity="1" fill="#F59E0B" stroke="none"/>
-<rect x="187" y="763" width="45" height="60" opacity="1" fill="#C47D08" stroke="none"/>
-<rect x="187" y="761" width="45" height="2" opacity="1" fill="#F59E0B" stroke="none"/>
-<rect x="233" y="817" width="45" height="21" opacity="1" fill="#F472B6" stroke="none"/>
-<rect x="233" y="759" width="45" height="58" opacity="1" fill="#C05A92" stroke="none"/>
-<rect x="233" y="754" width="45" height="5" opacity="1" fill="#F472B6" stroke="none"/>
+<rect x="95" y="831" width="36" height="7" opacity="1" fill="#60A5FA" stroke="none"/>
+<rect x="95" y="790" width="36" height="41" opacity="1" fill="#4680C4" stroke="none"/>
+<rect x="95" y="789" width="36" height="1" opacity="1" fill="#60A5FA" stroke="none"/>
+<rect x="132" y="827" width="35" height="11" opacity="1" fill="#F87171" stroke="none"/>
+<rect x="132" y="788" width="35" height="39" opacity="1" fill="#C45050" stroke="none"/>
+<rect x="132" y="785" width="35" height="3" opacity="1" fill="#F87171" stroke="none"/>
+<rect x="168" y="824" width="36" height="14" opacity="1" fill="#F472B6" stroke="none"/>
+<rect x="168" y="784" width="36" height="40" opacity="1" fill="#C05A92" stroke="none"/>
+<rect x="168" y="781" width="36" height="3" opacity="1" fill="#F472B6" stroke="none"/>
+<rect x="205" y="828" width="35" height="10" opacity="1" fill="#F59E0B" stroke="none"/>
+<rect x="205" y="788" width="35" height="40" opacity="1" fill="#C47D08" stroke="none"/>
+<rect x="205" y="786" width="35" height="2" opacity="1" fill="#F59E0B" stroke="none"/>
 <text x="197" y="856" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="9.67741935483871" opacity="1" fill="#E6EDF3" font-weight="bold">
 Level -1
 </text>
-<rect x="349" y="821" width="44" height="17" opacity="1" fill="#60A5FA" stroke="none"/>
-<rect x="349" y="769" width="44" height="52" opacity="1" fill="#4680C4" stroke="none"/>
-<rect x="349" y="763" width="44" height="6" opacity="1" fill="#60A5FA" stroke="none"/>
-<rect x="395" y="808" width="44" height="30" opacity="1" fill="#F87171" stroke="none"/>
-<rect x="395" y="753" width="44" height="55" opacity="1" fill="#C45050" stroke="none"/>
-<rect x="395" y="745" width="44" height="8" opacity="1" fill="#F87171" stroke="none"/>
-<rect x="441" y="803" width="44" height="35" opacity="1" fill="#F59E0B" stroke="none"/>
-<rect x="441" y="751" width="44" height="52" opacity="1" fill="#C47D08" stroke="none"/>
-<rect x="441" y="742" width="44" height="9" opacity="1" fill="#F59E0B" stroke="none"/>
-<rect x="487" y="797" width="44" height="41" opacity="1" fill="#F472B6" stroke="none"/>
-<rect x="487" y="742" width="44" height="55" opacity="1" fill="#C05A92" stroke="none"/>
-<rect x="487" y="731" width="44" height="11" opacity="1" fill="#F472B6" stroke="none"/>
+<rect x="349" y="826" width="35" height="12" opacity="1" fill="#60A5FA" stroke="none"/>
+<rect x="349" y="791" width="35" height="35" opacity="1" fill="#4680C4" stroke="none"/>
+<rect x="349" y="787" width="35" height="4" opacity="1" fill="#60A5FA" stroke="none"/>
+<rect x="385" y="819" width="36" height="19" opacity="1" fill="#F87171" stroke="none"/>
+<rect x="385" y="782" width="36" height="37" opacity="1" fill="#C45050" stroke="none"/>
+<rect x="385" y="776" width="36" height="6" opacity="1" fill="#F87171" stroke="none"/>
+<rect x="422" y="812" width="35" height="26" opacity="1" fill="#F472B6" stroke="none"/>
+<rect x="422" y="775" width="35" height="37" opacity="1" fill="#C05A92" stroke="none"/>
+<rect x="422" y="768" width="35" height="7" opacity="1" fill="#F472B6" stroke="none"/>
+<rect x="458" y="814" width="36" height="24" opacity="1" fill="#F59E0B" stroke="none"/>
+<rect x="458" y="779" width="36" height="35" opacity="1" fill="#C47D08" stroke="none"/>
+<rect x="458" y="773" width="36" height="6" opacity="1" fill="#F59E0B" stroke="none"/>
+<rect x="495" y="715" width="35" height="123" opacity="1" fill="#4ADE80" stroke="none"/>
+<rect x="495" y="679" width="35" height="36" opacity="1" fill="#3AAF60" stroke="none"/>
+<rect x="495" y="664" width="35" height="15" opacity="1" fill="#4ADE80" stroke="none"/>
 <text x="450" y="856" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="9.67741935483871" opacity="1" fill="#E6EDF3" font-weight="bold">
 Level 1
 </text>
-<rect x="602" y="775" width="44" height="63" opacity="1" fill="#60A5FA" stroke="none"/>
-<rect x="602" y="729" width="44" height="46" opacity="1" fill="#4680C4" stroke="none"/>
-<rect x="602" y="720" width="44" height="9" opacity="1" fill="#60A5FA" stroke="none"/>
-<rect x="648" y="777" width="44" height="61" opacity="1" fill="#F87171" stroke="none"/>
-<rect x="648" y="727" width="44" height="50" opacity="1" fill="#C45050" stroke="none"/>
-<rect x="648" y="714" width="44" height="13" opacity="1" fill="#F87171" stroke="none"/>
-<rect x="694" y="724" width="44" height="114" opacity="1" fill="#F59E0B" stroke="none"/>
-<rect x="694" y="677" width="44" height="47" opacity="1" fill="#C47D08" stroke="none"/>
-<rect x="694" y="664" width="44" height="13" opacity="1" fill="#F59E0B" stroke="none"/>
-<rect x="740" y="754" width="44" height="84" opacity="1" fill="#F472B6" stroke="none"/>
-<rect x="740" y="704" width="44" height="50" opacity="1" fill="#C05A92" stroke="none"/>
-<rect x="740" y="688" width="44" height="16" opacity="1" fill="#F472B6" stroke="none"/>
+<rect x="602" y="796" width="35" height="42" opacity="1" fill="#60A5FA" stroke="none"/>
+<rect x="602" y="765" width="35" height="31" opacity="1" fill="#4680C4" stroke="none"/>
+<rect x="602" y="759" width="35" height="6" opacity="1" fill="#60A5FA" stroke="none"/>
+<rect x="639" y="801" width="35" height="37" opacity="1" fill="#F87171" stroke="none"/>
+<rect x="639" y="766" width="35" height="35" opacity="1" fill="#C45050" stroke="none"/>
+<rect x="639" y="759" width="35" height="7" opacity="1" fill="#F87171" stroke="none"/>
+<rect x="675" y="789" width="36" height="49" opacity="1" fill="#F472B6" stroke="none"/>
+<rect x="675" y="754" width="36" height="35" opacity="1" fill="#C05A92" stroke="none"/>
+<rect x="675" y="745" width="36" height="9" opacity="1" fill="#F472B6" stroke="none"/>
+<rect x="712" y="758" width="35" height="80" opacity="1" fill="#F59E0B" stroke="none"/>
+<rect x="712" y="726" width="35" height="32" opacity="1" fill="#C47D08" stroke="none"/>
+<rect x="712" y="717" width="35" height="9" opacity="1" fill="#F59E0B" stroke="none"/>
 <text x="703" y="856" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="9.67741935483871" opacity="1" fill="#E6EDF3" font-weight="bold">
 Level 3
 </text>
@@ -204,18 +217,22 @@ libzstd v1.5.7 (C)
 <text x="208" y="906" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E6EDF3">
 zrip (safe SIMD + encapsulated unsafe)
 </text>
+<rect x="190" y="920" width="12" height="12" opacity="1" fill="#F472B6" stroke="none"/>
+<text x="208" y="926" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E6EDF3">
+zrip paranoid (safe SIMD, no unsafe)
+</text>
 <rect x="460" y="880" width="12" height="12" opacity="1" fill="#F59E0B" stroke="none"/>
 <text x="478" y="886" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E6EDF3">
 structured-zstd v0.0.49 (unsafe)
 </text>
-<rect x="460" y="900" width="12" height="12" opacity="1" fill="#F472B6" stroke="none"/>
+<rect x="460" y="900" width="12" height="12" opacity="1" fill="#4ADE80" stroke="none"/>
 <text x="478" y="906" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E6EDF3">
-zrip paranoid (safe SIMD, no unsafe)
+ruzstd v0.8.3 (safe)
 </text>
-<text x="215" y="942" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E6EDF3">
+<text x="215" y="962" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E6EDF3">
 bright = compress + decompress
 </text>
-<text x="455" y="942" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#7D8590">
+<text x="455" y="962" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#7D8590">
 dim = transfer @100 MB/s
 </text>
 </svg>

--- a/doc/charts/x86_64/pipeline.svg
+++ b/doc/charts/x86_64/pipeline.svg
@@ -4,7 +4,7 @@
 12-file Silesia: Per-file pipeline @100 MB/s, Level 1 (lower is better)
 </text>
 <text x="425" y="40" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#7D8590">
-Linux VM on a 2018 Mac Mini, Intel Core i7-8700B @ 3.20GHz, performance governor, turbo off
+Linux VM on a 2018 Mac Mini, Intel Core i7-8700B @ 3.20GHz, 12 cores, performance governor, turbo off
 </text>
 <text x="22" y="337" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="9.67741935483871" opacity="1" fill="#E6EDF3" font-weight="bold" transform="rotate(270, 22, 337)">
 seconds / GB
@@ -28,19 +28,19 @@ seconds / GB
 <polyline fill="none" opacity="1" stroke="#30363D" stroke-width="2" points="55,302 830,302 "/>
 <rect x="71" y="278" width="20" height="24" opacity="1" fill="#60A5FA" stroke="none"/>
 <rect x="71" y="256" width="20" height="22" opacity="1" fill="#4680C4" stroke="none"/>
-<rect x="71" y="251" width="20" height="5" opacity="1" fill="#60A5FA" stroke="none"/>
-<rect x="91" y="262" width="19" height="40" opacity="1" fill="#F87171" stroke="none"/>
-<rect x="91" y="238" width="19" height="24" opacity="1" fill="#C45050" stroke="none"/>
-<rect x="91" y="222" width="19" height="16" opacity="1" fill="#F87171" stroke="none"/>
-<rect x="110" y="264" width="19" height="38" opacity="1" fill="#F59E0B" stroke="none"/>
-<rect x="110" y="242" width="19" height="22" opacity="1" fill="#C47D08" stroke="none"/>
-<rect x="110" y="233" width="19" height="9" opacity="1" fill="#F59E0B" stroke="none"/>
-<rect x="129" y="245" width="20" height="57" opacity="1" fill="#F472B6" stroke="none"/>
-<rect x="129" y="222" width="20" height="23" opacity="1" fill="#C05A92" stroke="none"/>
-<rect x="129" y="202" width="20" height="20" opacity="1" fill="#F472B6" stroke="none"/>
-<rect x="149" y="184" width="19" height="118" opacity="1" fill="#4ADE80" stroke="none"/>
-<rect x="149" y="159" width="19" height="25" opacity="1" fill="#3AAF60" stroke="none"/>
-<rect x="149" y="119" width="19" height="40" opacity="1" fill="#4ADE80" stroke="none"/>
+<rect x="71" y="250" width="20" height="6" opacity="1" fill="#60A5FA" stroke="none"/>
+<rect x="91" y="261" width="19" height="41" opacity="1" fill="#F87171" stroke="none"/>
+<rect x="91" y="237" width="19" height="24" opacity="1" fill="#C45050" stroke="none"/>
+<rect x="91" y="221" width="19" height="16" opacity="1" fill="#F87171" stroke="none"/>
+<rect x="110" y="245" width="19" height="57" opacity="1" fill="#F472B6" stroke="none"/>
+<rect x="110" y="222" width="19" height="23" opacity="1" fill="#C05A92" stroke="none"/>
+<rect x="110" y="202" width="19" height="20" opacity="1" fill="#F472B6" stroke="none"/>
+<rect x="129" y="264" width="20" height="38" opacity="1" fill="#F59E0B" stroke="none"/>
+<rect x="129" y="243" width="20" height="21" opacity="1" fill="#C47D08" stroke="none"/>
+<rect x="129" y="233" width="20" height="10" opacity="1" fill="#F59E0B" stroke="none"/>
+<rect x="149" y="185" width="19" height="117" opacity="1" fill="#4ADE80" stroke="none"/>
+<rect x="149" y="159" width="19" height="26" opacity="1" fill="#3AAF60" stroke="none"/>
+<rect x="149" y="120" width="19" height="39" opacity="1" fill="#4ADE80" stroke="none"/>
 <text x="120" y="319" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E6EDF3" font-weight="bold">
 dickens
 </text>
@@ -52,16 +52,16 @@ dickens
 <rect x="200" y="259" width="20" height="6" opacity="1" fill="#60A5FA" stroke="none"/>
 <rect x="220" y="276" width="19" height="26" opacity="1" fill="#F87171" stroke="none"/>
 <rect x="220" y="254" width="19" height="22" opacity="1" fill="#C45050" stroke="none"/>
-<rect x="220" y="243" width="19" height="11" opacity="1" fill="#F87171" stroke="none"/>
-<rect x="239" y="272" width="19" height="30" opacity="1" fill="#F59E0B" stroke="none"/>
-<rect x="239" y="251" width="19" height="21" opacity="1" fill="#C47D08" stroke="none"/>
-<rect x="239" y="242" width="19" height="9" opacity="1" fill="#F59E0B" stroke="none"/>
-<rect x="258" y="266" width="20" height="36" opacity="1" fill="#F472B6" stroke="none"/>
-<rect x="258" y="245" width="20" height="21" opacity="1" fill="#C05A92" stroke="none"/>
-<rect x="258" y="230" width="20" height="15" opacity="1" fill="#F472B6" stroke="none"/>
-<rect x="278" y="196" width="19" height="106" opacity="1" fill="#4ADE80" stroke="none"/>
-<rect x="278" y="170" width="19" height="26" opacity="1" fill="#3AAF60" stroke="none"/>
-<rect x="278" y="147" width="19" height="23" opacity="1" fill="#4ADE80" stroke="none"/>
+<rect x="220" y="242" width="19" height="12" opacity="1" fill="#F87171" stroke="none"/>
+<rect x="239" y="266" width="19" height="36" opacity="1" fill="#F472B6" stroke="none"/>
+<rect x="239" y="245" width="19" height="21" opacity="1" fill="#C05A92" stroke="none"/>
+<rect x="239" y="230" width="19" height="15" opacity="1" fill="#F472B6" stroke="none"/>
+<rect x="258" y="271" width="20" height="31" opacity="1" fill="#F59E0B" stroke="none"/>
+<rect x="258" y="251" width="20" height="20" opacity="1" fill="#C47D08" stroke="none"/>
+<rect x="258" y="240" width="20" height="11" opacity="1" fill="#F59E0B" stroke="none"/>
+<rect x="278" y="194" width="19" height="108" opacity="1" fill="#4ADE80" stroke="none"/>
+<rect x="278" y="168" width="19" height="26" opacity="1" fill="#3AAF60" stroke="none"/>
+<rect x="278" y="146" width="19" height="22" opacity="1" fill="#4ADE80" stroke="none"/>
 <text x="249" y="319" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E6EDF3" font-weight="bold">
 mozilla
 </text>
@@ -74,15 +74,15 @@ mozilla
 <rect x="349" y="270" width="19" height="32" opacity="1" fill="#F87171" stroke="none"/>
 <rect x="349" y="248" width="19" height="22" opacity="1" fill="#C45050" stroke="none"/>
 <rect x="349" y="235" width="19" height="13" opacity="1" fill="#F87171" stroke="none"/>
-<rect x="368" y="271" width="20" height="31" opacity="1" fill="#F59E0B" stroke="none"/>
-<rect x="368" y="251" width="20" height="20" opacity="1" fill="#C47D08" stroke="none"/>
-<rect x="368" y="243" width="20" height="8" opacity="1" fill="#F59E0B" stroke="none"/>
-<rect x="388" y="256" width="19" height="46" opacity="1" fill="#F472B6" stroke="none"/>
-<rect x="388" y="234" width="19" height="22" opacity="1" fill="#C05A92" stroke="none"/>
-<rect x="388" y="218" width="19" height="16" opacity="1" fill="#F472B6" stroke="none"/>
-<rect x="407" y="203" width="19" height="99" opacity="1" fill="#4ADE80" stroke="none"/>
-<rect x="407" y="177" width="19" height="26" opacity="1" fill="#3AAF60" stroke="none"/>
-<rect x="407" y="150" width="19" height="27" opacity="1" fill="#4ADE80" stroke="none"/>
+<rect x="368" y="256" width="20" height="46" opacity="1" fill="#F472B6" stroke="none"/>
+<rect x="368" y="235" width="20" height="21" opacity="1" fill="#C05A92" stroke="none"/>
+<rect x="368" y="218" width="20" height="17" opacity="1" fill="#F472B6" stroke="none"/>
+<rect x="388" y="271" width="19" height="31" opacity="1" fill="#F59E0B" stroke="none"/>
+<rect x="388" y="251" width="19" height="20" opacity="1" fill="#C47D08" stroke="none"/>
+<rect x="388" y="243" width="19" height="8" opacity="1" fill="#F59E0B" stroke="none"/>
+<rect x="407" y="201" width="19" height="101" opacity="1" fill="#4ADE80" stroke="none"/>
+<rect x="407" y="175" width="19" height="26" opacity="1" fill="#3AAF60" stroke="none"/>
+<rect x="407" y="148" width="19" height="27" opacity="1" fill="#4ADE80" stroke="none"/>
 <text x="378" y="319" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E6EDF3" font-weight="bold">
 mr
 </text>
@@ -91,16 +91,16 @@ mr
 </text>
 <rect x="459" y="293" width="19" height="9" opacity="1" fill="#60A5FA" stroke="none"/>
 <rect x="459" y="289" width="19" height="4" opacity="1" fill="#4680C4" stroke="none"/>
-<rect x="459" y="285" width="19" height="4" opacity="1" fill="#60A5FA" stroke="none"/>
+<rect x="459" y="286" width="19" height="3" opacity="1" fill="#60A5FA" stroke="none"/>
 <rect x="478" y="289" width="19" height="13" opacity="1" fill="#F87171" stroke="none"/>
-<rect x="478" y="283" width="19" height="6" opacity="1" fill="#C45050" stroke="none"/>
-<rect x="478" y="277" width="19" height="6" opacity="1" fill="#F87171" stroke="none"/>
-<rect x="497" y="286" width="20" height="16" opacity="1" fill="#F59E0B" stroke="none"/>
-<rect x="497" y="281" width="20" height="5" opacity="1" fill="#C47D08" stroke="none"/>
-<rect x="497" y="277" width="20" height="4" opacity="1" fill="#F59E0B" stroke="none"/>
-<rect x="517" y="284" width="19" height="18" opacity="1" fill="#F472B6" stroke="none"/>
-<rect x="517" y="279" width="19" height="5" opacity="1" fill="#C05A92" stroke="none"/>
-<rect x="517" y="271" width="19" height="8" opacity="1" fill="#F472B6" stroke="none"/>
+<rect x="478" y="284" width="19" height="5" opacity="1" fill="#C45050" stroke="none"/>
+<rect x="478" y="277" width="19" height="7" opacity="1" fill="#F87171" stroke="none"/>
+<rect x="497" y="284" width="20" height="18" opacity="1" fill="#F472B6" stroke="none"/>
+<rect x="497" y="279" width="20" height="5" opacity="1" fill="#C05A92" stroke="none"/>
+<rect x="497" y="271" width="20" height="8" opacity="1" fill="#F472B6" stroke="none"/>
+<rect x="517" y="286" width="19" height="16" opacity="1" fill="#F59E0B" stroke="none"/>
+<rect x="517" y="281" width="19" height="5" opacity="1" fill="#C47D08" stroke="none"/>
+<rect x="517" y="274" width="19" height="7" opacity="1" fill="#F59E0B" stroke="none"/>
 <rect x="536" y="244" width="20" height="58" opacity="1" fill="#4ADE80" stroke="none"/>
 <rect x="536" y="236" width="20" height="8" opacity="1" fill="#3AAF60" stroke="none"/>
 <rect x="536" y="222" width="20" height="14" opacity="1" fill="#4ADE80" stroke="none"/>
@@ -116,12 +116,12 @@ nci
 <rect x="607" y="265" width="20" height="37" opacity="1" fill="#F87171" stroke="none"/>
 <rect x="607" y="235" width="20" height="30" opacity="1" fill="#C45050" stroke="none"/>
 <rect x="607" y="220" width="20" height="15" opacity="1" fill="#F87171" stroke="none"/>
-<rect x="627" y="266" width="19" height="36" opacity="1" fill="#F59E0B" stroke="none"/>
-<rect x="627" y="235" width="19" height="31" opacity="1" fill="#C47D08" stroke="none"/>
-<rect x="627" y="226" width="19" height="9" opacity="1" fill="#F59E0B" stroke="none"/>
-<rect x="646" y="251" width="19" height="51" opacity="1" fill="#F472B6" stroke="none"/>
-<rect x="646" y="222" width="19" height="29" opacity="1" fill="#C05A92" stroke="none"/>
-<rect x="646" y="204" width="19" height="18" opacity="1" fill="#F472B6" stroke="none"/>
+<rect x="627" y="251" width="19" height="51" opacity="1" fill="#F472B6" stroke="none"/>
+<rect x="627" y="222" width="19" height="29" opacity="1" fill="#C05A92" stroke="none"/>
+<rect x="627" y="204" width="19" height="18" opacity="1" fill="#F472B6" stroke="none"/>
+<rect x="646" y="266" width="19" height="36" opacity="1" fill="#F59E0B" stroke="none"/>
+<rect x="646" y="235" width="19" height="31" opacity="1" fill="#C47D08" stroke="none"/>
+<rect x="646" y="226" width="19" height="9" opacity="1" fill="#F59E0B" stroke="none"/>
 <rect x="665" y="172" width="20" height="130" opacity="1" fill="#4ADE80" stroke="none"/>
 <rect x="665" y="137" width="20" height="35" opacity="1" fill="#3AAF60" stroke="none"/>
 <rect x="665" y="114" width="20" height="23" opacity="1" fill="#4ADE80" stroke="none"/>
@@ -131,21 +131,21 @@ ooffice
 <text x="636" y="334" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#7D8590">
 6.2 MB
 </text>
-<rect x="717" y="286" width="19" height="16" opacity="1" fill="#60A5FA" stroke="none"/>
-<rect x="717" y="266" width="19" height="20" opacity="1" fill="#4680C4" stroke="none"/>
+<rect x="717" y="285" width="19" height="17" opacity="1" fill="#60A5FA" stroke="none"/>
+<rect x="717" y="266" width="19" height="19" opacity="1" fill="#4680C4" stroke="none"/>
 <rect x="717" y="261" width="19" height="5" opacity="1" fill="#60A5FA" stroke="none"/>
 <rect x="736" y="279" width="20" height="23" opacity="1" fill="#F87171" stroke="none"/>
 <rect x="736" y="259" width="20" height="20" opacity="1" fill="#C45050" stroke="none"/>
 <rect x="736" y="251" width="20" height="8" opacity="1" fill="#F87171" stroke="none"/>
-<rect x="756" y="274" width="19" height="28" opacity="1" fill="#F59E0B" stroke="none"/>
-<rect x="756" y="255" width="19" height="19" opacity="1" fill="#C47D08" stroke="none"/>
-<rect x="756" y="249" width="19" height="6" opacity="1" fill="#F59E0B" stroke="none"/>
-<rect x="775" y="271" width="19" height="31" opacity="1" fill="#F472B6" stroke="none"/>
-<rect x="775" y="250" width="19" height="21" opacity="1" fill="#C05A92" stroke="none"/>
-<rect x="775" y="241" width="19" height="9" opacity="1" fill="#F472B6" stroke="none"/>
-<rect x="794" y="212" width="20" height="90" opacity="1" fill="#4ADE80" stroke="none"/>
-<rect x="794" y="189" width="20" height="23" opacity="1" fill="#3AAF60" stroke="none"/>
-<rect x="794" y="173" width="20" height="16" opacity="1" fill="#4ADE80" stroke="none"/>
+<rect x="756" y="270" width="19" height="32" opacity="1" fill="#F472B6" stroke="none"/>
+<rect x="756" y="250" width="19" height="20" opacity="1" fill="#C05A92" stroke="none"/>
+<rect x="756" y="240" width="19" height="10" opacity="1" fill="#F472B6" stroke="none"/>
+<rect x="775" y="274" width="19" height="28" opacity="1" fill="#F59E0B" stroke="none"/>
+<rect x="775" y="254" width="19" height="20" opacity="1" fill="#C47D08" stroke="none"/>
+<rect x="775" y="248" width="19" height="6" opacity="1" fill="#F59E0B" stroke="none"/>
+<rect x="794" y="213" width="20" height="89" opacity="1" fill="#4ADE80" stroke="none"/>
+<rect x="794" y="190" width="20" height="23" opacity="1" fill="#3AAF60" stroke="none"/>
+<rect x="794" y="174" width="20" height="16" opacity="1" fill="#4ADE80" stroke="none"/>
 <text x="765" y="319" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E6EDF3" font-weight="bold">
 osdb
 </text>
@@ -173,17 +173,17 @@ osdb
 <rect x="71" y="572" width="20" height="17" opacity="1" fill="#4680C4" stroke="none"/>
 <rect x="71" y="566" width="20" height="6" opacity="1" fill="#60A5FA" stroke="none"/>
 <rect x="91" y="579" width="19" height="33" opacity="1" fill="#F87171" stroke="none"/>
-<rect x="91" y="561" width="19" height="18" opacity="1" fill="#C45050" stroke="none"/>
-<rect x="91" y="547" width="19" height="14" opacity="1" fill="#F87171" stroke="none"/>
-<rect x="110" y="575" width="19" height="37" opacity="1" fill="#F59E0B" stroke="none"/>
-<rect x="110" y="558" width="19" height="17" opacity="1" fill="#C47D08" stroke="none"/>
-<rect x="110" y="549" width="19" height="9" opacity="1" fill="#F59E0B" stroke="none"/>
-<rect x="129" y="565" width="20" height="47" opacity="1" fill="#F472B6" stroke="none"/>
-<rect x="129" y="546" width="20" height="19" opacity="1" fill="#C05A92" stroke="none"/>
-<rect x="129" y="529" width="20" height="17" opacity="1" fill="#F472B6" stroke="none"/>
-<rect x="149" y="512" width="19" height="100" opacity="1" fill="#4ADE80" stroke="none"/>
-<rect x="149" y="490" width="19" height="22" opacity="1" fill="#3AAF60" stroke="none"/>
-<rect x="149" y="456" width="19" height="34" opacity="1" fill="#4ADE80" stroke="none"/>
+<rect x="91" y="560" width="19" height="19" opacity="1" fill="#C45050" stroke="none"/>
+<rect x="91" y="546" width="19" height="14" opacity="1" fill="#F87171" stroke="none"/>
+<rect x="110" y="565" width="19" height="47" opacity="1" fill="#F472B6" stroke="none"/>
+<rect x="110" y="546" width="19" height="19" opacity="1" fill="#C05A92" stroke="none"/>
+<rect x="110" y="529" width="19" height="17" opacity="1" fill="#F472B6" stroke="none"/>
+<rect x="129" y="575" width="20" height="37" opacity="1" fill="#F59E0B" stroke="none"/>
+<rect x="129" y="558" width="20" height="17" opacity="1" fill="#C47D08" stroke="none"/>
+<rect x="129" y="549" width="20" height="9" opacity="1" fill="#F59E0B" stroke="none"/>
+<rect x="149" y="510" width="19" height="102" opacity="1" fill="#4ADE80" stroke="none"/>
+<rect x="149" y="489" width="19" height="21" opacity="1" fill="#3AAF60" stroke="none"/>
+<rect x="149" y="455" width="19" height="34" opacity="1" fill="#4ADE80" stroke="none"/>
 <text x="120" y="629" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E6EDF3" font-weight="bold">
 reymont
 </text>
@@ -196,15 +196,15 @@ reymont
 <rect x="220" y="592" width="19" height="20" opacity="1" fill="#F87171" stroke="none"/>
 <rect x="220" y="577" width="19" height="15" opacity="1" fill="#C45050" stroke="none"/>
 <rect x="220" y="568" width="19" height="9" opacity="1" fill="#F87171" stroke="none"/>
-<rect x="239" y="589" width="19" height="23" opacity="1" fill="#F59E0B" stroke="none"/>
-<rect x="239" y="576" width="19" height="13" opacity="1" fill="#C47D08" stroke="none"/>
-<rect x="239" y="570" width="19" height="6" opacity="1" fill="#F59E0B" stroke="none"/>
-<rect x="258" y="584" width="20" height="28" opacity="1" fill="#F472B6" stroke="none"/>
-<rect x="258" y="569" width="20" height="15" opacity="1" fill="#C05A92" stroke="none"/>
-<rect x="258" y="559" width="20" height="10" opacity="1" fill="#F472B6" stroke="none"/>
-<rect x="278" y="525" width="19" height="87" opacity="1" fill="#4ADE80" stroke="none"/>
-<rect x="278" y="508" width="19" height="17" opacity="1" fill="#3AAF60" stroke="none"/>
-<rect x="278" y="486" width="19" height="22" opacity="1" fill="#4ADE80" stroke="none"/>
+<rect x="239" y="584" width="19" height="28" opacity="1" fill="#F472B6" stroke="none"/>
+<rect x="239" y="569" width="19" height="15" opacity="1" fill="#C05A92" stroke="none"/>
+<rect x="239" y="559" width="19" height="10" opacity="1" fill="#F472B6" stroke="none"/>
+<rect x="258" y="589" width="20" height="23" opacity="1" fill="#F59E0B" stroke="none"/>
+<rect x="258" y="576" width="20" height="13" opacity="1" fill="#C47D08" stroke="none"/>
+<rect x="258" y="570" width="20" height="6" opacity="1" fill="#F59E0B" stroke="none"/>
+<rect x="278" y="526" width="19" height="86" opacity="1" fill="#4ADE80" stroke="none"/>
+<rect x="278" y="509" width="19" height="17" opacity="1" fill="#3AAF60" stroke="none"/>
+<rect x="278" y="487" width="19" height="22" opacity="1" fill="#4ADE80" stroke="none"/>
 <text x="249" y="629" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E6EDF3" font-weight="bold">
 samba
 </text>
@@ -217,15 +217,15 @@ samba
 <rect x="349" y="590" width="19" height="22" opacity="1" fill="#F87171" stroke="none"/>
 <rect x="349" y="545" width="19" height="45" opacity="1" fill="#C45050" stroke="none"/>
 <rect x="349" y="538" width="19" height="7" opacity="1" fill="#F87171" stroke="none"/>
-<rect x="368" y="575" width="20" height="37" opacity="1" fill="#F59E0B" stroke="none"/>
-<rect x="368" y="530" width="20" height="45" opacity="1" fill="#C47D08" stroke="none"/>
-<rect x="368" y="522" width="20" height="8" opacity="1" fill="#F59E0B" stroke="none"/>
-<rect x="388" y="582" width="19" height="30" opacity="1" fill="#F472B6" stroke="none"/>
-<rect x="388" y="536" width="19" height="46" opacity="1" fill="#C05A92" stroke="none"/>
-<rect x="388" y="528" width="19" height="8" opacity="1" fill="#F472B6" stroke="none"/>
-<rect x="407" y="462" width="19" height="150" opacity="1" fill="#4ADE80" stroke="none"/>
-<rect x="407" y="418" width="19" height="44" opacity="1" fill="#3AAF60" stroke="none"/>
-<rect x="407" y="399" width="19" height="19" opacity="1" fill="#4ADE80" stroke="none"/>
+<rect x="368" y="581" width="20" height="31" opacity="1" fill="#F472B6" stroke="none"/>
+<rect x="368" y="536" width="20" height="45" opacity="1" fill="#C05A92" stroke="none"/>
+<rect x="368" y="528" width="20" height="8" opacity="1" fill="#F472B6" stroke="none"/>
+<rect x="388" y="575" width="19" height="37" opacity="1" fill="#F59E0B" stroke="none"/>
+<rect x="388" y="529" width="19" height="46" opacity="1" fill="#C47D08" stroke="none"/>
+<rect x="388" y="521" width="19" height="8" opacity="1" fill="#F59E0B" stroke="none"/>
+<rect x="407" y="460" width="19" height="152" opacity="1" fill="#4ADE80" stroke="none"/>
+<rect x="407" y="416" width="19" height="44" opacity="1" fill="#3AAF60" stroke="none"/>
+<rect x="407" y="398" width="19" height="18" opacity="1" fill="#4ADE80" stroke="none"/>
 <text x="378" y="629" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E6EDF3" font-weight="bold">
 sao
 </text>
@@ -235,18 +235,18 @@ sao
 <rect x="459" y="591" width="19" height="21" opacity="1" fill="#60A5FA" stroke="none"/>
 <rect x="459" y="574" width="19" height="17" opacity="1" fill="#4680C4" stroke="none"/>
 <rect x="459" y="569" width="19" height="5" opacity="1" fill="#60A5FA" stroke="none"/>
-<rect x="478" y="578" width="19" height="34" opacity="1" fill="#F87171" stroke="none"/>
-<rect x="478" y="559" width="19" height="19" opacity="1" fill="#C45050" stroke="none"/>
-<rect x="478" y="546" width="19" height="13" opacity="1" fill="#F87171" stroke="none"/>
-<rect x="497" y="579" width="20" height="33" opacity="1" fill="#F59E0B" stroke="none"/>
-<rect x="497" y="562" width="20" height="17" opacity="1" fill="#C47D08" stroke="none"/>
-<rect x="497" y="554" width="20" height="8" opacity="1" fill="#F59E0B" stroke="none"/>
-<rect x="517" y="565" width="19" height="47" opacity="1" fill="#F472B6" stroke="none"/>
-<rect x="517" y="546" width="19" height="19" opacity="1" fill="#C05A92" stroke="none"/>
-<rect x="517" y="529" width="19" height="17" opacity="1" fill="#F472B6" stroke="none"/>
-<rect x="536" y="506" width="20" height="106" opacity="1" fill="#4ADE80" stroke="none"/>
-<rect x="536" y="485" width="20" height="21" opacity="1" fill="#3AAF60" stroke="none"/>
-<rect x="536" y="453" width="20" height="32" opacity="1" fill="#4ADE80" stroke="none"/>
+<rect x="478" y="577" width="19" height="35" opacity="1" fill="#F87171" stroke="none"/>
+<rect x="478" y="558" width="19" height="19" opacity="1" fill="#C45050" stroke="none"/>
+<rect x="478" y="545" width="19" height="13" opacity="1" fill="#F87171" stroke="none"/>
+<rect x="497" y="565" width="20" height="47" opacity="1" fill="#F472B6" stroke="none"/>
+<rect x="497" y="546" width="20" height="19" opacity="1" fill="#C05A92" stroke="none"/>
+<rect x="497" y="529" width="20" height="17" opacity="1" fill="#F472B6" stroke="none"/>
+<rect x="517" y="579" width="19" height="33" opacity="1" fill="#F59E0B" stroke="none"/>
+<rect x="517" y="561" width="19" height="18" opacity="1" fill="#C47D08" stroke="none"/>
+<rect x="517" y="550" width="19" height="11" opacity="1" fill="#F59E0B" stroke="none"/>
+<rect x="536" y="507" width="20" height="105" opacity="1" fill="#4ADE80" stroke="none"/>
+<rect x="536" y="486" width="20" height="21" opacity="1" fill="#3AAF60" stroke="none"/>
+<rect x="536" y="454" width="20" height="32" opacity="1" fill="#4ADE80" stroke="none"/>
 <text x="507" y="629" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E6EDF3" font-weight="bold">
 webster
 </text>
@@ -254,17 +254,17 @@ webster
 41.5 MB
 </text>
 <rect x="588" y="603" width="19" height="9" opacity="1" fill="#60A5FA" stroke="none"/>
-<rect x="588" y="562" width="19" height="41" opacity="1" fill="#4680C4" stroke="none"/>
-<rect x="588" y="557" width="19" height="5" opacity="1" fill="#60A5FA" stroke="none"/>
-<rect x="607" y="585" width="20" height="27" opacity="1" fill="#F87171" stroke="none"/>
-<rect x="607" y="538" width="20" height="47" opacity="1" fill="#C45050" stroke="none"/>
-<rect x="607" y="530" width="20" height="8" opacity="1" fill="#F87171" stroke="none"/>
-<rect x="627" y="589" width="19" height="23" opacity="1" fill="#F59E0B" stroke="none"/>
-<rect x="627" y="547" width="19" height="42" opacity="1" fill="#C47D08" stroke="none"/>
-<rect x="627" y="540" width="19" height="7" opacity="1" fill="#F59E0B" stroke="none"/>
-<rect x="646" y="574" width="19" height="38" opacity="1" fill="#F472B6" stroke="none"/>
-<rect x="646" y="527" width="19" height="47" opacity="1" fill="#C05A92" stroke="none"/>
-<rect x="646" y="518" width="19" height="9" opacity="1" fill="#F472B6" stroke="none"/>
+<rect x="588" y="561" width="19" height="42" opacity="1" fill="#4680C4" stroke="none"/>
+<rect x="588" y="557" width="19" height="4" opacity="1" fill="#60A5FA" stroke="none"/>
+<rect x="607" y="588" width="20" height="24" opacity="1" fill="#F87171" stroke="none"/>
+<rect x="607" y="541" width="20" height="47" opacity="1" fill="#C45050" stroke="none"/>
+<rect x="607" y="534" width="20" height="7" opacity="1" fill="#F87171" stroke="none"/>
+<rect x="627" y="579" width="19" height="33" opacity="1" fill="#F472B6" stroke="none"/>
+<rect x="627" y="532" width="19" height="47" opacity="1" fill="#C05A92" stroke="none"/>
+<rect x="627" y="523" width="19" height="9" opacity="1" fill="#F472B6" stroke="none"/>
+<rect x="646" y="588" width="19" height="24" opacity="1" fill="#F59E0B" stroke="none"/>
+<rect x="646" y="546" width="19" height="42" opacity="1" fill="#C47D08" stroke="none"/>
+<rect x="646" y="540" width="19" height="6" opacity="1" fill="#F59E0B" stroke="none"/>
 <rect x="665" y="458" width="20" height="154" opacity="1" fill="#4ADE80" stroke="none"/>
 <rect x="665" y="412" width="20" height="46" opacity="1" fill="#3AAF60" stroke="none"/>
 <rect x="665" y="394" width="20" height="18" opacity="1" fill="#4ADE80" stroke="none"/>
@@ -280,15 +280,15 @@ x-ray
 <rect x="736" y="596" width="20" height="16" opacity="1" fill="#F87171" stroke="none"/>
 <rect x="736" y="588" width="20" height="8" opacity="1" fill="#C45050" stroke="none"/>
 <rect x="736" y="581" width="20" height="7" opacity="1" fill="#F87171" stroke="none"/>
-<rect x="756" y="594" width="19" height="18" opacity="1" fill="#F59E0B" stroke="none"/>
-<rect x="756" y="588" width="19" height="6" opacity="1" fill="#C47D08" stroke="none"/>
-<rect x="756" y="583" width="19" height="5" opacity="1" fill="#F59E0B" stroke="none"/>
-<rect x="775" y="591" width="19" height="21" opacity="1" fill="#F472B6" stroke="none"/>
-<rect x="775" y="583" width="19" height="8" opacity="1" fill="#C05A92" stroke="none"/>
-<rect x="775" y="574" width="19" height="9" opacity="1" fill="#F472B6" stroke="none"/>
-<rect x="794" y="544" width="20" height="68" opacity="1" fill="#4ADE80" stroke="none"/>
-<rect x="794" y="532" width="20" height="12" opacity="1" fill="#3AAF60" stroke="none"/>
-<rect x="794" y="513" width="20" height="19" opacity="1" fill="#4ADE80" stroke="none"/>
+<rect x="756" y="591" width="19" height="21" opacity="1" fill="#F472B6" stroke="none"/>
+<rect x="756" y="582" width="19" height="9" opacity="1" fill="#C05A92" stroke="none"/>
+<rect x="756" y="574" width="19" height="8" opacity="1" fill="#F472B6" stroke="none"/>
+<rect x="775" y="594" width="19" height="18" opacity="1" fill="#F59E0B" stroke="none"/>
+<rect x="775" y="588" width="19" height="6" opacity="1" fill="#C47D08" stroke="none"/>
+<rect x="775" y="583" width="19" height="5" opacity="1" fill="#F59E0B" stroke="none"/>
+<rect x="794" y="543" width="20" height="69" opacity="1" fill="#4ADE80" stroke="none"/>
+<rect x="794" y="531" width="20" height="12" opacity="1" fill="#3AAF60" stroke="none"/>
+<rect x="794" y="513" width="20" height="18" opacity="1" fill="#4ADE80" stroke="none"/>
 <text x="765" y="629" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E6EDF3" font-weight="bold">
 xml
 </text>
@@ -303,13 +303,13 @@ libzstd v1.5.7 (C)
 <text x="208" y="694" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E6EDF3">
 zrip (safe SIMD + encapsulated unsafe)
 </text>
-<rect x="190" y="708" width="12" height="12" opacity="1" fill="#F59E0B" stroke="none"/>
+<rect x="190" y="708" width="12" height="12" opacity="1" fill="#F472B6" stroke="none"/>
 <text x="208" y="714" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E6EDF3">
-structured-zstd v0.0.49 (unsafe)
-</text>
-<rect x="460" y="668" width="12" height="12" opacity="1" fill="#F472B6" stroke="none"/>
-<text x="478" y="674" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E6EDF3">
 zrip paranoid (safe SIMD, no unsafe)
+</text>
+<rect x="460" y="668" width="12" height="12" opacity="1" fill="#F59E0B" stroke="none"/>
+<text x="478" y="674" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E6EDF3">
+structured-zstd v0.0.49 (unsafe)
 </text>
 <rect x="460" y="688" width="12" height="12" opacity="1" fill="#4ADE80" stroke="none"/>
 <text x="478" y="694" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E6EDF3">

--- a/doc/charts/x86_64/scatter.svg
+++ b/doc/charts/x86_64/scatter.svg
@@ -4,7 +4,7 @@
 12-file Silesia: Encode Speed vs Compression Ratio
 </text>
 <text x="425" y="36" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#7D8590">
-Linux VM on a 2018 Mac Mini, Intel Core i7-8700B @ 3.20GHz, performance governor, turbo off
+Linux VM on a 2018 Mac Mini, Intel Core i7-8700B @ 3.20GHz, 12 cores, performance governor, turbo off
 </text>
 <rect x="70" y="66" width="760" height="250" opacity="1" fill="#161B22" stroke="none"/>
 <text x="450" y="53" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="10.483870967741936" opacity="1" fill="#E6EDF3" font-weight="bold">
@@ -67,110 +67,110 @@ High compressibility
 8.00x
 </text>
 <polyline fill="none" opacity="1" stroke="#30363D" stroke-width="2" points="70,316 830,316 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="470,259 464,248 461,237 455,221 452,201 446,181 441,165 434,107 421,101 397,85 403,84 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="470,259 465,248 461,237 456,221 452,201 447,181 442,165 435,107 422,101 402,85 402,84 "/>
 <circle cx="470" cy="259" r="3" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
 <text x="476" y="259" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="7.258064516129032" opacity="1" fill="#60A5FA" font-weight="bold">
 L-7
 </text>
-<circle cx="464" cy="248" r="3" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
+<circle cx="465" cy="248" r="3" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
 <circle cx="461" cy="237" r="3" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
-<circle cx="455" cy="221" r="3" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
+<circle cx="456" cy="221" r="3" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
 <circle cx="452" cy="201" r="3" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
-<circle cx="446" cy="181" r="3" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
-<circle cx="441" cy="165" r="3" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
-<text x="447" y="165" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="7.258064516129032" opacity="1" fill="#60A5FA" font-weight="bold">
+<circle cx="447" cy="181" r="3" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
+<circle cx="442" cy="165" r="3" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
+<text x="448" y="165" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="7.258064516129032" opacity="1" fill="#60A5FA" font-weight="bold">
 L-1
 </text>
-<circle cx="434" cy="107" r="3" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
-<text x="440" y="107" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="7.258064516129032" opacity="1" fill="#60A5FA" font-weight="bold">
+<circle cx="435" cy="107" r="3" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
+<text x="441" y="107" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="7.258064516129032" opacity="1" fill="#60A5FA" font-weight="bold">
 L1
 </text>
-<circle cx="421" cy="101" r="3" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
-<circle cx="397" cy="85" r="3" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
-<text x="403" y="85" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="7.258064516129032" opacity="1" fill="#60A5FA" font-weight="bold">
+<circle cx="422" cy="101" r="3" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
+<circle cx="402" cy="85" r="3" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
+<text x="408" y="85" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="7.258064516129032" opacity="1" fill="#60A5FA" font-weight="bold">
 L3
 </text>
-<circle cx="403" cy="84" r="3" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
-<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="1" points="426,273 410,264 407,247 404,235 402,225 397,209 393,188 390,166 382,152 382,145 365,123 355,117 "/>
-<circle cx="426" cy="273" r="3" opacity="1" fill="#F87171" stroke="none" stroke-width="1"/>
-<text x="432" y="273" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="7.258064516129032" opacity="1" fill="#F87171" font-weight="bold">
+<circle cx="402" cy="84" r="3" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
+<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="1" points="425,273 411,264 408,247 405,235 403,225 398,209 394,188 391,166 383,153 385,145 366,123 360,117 "/>
+<circle cx="425" cy="273" r="3" opacity="1" fill="#F87171" stroke="none" stroke-width="1"/>
+<text x="431" y="273" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="7.258064516129032" opacity="1" fill="#F87171" font-weight="bold">
 L-8
 </text>
-<circle cx="410" cy="264" r="3" opacity="1" fill="#F87171" stroke="none" stroke-width="1"/>
-<circle cx="407" cy="247" r="3" opacity="1" fill="#F87171" stroke="none" stroke-width="1"/>
-<circle cx="404" cy="235" r="3" opacity="1" fill="#F87171" stroke="none" stroke-width="1"/>
-<circle cx="402" cy="225" r="3" opacity="1" fill="#F87171" stroke="none" stroke-width="1"/>
-<circle cx="397" cy="209" r="3" opacity="1" fill="#F87171" stroke="none" stroke-width="1"/>
-<circle cx="393" cy="188" r="3" opacity="1" fill="#F87171" stroke="none" stroke-width="1"/>
-<circle cx="390" cy="166" r="3" opacity="1" fill="#F87171" stroke="none" stroke-width="1"/>
-<text x="396" y="166" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="7.258064516129032" opacity="1" fill="#F87171" font-weight="bold">
+<circle cx="411" cy="264" r="3" opacity="1" fill="#F87171" stroke="none" stroke-width="1"/>
+<circle cx="408" cy="247" r="3" opacity="1" fill="#F87171" stroke="none" stroke-width="1"/>
+<circle cx="405" cy="235" r="3" opacity="1" fill="#F87171" stroke="none" stroke-width="1"/>
+<circle cx="403" cy="225" r="3" opacity="1" fill="#F87171" stroke="none" stroke-width="1"/>
+<circle cx="398" cy="209" r="3" opacity="1" fill="#F87171" stroke="none" stroke-width="1"/>
+<circle cx="394" cy="188" r="3" opacity="1" fill="#F87171" stroke="none" stroke-width="1"/>
+<circle cx="391" cy="166" r="3" opacity="1" fill="#F87171" stroke="none" stroke-width="1"/>
+<text x="397" y="166" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="7.258064516129032" opacity="1" fill="#F87171" font-weight="bold">
 L-1
 </text>
-<circle cx="382" cy="152" r="3" opacity="1" fill="#F87171" stroke="none" stroke-width="1"/>
-<text x="388" y="152" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="7.258064516129032" opacity="1" fill="#F87171" font-weight="bold">
+<circle cx="383" cy="153" r="3" opacity="1" fill="#F87171" stroke="none" stroke-width="1"/>
+<text x="389" y="153" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="7.258064516129032" opacity="1" fill="#F87171" font-weight="bold">
 L1
 </text>
-<circle cx="382" cy="145" r="3" opacity="1" fill="#F87171" stroke="none" stroke-width="1"/>
-<circle cx="365" cy="123" r="3" opacity="1" fill="#F87171" stroke="none" stroke-width="1"/>
-<text x="371" y="123" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="7.258064516129032" opacity="1" fill="#F87171" font-weight="bold">
+<circle cx="385" cy="145" r="3" opacity="1" fill="#F87171" stroke="none" stroke-width="1"/>
+<circle cx="366" cy="123" r="3" opacity="1" fill="#F87171" stroke="none" stroke-width="1"/>
+<text x="372" y="123" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="7.258064516129032" opacity="1" fill="#F87171" font-weight="bold">
 L3
 </text>
-<circle cx="355" cy="117" r="3" opacity="1" fill="#F87171" stroke="none" stroke-width="1"/>
-<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="1" points="392,259 388,248 385,237 381,221 376,201 373,181 367,166 363,107 351,101 307,85 307,84 "/>
-<circle cx="392" cy="259" r="3" opacity="1" fill="#F59E0B" stroke="none" stroke-width="1"/>
-<text x="398" y="259" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="7.258064516129032" opacity="1" fill="#F59E0B" font-weight="bold">
+<circle cx="360" cy="117" r="3" opacity="1" fill="#F87171" stroke="none" stroke-width="1"/>
+<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="1" points="391,259 387,248 384,237 380,221 376,201 372,181 367,166 362,107 351,101 304,85 304,84 "/>
+<circle cx="391" cy="259" r="3" opacity="1" fill="#F59E0B" stroke="none" stroke-width="1"/>
+<text x="397" y="259" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="7.258064516129032" opacity="1" fill="#F59E0B" font-weight="bold">
 L-7
 </text>
-<circle cx="388" cy="248" r="3" opacity="1" fill="#F59E0B" stroke="none" stroke-width="1"/>
-<circle cx="385" cy="237" r="3" opacity="1" fill="#F59E0B" stroke="none" stroke-width="1"/>
-<circle cx="381" cy="221" r="3" opacity="1" fill="#F59E0B" stroke="none" stroke-width="1"/>
+<circle cx="387" cy="248" r="3" opacity="1" fill="#F59E0B" stroke="none" stroke-width="1"/>
+<circle cx="384" cy="237" r="3" opacity="1" fill="#F59E0B" stroke="none" stroke-width="1"/>
+<circle cx="380" cy="221" r="3" opacity="1" fill="#F59E0B" stroke="none" stroke-width="1"/>
 <circle cx="376" cy="201" r="3" opacity="1" fill="#F59E0B" stroke="none" stroke-width="1"/>
-<circle cx="373" cy="181" r="3" opacity="1" fill="#F59E0B" stroke="none" stroke-width="1"/>
+<circle cx="372" cy="181" r="3" opacity="1" fill="#F59E0B" stroke="none" stroke-width="1"/>
 <circle cx="367" cy="166" r="3" opacity="1" fill="#F59E0B" stroke="none" stroke-width="1"/>
 <text x="373" y="166" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="7.258064516129032" opacity="1" fill="#F59E0B" font-weight="bold">
 L-1
 </text>
-<circle cx="363" cy="107" r="3" opacity="1" fill="#F59E0B" stroke="none" stroke-width="1"/>
-<text x="369" y="107" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="7.258064516129032" opacity="1" fill="#F59E0B" font-weight="bold">
+<circle cx="362" cy="107" r="3" opacity="1" fill="#F59E0B" stroke="none" stroke-width="1"/>
+<text x="368" y="107" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="7.258064516129032" opacity="1" fill="#F59E0B" font-weight="bold">
 L1
 </text>
 <circle cx="351" cy="101" r="3" opacity="1" fill="#F59E0B" stroke="none" stroke-width="1"/>
-<circle cx="307" cy="85" r="3" opacity="1" fill="#F59E0B" stroke="none" stroke-width="1"/>
-<text x="313" y="85" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="7.258064516129032" opacity="1" fill="#F59E0B" font-weight="bold">
+<circle cx="304" cy="85" r="3" opacity="1" fill="#F59E0B" stroke="none" stroke-width="1"/>
+<text x="310" y="85" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="7.258064516129032" opacity="1" fill="#F59E0B" font-weight="bold">
 L3
 </text>
-<circle cx="307" cy="84" r="3" opacity="1" fill="#F59E0B" stroke="none" stroke-width="1"/>
-<polyline fill="none" opacity="1" stroke="#F472B6" stroke-width="1" points="382,273 371,264 367,247 364,235 362,225 357,209 354,188 351,166 341,152 340,145 324,123 321,117 "/>
-<circle cx="382" cy="273" r="3" opacity="1" fill="#F472B6" stroke="none" stroke-width="1"/>
-<text x="388" y="273" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="7.258064516129032" opacity="1" fill="#F472B6" font-weight="bold">
+<circle cx="304" cy="84" r="3" opacity="1" fill="#F59E0B" stroke="none" stroke-width="1"/>
+<polyline fill="none" opacity="1" stroke="#F472B6" stroke-width="1" points="381,273 369,264 365,247 361,235 359,225 355,209 352,188 349,166 341,153 341,145 323,123 319,117 "/>
+<circle cx="381" cy="273" r="3" opacity="1" fill="#F472B6" stroke="none" stroke-width="1"/>
+<text x="387" y="273" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="7.258064516129032" opacity="1" fill="#F472B6" font-weight="bold">
 L-8
 </text>
-<circle cx="371" cy="264" r="3" opacity="1" fill="#F472B6" stroke="none" stroke-width="1"/>
-<circle cx="367" cy="247" r="3" opacity="1" fill="#F472B6" stroke="none" stroke-width="1"/>
-<circle cx="364" cy="235" r="3" opacity="1" fill="#F472B6" stroke="none" stroke-width="1"/>
-<circle cx="362" cy="225" r="3" opacity="1" fill="#F472B6" stroke="none" stroke-width="1"/>
-<circle cx="357" cy="209" r="3" opacity="1" fill="#F472B6" stroke="none" stroke-width="1"/>
-<circle cx="354" cy="188" r="3" opacity="1" fill="#F472B6" stroke="none" stroke-width="1"/>
-<circle cx="351" cy="166" r="3" opacity="1" fill="#F472B6" stroke="none" stroke-width="1"/>
-<text x="357" y="166" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="7.258064516129032" opacity="1" fill="#F472B6" font-weight="bold">
+<circle cx="369" cy="264" r="3" opacity="1" fill="#F472B6" stroke="none" stroke-width="1"/>
+<circle cx="365" cy="247" r="3" opacity="1" fill="#F472B6" stroke="none" stroke-width="1"/>
+<circle cx="361" cy="235" r="3" opacity="1" fill="#F472B6" stroke="none" stroke-width="1"/>
+<circle cx="359" cy="225" r="3" opacity="1" fill="#F472B6" stroke="none" stroke-width="1"/>
+<circle cx="355" cy="209" r="3" opacity="1" fill="#F472B6" stroke="none" stroke-width="1"/>
+<circle cx="352" cy="188" r="3" opacity="1" fill="#F472B6" stroke="none" stroke-width="1"/>
+<circle cx="349" cy="166" r="3" opacity="1" fill="#F472B6" stroke="none" stroke-width="1"/>
+<text x="355" y="166" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="7.258064516129032" opacity="1" fill="#F472B6" font-weight="bold">
 L-1
 </text>
-<circle cx="341" cy="152" r="3" opacity="1" fill="#F472B6" stroke="none" stroke-width="1"/>
-<text x="347" y="152" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="7.258064516129032" opacity="1" fill="#F472B6" font-weight="bold">
+<circle cx="341" cy="153" r="3" opacity="1" fill="#F472B6" stroke="none" stroke-width="1"/>
+<text x="347" y="153" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="7.258064516129032" opacity="1" fill="#F472B6" font-weight="bold">
 L1
 </text>
-<circle cx="340" cy="145" r="3" opacity="1" fill="#F472B6" stroke="none" stroke-width="1"/>
-<circle cx="324" cy="123" r="3" opacity="1" fill="#F472B6" stroke="none" stroke-width="1"/>
-<text x="330" y="123" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="7.258064516129032" opacity="1" fill="#F472B6" font-weight="bold">
+<circle cx="341" cy="145" r="3" opacity="1" fill="#F472B6" stroke="none" stroke-width="1"/>
+<circle cx="323" cy="123" r="3" opacity="1" fill="#F472B6" stroke="none" stroke-width="1"/>
+<text x="329" y="123" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="7.258064516129032" opacity="1" fill="#F472B6" font-weight="bold">
 L3
 </text>
-<circle cx="321" cy="117" r="3" opacity="1" fill="#F472B6" stroke="none" stroke-width="1"/>
+<circle cx="319" cy="117" r="3" opacity="1" fill="#F472B6" stroke="none" stroke-width="1"/>
 <circle cx="190" cy="227" r="3" opacity="1" fill="#4ADE80" stroke="none" stroke-width="1"/>
 <text x="196" y="227" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="7.258064516129032" opacity="1" fill="#4ADE80" font-weight="bold">
 L1
 </text>
-<circle cx="472" cy="249" r="3" opacity="1" fill="#C084FC" stroke="none" stroke-width="1"/>
-<text x="478" y="249" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="7.258064516129032" opacity="1" fill="#C084FC" font-weight="bold">
+<circle cx="470" cy="249" r="3" opacity="1" fill="#C084FC" stroke="none" stroke-width="1"/>
+<text x="476" y="249" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="7.258064516129032" opacity="1" fill="#C084FC" font-weight="bold">
 LZ4
 </text>
 <text x="450" y="350" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#7D8590">
@@ -229,33 +229,33 @@ Medium compressibility
 3.00x
 </text>
 <polyline fill="none" opacity="1" stroke="#30363D" stroke-width="2" points="70,651 830,651 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="415,606 409,602 403,594 396,585 388,575 379,564 366,552 356,492 329,468 285,452 290,446 "/>
-<circle cx="415" cy="606" r="3" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
-<text x="421" y="606" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="7.258064516129032" opacity="1" fill="#60A5FA" font-weight="bold">
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="414,606 409,602 403,594 395,585 388,575 378,564 366,552 355,492 327,468 288,452 288,446 "/>
+<circle cx="414" cy="606" r="3" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
+<text x="420" y="606" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="7.258064516129032" opacity="1" fill="#60A5FA" font-weight="bold">
 L-7
 </text>
 <circle cx="409" cy="602" r="3" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
 <circle cx="403" cy="594" r="3" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
-<circle cx="396" cy="585" r="3" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
+<circle cx="395" cy="585" r="3" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
 <circle cx="388" cy="575" r="3" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
-<circle cx="379" cy="564" r="3" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
+<circle cx="378" cy="564" r="3" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
 <circle cx="366" cy="552" r="3" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
 <text x="372" y="552" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="7.258064516129032" opacity="1" fill="#60A5FA" font-weight="bold">
 L-1
 </text>
-<circle cx="356" cy="492" r="3" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
-<text x="362" y="492" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="7.258064516129032" opacity="1" fill="#60A5FA" font-weight="bold">
+<circle cx="355" cy="492" r="3" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
+<text x="361" y="492" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="7.258064516129032" opacity="1" fill="#60A5FA" font-weight="bold">
 L1
 </text>
-<circle cx="329" cy="468" r="3" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
-<circle cx="285" cy="452" r="3" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
-<text x="291" y="452" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="7.258064516129032" opacity="1" fill="#60A5FA" font-weight="bold">
+<circle cx="327" cy="468" r="3" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
+<circle cx="288" cy="452" r="3" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
+<text x="294" y="452" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="7.258064516129032" opacity="1" fill="#60A5FA" font-weight="bold">
 L3
 </text>
-<circle cx="290" cy="446" r="3" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
-<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="1" points="356,609 341,581 333,571 330,567 326,559 321,548 316,539 310,528 294,511 277,495 254,488 233,479 "/>
-<circle cx="356" cy="609" r="3" opacity="1" fill="#F87171" stroke="none" stroke-width="1"/>
-<text x="362" y="609" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="7.258064516129032" opacity="1" fill="#F87171" font-weight="bold">
+<circle cx="288" cy="446" r="3" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
+<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="1" points="355,609 341,581 333,571 330,567 326,559 321,548 316,539 310,528 293,512 279,497 254,490 235,481 "/>
+<circle cx="355" cy="609" r="3" opacity="1" fill="#F87171" stroke="none" stroke-width="1"/>
+<text x="361" y="609" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="7.258064516129032" opacity="1" fill="#F87171" font-weight="bold">
 L-8
 </text>
 <circle cx="341" cy="581" r="3" opacity="1" fill="#F87171" stroke="none" stroke-width="1"/>
@@ -268,71 +268,71 @@ L-8
 <text x="316" y="528" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="7.258064516129032" opacity="1" fill="#F87171" font-weight="bold">
 L-1
 </text>
-<circle cx="294" cy="511" r="3" opacity="1" fill="#F87171" stroke="none" stroke-width="1"/>
-<text x="300" y="511" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="7.258064516129032" opacity="1" fill="#F87171" font-weight="bold">
+<circle cx="293" cy="512" r="3" opacity="1" fill="#F87171" stroke="none" stroke-width="1"/>
+<text x="299" y="512" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="7.258064516129032" opacity="1" fill="#F87171" font-weight="bold">
 L1
 </text>
-<circle cx="277" cy="495" r="3" opacity="1" fill="#F87171" stroke="none" stroke-width="1"/>
-<circle cx="254" cy="488" r="3" opacity="1" fill="#F87171" stroke="none" stroke-width="1"/>
-<text x="260" y="488" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="7.258064516129032" opacity="1" fill="#F87171" font-weight="bold">
+<circle cx="279" cy="497" r="3" opacity="1" fill="#F87171" stroke="none" stroke-width="1"/>
+<circle cx="254" cy="490" r="3" opacity="1" fill="#F87171" stroke="none" stroke-width="1"/>
+<text x="260" y="490" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="7.258064516129032" opacity="1" fill="#F87171" font-weight="bold">
 L3
 </text>
-<circle cx="233" cy="479" r="3" opacity="1" fill="#F87171" stroke="none" stroke-width="1"/>
-<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="1" points="347,606 344,602 337,594 331,585 323,575 315,564 304,553 288,492 265,468 204,454 203,447 "/>
-<circle cx="347" cy="606" r="3" opacity="1" fill="#F59E0B" stroke="none" stroke-width="1"/>
-<text x="353" y="606" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="7.258064516129032" opacity="1" fill="#F59E0B" font-weight="bold">
+<circle cx="235" cy="481" r="3" opacity="1" fill="#F87171" stroke="none" stroke-width="1"/>
+<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="1" points="345,606 342,602 335,594 329,585 321,575 313,564 303,553 287,492 262,468 200,454 196,447 "/>
+<circle cx="345" cy="606" r="3" opacity="1" fill="#F59E0B" stroke="none" stroke-width="1"/>
+<text x="351" y="606" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="7.258064516129032" opacity="1" fill="#F59E0B" font-weight="bold">
 L-7
 </text>
-<circle cx="344" cy="602" r="3" opacity="1" fill="#F59E0B" stroke="none" stroke-width="1"/>
-<circle cx="337" cy="594" r="3" opacity="1" fill="#F59E0B" stroke="none" stroke-width="1"/>
-<circle cx="331" cy="585" r="3" opacity="1" fill="#F59E0B" stroke="none" stroke-width="1"/>
-<circle cx="323" cy="575" r="3" opacity="1" fill="#F59E0B" stroke="none" stroke-width="1"/>
-<circle cx="315" cy="564" r="3" opacity="1" fill="#F59E0B" stroke="none" stroke-width="1"/>
-<circle cx="304" cy="553" r="3" opacity="1" fill="#F59E0B" stroke="none" stroke-width="1"/>
-<text x="310" y="553" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="7.258064516129032" opacity="1" fill="#F59E0B" font-weight="bold">
+<circle cx="342" cy="602" r="3" opacity="1" fill="#F59E0B" stroke="none" stroke-width="1"/>
+<circle cx="335" cy="594" r="3" opacity="1" fill="#F59E0B" stroke="none" stroke-width="1"/>
+<circle cx="329" cy="585" r="3" opacity="1" fill="#F59E0B" stroke="none" stroke-width="1"/>
+<circle cx="321" cy="575" r="3" opacity="1" fill="#F59E0B" stroke="none" stroke-width="1"/>
+<circle cx="313" cy="564" r="3" opacity="1" fill="#F59E0B" stroke="none" stroke-width="1"/>
+<circle cx="303" cy="553" r="3" opacity="1" fill="#F59E0B" stroke="none" stroke-width="1"/>
+<text x="309" y="553" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="7.258064516129032" opacity="1" fill="#F59E0B" font-weight="bold">
 L-1
 </text>
-<circle cx="288" cy="492" r="3" opacity="1" fill="#F59E0B" stroke="none" stroke-width="1"/>
-<text x="294" y="492" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="7.258064516129032" opacity="1" fill="#F59E0B" font-weight="bold">
+<circle cx="287" cy="492" r="3" opacity="1" fill="#F59E0B" stroke="none" stroke-width="1"/>
+<text x="293" y="492" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="7.258064516129032" opacity="1" fill="#F59E0B" font-weight="bold">
 L1
 </text>
-<circle cx="265" cy="468" r="3" opacity="1" fill="#F59E0B" stroke="none" stroke-width="1"/>
-<circle cx="204" cy="454" r="3" opacity="1" fill="#F59E0B" stroke="none" stroke-width="1"/>
-<text x="210" y="454" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="7.258064516129032" opacity="1" fill="#F59E0B" font-weight="bold">
+<circle cx="262" cy="468" r="3" opacity="1" fill="#F59E0B" stroke="none" stroke-width="1"/>
+<circle cx="200" cy="454" r="3" opacity="1" fill="#F59E0B" stroke="none" stroke-width="1"/>
+<text x="206" y="454" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="7.258064516129032" opacity="1" fill="#F59E0B" font-weight="bold">
 L3
 </text>
-<circle cx="203" cy="447" r="3" opacity="1" fill="#F59E0B" stroke="none" stroke-width="1"/>
-<polyline fill="none" opacity="1" stroke="#F472B6" stroke-width="1" points="314,609 305,581 297,571 293,567 289,559 283,548 279,539 272,528 250,511 234,495 213,488 204,479 "/>
-<circle cx="314" cy="609" r="3" opacity="1" fill="#F472B6" stroke="none" stroke-width="1"/>
-<text x="320" y="609" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="7.258064516129032" opacity="1" fill="#F472B6" font-weight="bold">
+<circle cx="196" cy="447" r="3" opacity="1" fill="#F59E0B" stroke="none" stroke-width="1"/>
+<polyline fill="none" opacity="1" stroke="#F472B6" stroke-width="1" points="313,609 302,581 294,571 290,567 286,559 280,548 275,539 269,528 250,512 236,497 214,490 201,481 "/>
+<circle cx="313" cy="609" r="3" opacity="1" fill="#F472B6" stroke="none" stroke-width="1"/>
+<text x="319" y="609" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="7.258064516129032" opacity="1" fill="#F472B6" font-weight="bold">
 L-8
 </text>
-<circle cx="305" cy="581" r="3" opacity="1" fill="#F472B6" stroke="none" stroke-width="1"/>
-<circle cx="297" cy="571" r="3" opacity="1" fill="#F472B6" stroke="none" stroke-width="1"/>
-<circle cx="293" cy="567" r="3" opacity="1" fill="#F472B6" stroke="none" stroke-width="1"/>
-<circle cx="289" cy="559" r="3" opacity="1" fill="#F472B6" stroke="none" stroke-width="1"/>
-<circle cx="283" cy="548" r="3" opacity="1" fill="#F472B6" stroke="none" stroke-width="1"/>
-<circle cx="279" cy="539" r="3" opacity="1" fill="#F472B6" stroke="none" stroke-width="1"/>
-<circle cx="272" cy="528" r="3" opacity="1" fill="#F472B6" stroke="none" stroke-width="1"/>
-<text x="278" y="528" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="7.258064516129032" opacity="1" fill="#F472B6" font-weight="bold">
+<circle cx="302" cy="581" r="3" opacity="1" fill="#F472B6" stroke="none" stroke-width="1"/>
+<circle cx="294" cy="571" r="3" opacity="1" fill="#F472B6" stroke="none" stroke-width="1"/>
+<circle cx="290" cy="567" r="3" opacity="1" fill="#F472B6" stroke="none" stroke-width="1"/>
+<circle cx="286" cy="559" r="3" opacity="1" fill="#F472B6" stroke="none" stroke-width="1"/>
+<circle cx="280" cy="548" r="3" opacity="1" fill="#F472B6" stroke="none" stroke-width="1"/>
+<circle cx="275" cy="539" r="3" opacity="1" fill="#F472B6" stroke="none" stroke-width="1"/>
+<circle cx="269" cy="528" r="3" opacity="1" fill="#F472B6" stroke="none" stroke-width="1"/>
+<text x="275" y="528" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="7.258064516129032" opacity="1" fill="#F472B6" font-weight="bold">
 L-1
 </text>
-<circle cx="250" cy="511" r="3" opacity="1" fill="#F472B6" stroke="none" stroke-width="1"/>
-<text x="256" y="511" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="7.258064516129032" opacity="1" fill="#F472B6" font-weight="bold">
+<circle cx="250" cy="512" r="3" opacity="1" fill="#F472B6" stroke="none" stroke-width="1"/>
+<text x="256" y="512" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="7.258064516129032" opacity="1" fill="#F472B6" font-weight="bold">
 L1
 </text>
-<circle cx="234" cy="495" r="3" opacity="1" fill="#F472B6" stroke="none" stroke-width="1"/>
-<circle cx="213" cy="488" r="3" opacity="1" fill="#F472B6" stroke="none" stroke-width="1"/>
-<text x="219" y="488" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="7.258064516129032" opacity="1" fill="#F472B6" font-weight="bold">
+<circle cx="236" cy="497" r="3" opacity="1" fill="#F472B6" stroke="none" stroke-width="1"/>
+<circle cx="214" cy="490" r="3" opacity="1" fill="#F472B6" stroke="none" stroke-width="1"/>
+<text x="220" y="490" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="7.258064516129032" opacity="1" fill="#F472B6" font-weight="bold">
 L3
 </text>
-<circle cx="204" cy="479" r="3" opacity="1" fill="#F472B6" stroke="none" stroke-width="1"/>
+<circle cx="201" cy="481" r="3" opacity="1" fill="#F472B6" stroke="none" stroke-width="1"/>
 <circle cx="135" cy="557" r="3" opacity="1" fill="#4ADE80" stroke="none" stroke-width="1"/>
 <text x="141" y="557" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="7.258064516129032" opacity="1" fill="#4ADE80" font-weight="bold">
 L1
 </text>
-<circle cx="424" cy="619" r="3" opacity="1" fill="#C084FC" stroke="none" stroke-width="1"/>
-<text x="430" y="619" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="7.258064516129032" opacity="1" fill="#C084FC" font-weight="bold">
+<circle cx="423" cy="619" r="3" opacity="1" fill="#C084FC" stroke="none" stroke-width="1"/>
+<text x="429" y="619" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="7.258064516129032" opacity="1" fill="#C084FC" font-weight="bold">
 LZ4
 </text>
 <text x="450" y="685" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#7D8590">
@@ -387,106 +387,106 @@ Low compressibility
 1.40x
 </text>
 <polyline fill="none" opacity="1" stroke="#30363D" stroke-width="2" points="70,986 830,986 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="591,956 580,952 577,953 565,950 552,948 537,946 511,943 405,880 340,857 227,819 223,793 "/>
-<circle cx="591" cy="956" r="3" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
-<text x="597" y="956" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="7.258064516129032" opacity="1" fill="#60A5FA" font-weight="bold">
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="590,956 578,952 575,953 563,950 550,948 535,946 509,943 405,880 337,857 229,819 218,793 "/>
+<circle cx="590" cy="956" r="3" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
+<text x="596" y="956" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="7.258064516129032" opacity="1" fill="#60A5FA" font-weight="bold">
 L-7
 </text>
-<circle cx="580" cy="952" r="3" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
-<circle cx="577" cy="953" r="3" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
-<circle cx="565" cy="950" r="3" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
-<circle cx="552" cy="948" r="3" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
-<circle cx="537" cy="946" r="3" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
-<circle cx="511" cy="943" r="3" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
-<text x="517" y="943" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="7.258064516129032" opacity="1" fill="#60A5FA" font-weight="bold">
+<circle cx="578" cy="952" r="3" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
+<circle cx="575" cy="953" r="3" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
+<circle cx="563" cy="950" r="3" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
+<circle cx="550" cy="948" r="3" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
+<circle cx="535" cy="946" r="3" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
+<circle cx="509" cy="943" r="3" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
+<text x="515" y="943" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="7.258064516129032" opacity="1" fill="#60A5FA" font-weight="bold">
 L-1
 </text>
 <circle cx="405" cy="880" r="3" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
 <text x="411" y="880" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="7.258064516129032" opacity="1" fill="#60A5FA" font-weight="bold">
 L1
 </text>
-<circle cx="340" cy="857" r="3" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
-<circle cx="227" cy="819" r="3" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
-<text x="233" y="819" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="7.258064516129032" opacity="1" fill="#60A5FA" font-weight="bold">
+<circle cx="337" cy="857" r="3" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
+<circle cx="229" cy="819" r="3" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
+<text x="235" y="819" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="7.258064516129032" opacity="1" fill="#60A5FA" font-weight="bold">
 L3
 </text>
-<circle cx="223" cy="793" r="3" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
-<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="1" points="633,964 579,961 534,954 520,950 502,948 483,946 439,942 410,936 328,909 262,868 240,858 198,834 "/>
-<circle cx="633" cy="964" r="3" opacity="1" fill="#F87171" stroke="none" stroke-width="1"/>
-<text x="639" y="964" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="7.258064516129032" opacity="1" fill="#F87171" font-weight="bold">
+<circle cx="218" cy="793" r="3" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
+<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="1" points="628,964 578,961 533,954 519,950 501,948 482,946 439,942 410,936 336,910 290,891 254,873 214,854 "/>
+<circle cx="628" cy="964" r="3" opacity="1" fill="#F87171" stroke="none" stroke-width="1"/>
+<text x="634" y="964" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="7.258064516129032" opacity="1" fill="#F87171" font-weight="bold">
 L-8
 </text>
-<circle cx="579" cy="961" r="3" opacity="1" fill="#F87171" stroke="none" stroke-width="1"/>
-<circle cx="534" cy="954" r="3" opacity="1" fill="#F87171" stroke="none" stroke-width="1"/>
-<circle cx="520" cy="950" r="3" opacity="1" fill="#F87171" stroke="none" stroke-width="1"/>
-<circle cx="502" cy="948" r="3" opacity="1" fill="#F87171" stroke="none" stroke-width="1"/>
-<circle cx="483" cy="946" r="3" opacity="1" fill="#F87171" stroke="none" stroke-width="1"/>
+<circle cx="578" cy="961" r="3" opacity="1" fill="#F87171" stroke="none" stroke-width="1"/>
+<circle cx="533" cy="954" r="3" opacity="1" fill="#F87171" stroke="none" stroke-width="1"/>
+<circle cx="519" cy="950" r="3" opacity="1" fill="#F87171" stroke="none" stroke-width="1"/>
+<circle cx="501" cy="948" r="3" opacity="1" fill="#F87171" stroke="none" stroke-width="1"/>
+<circle cx="482" cy="946" r="3" opacity="1" fill="#F87171" stroke="none" stroke-width="1"/>
 <circle cx="439" cy="942" r="3" opacity="1" fill="#F87171" stroke="none" stroke-width="1"/>
 <circle cx="410" cy="936" r="3" opacity="1" fill="#F87171" stroke="none" stroke-width="1"/>
 <text x="416" y="936" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="7.258064516129032" opacity="1" fill="#F87171" font-weight="bold">
 L-1
 </text>
-<circle cx="328" cy="909" r="3" opacity="1" fill="#F87171" stroke="none" stroke-width="1"/>
-<text x="334" y="909" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="7.258064516129032" opacity="1" fill="#F87171" font-weight="bold">
+<circle cx="336" cy="910" r="3" opacity="1" fill="#F87171" stroke="none" stroke-width="1"/>
+<text x="342" y="910" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="7.258064516129032" opacity="1" fill="#F87171" font-weight="bold">
 L1
 </text>
-<circle cx="262" cy="868" r="3" opacity="1" fill="#F87171" stroke="none" stroke-width="1"/>
-<circle cx="240" cy="858" r="3" opacity="1" fill="#F87171" stroke="none" stroke-width="1"/>
-<text x="246" y="858" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="7.258064516129032" opacity="1" fill="#F87171" font-weight="bold">
+<circle cx="290" cy="891" r="3" opacity="1" fill="#F87171" stroke="none" stroke-width="1"/>
+<circle cx="254" cy="873" r="3" opacity="1" fill="#F87171" stroke="none" stroke-width="1"/>
+<text x="260" y="873" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="7.258064516129032" opacity="1" fill="#F87171" font-weight="bold">
 L3
 </text>
-<circle cx="198" cy="834" r="3" opacity="1" fill="#F87171" stroke="none" stroke-width="1"/>
-<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="1" points="535,956 524,952 515,953 509,950 493,948 476,946 459,943 303,880 263,857 149,827 138,804 "/>
-<circle cx="535" cy="956" r="3" opacity="1" fill="#F59E0B" stroke="none" stroke-width="1"/>
-<text x="541" y="956" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="7.258064516129032" opacity="1" fill="#F59E0B" font-weight="bold">
+<circle cx="214" cy="854" r="3" opacity="1" fill="#F87171" stroke="none" stroke-width="1"/>
+<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="1" points="529,956 518,952 509,953 503,950 484,948 472,946 455,943 301,880 259,857 144,827 134,804 "/>
+<circle cx="529" cy="956" r="3" opacity="1" fill="#F59E0B" stroke="none" stroke-width="1"/>
+<text x="535" y="956" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="7.258064516129032" opacity="1" fill="#F59E0B" font-weight="bold">
 L-7
 </text>
-<circle cx="524" cy="952" r="3" opacity="1" fill="#F59E0B" stroke="none" stroke-width="1"/>
-<circle cx="515" cy="953" r="3" opacity="1" fill="#F59E0B" stroke="none" stroke-width="1"/>
-<circle cx="509" cy="950" r="3" opacity="1" fill="#F59E0B" stroke="none" stroke-width="1"/>
-<circle cx="493" cy="948" r="3" opacity="1" fill="#F59E0B" stroke="none" stroke-width="1"/>
-<circle cx="476" cy="946" r="3" opacity="1" fill="#F59E0B" stroke="none" stroke-width="1"/>
-<circle cx="459" cy="943" r="3" opacity="1" fill="#F59E0B" stroke="none" stroke-width="1"/>
-<text x="465" y="943" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="7.258064516129032" opacity="1" fill="#F59E0B" font-weight="bold">
+<circle cx="518" cy="952" r="3" opacity="1" fill="#F59E0B" stroke="none" stroke-width="1"/>
+<circle cx="509" cy="953" r="3" opacity="1" fill="#F59E0B" stroke="none" stroke-width="1"/>
+<circle cx="503" cy="950" r="3" opacity="1" fill="#F59E0B" stroke="none" stroke-width="1"/>
+<circle cx="484" cy="948" r="3" opacity="1" fill="#F59E0B" stroke="none" stroke-width="1"/>
+<circle cx="472" cy="946" r="3" opacity="1" fill="#F59E0B" stroke="none" stroke-width="1"/>
+<circle cx="455" cy="943" r="3" opacity="1" fill="#F59E0B" stroke="none" stroke-width="1"/>
+<text x="461" y="943" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="7.258064516129032" opacity="1" fill="#F59E0B" font-weight="bold">
 L-1
 </text>
-<circle cx="303" cy="880" r="3" opacity="1" fill="#F59E0B" stroke="none" stroke-width="1"/>
-<text x="309" y="880" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="7.258064516129032" opacity="1" fill="#F59E0B" font-weight="bold">
+<circle cx="301" cy="880" r="3" opacity="1" fill="#F59E0B" stroke="none" stroke-width="1"/>
+<text x="307" y="880" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="7.258064516129032" opacity="1" fill="#F59E0B" font-weight="bold">
 L1
 </text>
-<circle cx="263" cy="857" r="3" opacity="1" fill="#F59E0B" stroke="none" stroke-width="1"/>
-<circle cx="149" cy="827" r="3" opacity="1" fill="#F59E0B" stroke="none" stroke-width="1"/>
-<text x="155" y="827" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="7.258064516129032" opacity="1" fill="#F59E0B" font-weight="bold">
+<circle cx="259" cy="857" r="3" opacity="1" fill="#F59E0B" stroke="none" stroke-width="1"/>
+<circle cx="144" cy="827" r="3" opacity="1" fill="#F59E0B" stroke="none" stroke-width="1"/>
+<text x="150" y="827" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="7.258064516129032" opacity="1" fill="#F59E0B" font-weight="bold">
 L3
 </text>
-<circle cx="138" cy="804" r="3" opacity="1" fill="#F59E0B" stroke="none" stroke-width="1"/>
-<polyline fill="none" opacity="1" stroke="#F472B6" stroke-width="1" points="596,964 547,961 501,954 487,950 468,948 448,946 405,942 373,936 284,909 223,868 200,858 164,834 "/>
-<circle cx="596" cy="964" r="3" opacity="1" fill="#F472B6" stroke="none" stroke-width="1"/>
-<text x="602" y="964" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="7.258064516129032" opacity="1" fill="#F472B6" font-weight="bold">
+<circle cx="134" cy="804" r="3" opacity="1" fill="#F59E0B" stroke="none" stroke-width="1"/>
+<polyline fill="none" opacity="1" stroke="#F472B6" stroke-width="1" points="599,964 546,961 499,954 485,950 465,948 446,946 402,942 371,936 293,910 252,891 216,873 189,854 "/>
+<circle cx="599" cy="964" r="3" opacity="1" fill="#F472B6" stroke="none" stroke-width="1"/>
+<text x="605" y="964" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="7.258064516129032" opacity="1" fill="#F472B6" font-weight="bold">
 L-8
 </text>
-<circle cx="547" cy="961" r="3" opacity="1" fill="#F472B6" stroke="none" stroke-width="1"/>
-<circle cx="501" cy="954" r="3" opacity="1" fill="#F472B6" stroke="none" stroke-width="1"/>
-<circle cx="487" cy="950" r="3" opacity="1" fill="#F472B6" stroke="none" stroke-width="1"/>
-<circle cx="468" cy="948" r="3" opacity="1" fill="#F472B6" stroke="none" stroke-width="1"/>
-<circle cx="448" cy="946" r="3" opacity="1" fill="#F472B6" stroke="none" stroke-width="1"/>
-<circle cx="405" cy="942" r="3" opacity="1" fill="#F472B6" stroke="none" stroke-width="1"/>
-<circle cx="373" cy="936" r="3" opacity="1" fill="#F472B6" stroke="none" stroke-width="1"/>
-<text x="379" y="936" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="7.258064516129032" opacity="1" fill="#F472B6" font-weight="bold">
+<circle cx="546" cy="961" r="3" opacity="1" fill="#F472B6" stroke="none" stroke-width="1"/>
+<circle cx="499" cy="954" r="3" opacity="1" fill="#F472B6" stroke="none" stroke-width="1"/>
+<circle cx="485" cy="950" r="3" opacity="1" fill="#F472B6" stroke="none" stroke-width="1"/>
+<circle cx="465" cy="948" r="3" opacity="1" fill="#F472B6" stroke="none" stroke-width="1"/>
+<circle cx="446" cy="946" r="3" opacity="1" fill="#F472B6" stroke="none" stroke-width="1"/>
+<circle cx="402" cy="942" r="3" opacity="1" fill="#F472B6" stroke="none" stroke-width="1"/>
+<circle cx="371" cy="936" r="3" opacity="1" fill="#F472B6" stroke="none" stroke-width="1"/>
+<text x="377" y="936" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="7.258064516129032" opacity="1" fill="#F472B6" font-weight="bold">
 L-1
 </text>
-<circle cx="284" cy="909" r="3" opacity="1" fill="#F472B6" stroke="none" stroke-width="1"/>
-<text x="290" y="909" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="7.258064516129032" opacity="1" fill="#F472B6" font-weight="bold">
+<circle cx="293" cy="910" r="3" opacity="1" fill="#F472B6" stroke="none" stroke-width="1"/>
+<text x="299" y="910" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="7.258064516129032" opacity="1" fill="#F472B6" font-weight="bold">
 L1
 </text>
-<circle cx="223" cy="868" r="3" opacity="1" fill="#F472B6" stroke="none" stroke-width="1"/>
-<circle cx="200" cy="858" r="3" opacity="1" fill="#F472B6" stroke="none" stroke-width="1"/>
-<text x="206" y="858" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="7.258064516129032" opacity="1" fill="#F472B6" font-weight="bold">
+<circle cx="252" cy="891" r="3" opacity="1" fill="#F472B6" stroke="none" stroke-width="1"/>
+<circle cx="216" cy="873" r="3" opacity="1" fill="#F472B6" stroke="none" stroke-width="1"/>
+<text x="222" y="873" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="7.258064516129032" opacity="1" fill="#F472B6" font-weight="bold">
 L3
 </text>
-<circle cx="164" cy="834" r="3" opacity="1" fill="#F472B6" stroke="none" stroke-width="1"/>
-<circle cx="88" cy="894" r="3" opacity="1" fill="#4ADE80" stroke="none" stroke-width="1"/>
-<text x="94" y="894" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="7.258064516129032" opacity="1" fill="#4ADE80" font-weight="bold">
+<circle cx="189" cy="854" r="3" opacity="1" fill="#F472B6" stroke="none" stroke-width="1"/>
+<circle cx="87" cy="894" r="3" opacity="1" fill="#4ADE80" stroke="none" stroke-width="1"/>
+<text x="93" y="894" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="7.258064516129032" opacity="1" fill="#4ADE80" font-weight="bold">
 L1
 </text>
 <circle cx="688" cy="963" r="3" opacity="1" fill="#C084FC" stroke="none" stroke-width="1"/>

--- a/doc/charts/x86_64/small_decode.svg
+++ b/doc/charts/x86_64/small_decode.svg
@@ -4,7 +4,7 @@
 Decode Throughput vs Input Size (Silesia slices, C zstd L3 bitstream)
 </text>
 <text x="415" y="36" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#7D8590">
-Linux VM on a 2018 Mac Mini, Intel Core i7-8700B @ 3.20GHz, performance governor, turbo off
+Linux VM on a 2018 Mac Mini, Intel Core i7-8700B @ 3.20GHz, 12 cores, performance governor, turbo off
 </text>
 <rect x="90" y="66" width="700" height="220" opacity="1" fill="#161B22" stroke="none"/>
 <text x="440" y="54" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="10.483870967741936" opacity="1" fill="#E6EDF3" font-weight="bold">
@@ -47,72 +47,72 @@ dickens
 <text x="742" y="302" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#7D8590">
 128K
 </text>
-<polyline fill="none" opacity="1" stroke="#21262D" stroke-width="1" points="90,238 790,238 "/>
-<text x="82" y="238" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#7D8590">
+<polyline fill="none" opacity="1" stroke="#21262D" stroke-width="1" points="90,237 790,237 "/>
+<text x="82" y="237" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#7D8590">
 200
 </text>
 <polyline fill="none" opacity="1" stroke="#21262D" stroke-width="1" points="90,189 790,189 "/>
 <text x="82" y="189" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#7D8590">
 400
 </text>
-<polyline fill="none" opacity="1" stroke="#21262D" stroke-width="1" points="90,141 790,141 "/>
-<text x="82" y="141" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#7D8590">
+<polyline fill="none" opacity="1" stroke="#21262D" stroke-width="1" points="90,140 790,140 "/>
+<text x="82" y="140" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#7D8590">
 600
 </text>
 <polyline fill="none" opacity="1" stroke="#21262D" stroke-width="1" points="90,92 790,92 "/>
 <text x="82" y="92" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#7D8590">
 800
 </text>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="118,239 196,212 274,199 352,170 430,151 508,144 586,114 664,100 742,95 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="118,239 196,212 274,198 352,170 430,151 508,143 586,115 664,101 742,95 "/>
 <circle cx="118" cy="239" r="3" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
 <circle cx="196" cy="212" r="3" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
-<circle cx="274" cy="199" r="3" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
+<circle cx="274" cy="198" r="3" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
 <circle cx="352" cy="170" r="3" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
 <circle cx="430" cy="151" r="3" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
-<circle cx="508" cy="144" r="3" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
-<circle cx="586" cy="114" r="3" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
-<circle cx="664" cy="100" r="3" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
+<circle cx="508" cy="143" r="3" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
+<circle cx="586" cy="115" r="3" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
+<circle cx="664" cy="101" r="3" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
 <circle cx="742" cy="95" r="3" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
-<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="118,231 196,207 274,195 352,187 430,180 508,180 586,176 664,195 742,193 "/>
-<circle cx="118" cy="231" r="3" opacity="1" fill="#F87171" stroke="none" stroke-width="1"/>
+<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="118,230 196,207 274,194 352,187 430,180 508,180 586,177 664,195 742,192 "/>
+<circle cx="118" cy="230" r="3" opacity="1" fill="#F87171" stroke="none" stroke-width="1"/>
 <circle cx="196" cy="207" r="3" opacity="1" fill="#F87171" stroke="none" stroke-width="1"/>
-<circle cx="274" cy="195" r="3" opacity="1" fill="#F87171" stroke="none" stroke-width="1"/>
+<circle cx="274" cy="194" r="3" opacity="1" fill="#F87171" stroke="none" stroke-width="1"/>
 <circle cx="352" cy="187" r="3" opacity="1" fill="#F87171" stroke="none" stroke-width="1"/>
 <circle cx="430" cy="180" r="3" opacity="1" fill="#F87171" stroke="none" stroke-width="1"/>
 <circle cx="508" cy="180" r="3" opacity="1" fill="#F87171" stroke="none" stroke-width="1"/>
-<circle cx="586" cy="176" r="3" opacity="1" fill="#F87171" stroke="none" stroke-width="1"/>
+<circle cx="586" cy="177" r="3" opacity="1" fill="#F87171" stroke="none" stroke-width="1"/>
 <circle cx="664" cy="195" r="3" opacity="1" fill="#F87171" stroke="none" stroke-width="1"/>
-<circle cx="742" cy="193" r="3" opacity="1" fill="#F87171" stroke="none" stroke-width="1"/>
-<polyline fill="none" opacity="1" stroke="#F472B6" stroke-width="2" points="118,235 196,217 274,209 352,204 430,200 508,207 586,210 664,216 742,214 "/>
-<circle cx="118" cy="235" r="3" opacity="1" fill="#F472B6" stroke="none" stroke-width="1"/>
-<circle cx="196" cy="217" r="3" opacity="1" fill="#F472B6" stroke="none" stroke-width="1"/>
-<circle cx="274" cy="209" r="3" opacity="1" fill="#F472B6" stroke="none" stroke-width="1"/>
-<circle cx="352" cy="204" r="3" opacity="1" fill="#F472B6" stroke="none" stroke-width="1"/>
-<circle cx="430" cy="200" r="3" opacity="1" fill="#F472B6" stroke="none" stroke-width="1"/>
+<circle cx="742" cy="192" r="3" opacity="1" fill="#F87171" stroke="none" stroke-width="1"/>
+<polyline fill="none" opacity="1" stroke="#F472B6" stroke-width="2" points="118,234 196,215 274,207 352,203 430,199 508,207 586,209 664,215 742,214 "/>
+<circle cx="118" cy="234" r="3" opacity="1" fill="#F472B6" stroke="none" stroke-width="1"/>
+<circle cx="196" cy="215" r="3" opacity="1" fill="#F472B6" stroke="none" stroke-width="1"/>
+<circle cx="274" cy="207" r="3" opacity="1" fill="#F472B6" stroke="none" stroke-width="1"/>
+<circle cx="352" cy="203" r="3" opacity="1" fill="#F472B6" stroke="none" stroke-width="1"/>
+<circle cx="430" cy="199" r="3" opacity="1" fill="#F472B6" stroke="none" stroke-width="1"/>
 <circle cx="508" cy="207" r="3" opacity="1" fill="#F472B6" stroke="none" stroke-width="1"/>
-<circle cx="586" cy="210" r="3" opacity="1" fill="#F472B6" stroke="none" stroke-width="1"/>
-<circle cx="664" cy="216" r="3" opacity="1" fill="#F472B6" stroke="none" stroke-width="1"/>
+<circle cx="586" cy="209" r="3" opacity="1" fill="#F472B6" stroke="none" stroke-width="1"/>
+<circle cx="664" cy="215" r="3" opacity="1" fill="#F472B6" stroke="none" stroke-width="1"/>
 <circle cx="742" cy="214" r="3" opacity="1" fill="#F472B6" stroke="none" stroke-width="1"/>
-<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="118,262 196,246 274,238 352,220 430,207 508,204 586,185 664,180 742,176 "/>
-<circle cx="118" cy="262" r="3" opacity="1" fill="#F59E0B" stroke="none" stroke-width="1"/>
-<circle cx="196" cy="246" r="3" opacity="1" fill="#F59E0B" stroke="none" stroke-width="1"/>
+<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="118,261 196,245 274,238 352,219 430,207 508,204 586,185 664,180 742,176 "/>
+<circle cx="118" cy="261" r="3" opacity="1" fill="#F59E0B" stroke="none" stroke-width="1"/>
+<circle cx="196" cy="245" r="3" opacity="1" fill="#F59E0B" stroke="none" stroke-width="1"/>
 <circle cx="274" cy="238" r="3" opacity="1" fill="#F59E0B" stroke="none" stroke-width="1"/>
-<circle cx="352" cy="220" r="3" opacity="1" fill="#F59E0B" stroke="none" stroke-width="1"/>
+<circle cx="352" cy="219" r="3" opacity="1" fill="#F59E0B" stroke="none" stroke-width="1"/>
 <circle cx="430" cy="207" r="3" opacity="1" fill="#F59E0B" stroke="none" stroke-width="1"/>
 <circle cx="508" cy="204" r="3" opacity="1" fill="#F59E0B" stroke="none" stroke-width="1"/>
 <circle cx="586" cy="185" r="3" opacity="1" fill="#F59E0B" stroke="none" stroke-width="1"/>
 <circle cx="664" cy="180" r="3" opacity="1" fill="#F59E0B" stroke="none" stroke-width="1"/>
 <circle cx="742" cy="176" r="3" opacity="1" fill="#F59E0B" stroke="none" stroke-width="1"/>
-<polyline fill="none" opacity="1" stroke="#4ADE80" stroke-width="2" points="118,271 196,263 274,261 352,258 430,256 508,257 586,253 664,251 742,250 "/>
+<polyline fill="none" opacity="1" stroke="#4ADE80" stroke-width="2" points="118,271 196,264 274,261 352,258 430,256 508,257 586,253 664,252 742,251 "/>
 <circle cx="118" cy="271" r="3" opacity="1" fill="#4ADE80" stroke="none" stroke-width="1"/>
-<circle cx="196" cy="263" r="3" opacity="1" fill="#4ADE80" stroke="none" stroke-width="1"/>
+<circle cx="196" cy="264" r="3" opacity="1" fill="#4ADE80" stroke="none" stroke-width="1"/>
 <circle cx="274" cy="261" r="3" opacity="1" fill="#4ADE80" stroke="none" stroke-width="1"/>
 <circle cx="352" cy="258" r="3" opacity="1" fill="#4ADE80" stroke="none" stroke-width="1"/>
 <circle cx="430" cy="256" r="3" opacity="1" fill="#4ADE80" stroke="none" stroke-width="1"/>
 <circle cx="508" cy="257" r="3" opacity="1" fill="#4ADE80" stroke="none" stroke-width="1"/>
 <circle cx="586" cy="253" r="3" opacity="1" fill="#4ADE80" stroke="none" stroke-width="1"/>
-<circle cx="664" cy="251" r="3" opacity="1" fill="#4ADE80" stroke="none" stroke-width="1"/>
-<circle cx="742" cy="250" r="3" opacity="1" fill="#4ADE80" stroke="none" stroke-width="1"/>
+<circle cx="664" cy="252" r="3" opacity="1" fill="#4ADE80" stroke="none" stroke-width="1"/>
+<circle cx="742" cy="251" r="3" opacity="1" fill="#4ADE80" stroke="none" stroke-width="1"/>
 <rect x="90" y="336" width="700" height="220" opacity="1" fill="#161B22" stroke="none"/>
 <text x="440" y="324" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="10.483870967741936" opacity="1" fill="#E6EDF3" font-weight="bold">
 nci
@@ -158,67 +158,67 @@ nci
 <text x="82" y="507" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#7D8590">
 500
 </text>
-<polyline fill="none" opacity="1" stroke="#21262D" stroke-width="1" points="90,458 790,458 "/>
-<text x="82" y="458" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#7D8590">
+<polyline fill="none" opacity="1" stroke="#21262D" stroke-width="1" points="90,457 790,457 "/>
+<text x="82" y="457" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#7D8590">
 1000
 </text>
-<polyline fill="none" opacity="1" stroke="#21262D" stroke-width="1" points="90,409 790,409 "/>
-<text x="82" y="409" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#7D8590">
+<polyline fill="none" opacity="1" stroke="#21262D" stroke-width="1" points="90,408 790,408 "/>
+<text x="82" y="408" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#7D8590">
 1500
 </text>
-<polyline fill="none" opacity="1" stroke="#21262D" stroke-width="1" points="90,360 790,360 "/>
-<text x="82" y="360" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#7D8590">
+<polyline fill="none" opacity="1" stroke="#21262D" stroke-width="1" points="90,359 790,359 "/>
+<text x="82" y="359" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#7D8590">
 2000
 </text>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="118,536 196,522 274,510 352,479 430,440 508,408 586,389 664,365 742,382 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="118,536 196,521 274,509 352,478 430,440 508,409 586,389 664,365 742,381 "/>
 <circle cx="118" cy="536" r="3" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
-<circle cx="196" cy="522" r="3" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
-<circle cx="274" cy="510" r="3" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
-<circle cx="352" cy="479" r="3" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
+<circle cx="196" cy="521" r="3" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
+<circle cx="274" cy="509" r="3" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
+<circle cx="352" cy="478" r="3" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
 <circle cx="430" cy="440" r="3" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
-<circle cx="508" cy="408" r="3" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
+<circle cx="508" cy="409" r="3" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
 <circle cx="586" cy="389" r="3" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
 <circle cx="664" cy="365" r="3" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
-<circle cx="742" cy="382" r="3" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
-<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="118,529 196,511 274,486 352,472 430,451 508,435 586,422 664,401 742,439 "/>
-<circle cx="118" cy="529" r="3" opacity="1" fill="#F87171" stroke="none" stroke-width="1"/>
-<circle cx="196" cy="511" r="3" opacity="1" fill="#F87171" stroke="none" stroke-width="1"/>
-<circle cx="274" cy="486" r="3" opacity="1" fill="#F87171" stroke="none" stroke-width="1"/>
+<circle cx="742" cy="381" r="3" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
+<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="118,528 196,510 274,485 352,472 430,450 508,435 586,421 664,400 742,439 "/>
+<circle cx="118" cy="528" r="3" opacity="1" fill="#F87171" stroke="none" stroke-width="1"/>
+<circle cx="196" cy="510" r="3" opacity="1" fill="#F87171" stroke="none" stroke-width="1"/>
+<circle cx="274" cy="485" r="3" opacity="1" fill="#F87171" stroke="none" stroke-width="1"/>
 <circle cx="352" cy="472" r="3" opacity="1" fill="#F87171" stroke="none" stroke-width="1"/>
-<circle cx="430" cy="451" r="3" opacity="1" fill="#F87171" stroke="none" stroke-width="1"/>
+<circle cx="430" cy="450" r="3" opacity="1" fill="#F87171" stroke="none" stroke-width="1"/>
 <circle cx="508" cy="435" r="3" opacity="1" fill="#F87171" stroke="none" stroke-width="1"/>
-<circle cx="586" cy="422" r="3" opacity="1" fill="#F87171" stroke="none" stroke-width="1"/>
-<circle cx="664" cy="401" r="3" opacity="1" fill="#F87171" stroke="none" stroke-width="1"/>
+<circle cx="586" cy="421" r="3" opacity="1" fill="#F87171" stroke="none" stroke-width="1"/>
+<circle cx="664" cy="400" r="3" opacity="1" fill="#F87171" stroke="none" stroke-width="1"/>
 <circle cx="742" cy="439" r="3" opacity="1" fill="#F87171" stroke="none" stroke-width="1"/>
-<polyline fill="none" opacity="1" stroke="#F472B6" stroke-width="2" points="118,530 196,514 274,492 352,481 430,463 508,451 586,440 664,431 742,460 "/>
+<polyline fill="none" opacity="1" stroke="#F472B6" stroke-width="2" points="118,530 196,513 274,491 352,479 430,462 508,450 586,440 664,431 742,459 "/>
 <circle cx="118" cy="530" r="3" opacity="1" fill="#F472B6" stroke="none" stroke-width="1"/>
-<circle cx="196" cy="514" r="3" opacity="1" fill="#F472B6" stroke="none" stroke-width="1"/>
-<circle cx="274" cy="492" r="3" opacity="1" fill="#F472B6" stroke="none" stroke-width="1"/>
-<circle cx="352" cy="481" r="3" opacity="1" fill="#F472B6" stroke="none" stroke-width="1"/>
-<circle cx="430" cy="463" r="3" opacity="1" fill="#F472B6" stroke="none" stroke-width="1"/>
-<circle cx="508" cy="451" r="3" opacity="1" fill="#F472B6" stroke="none" stroke-width="1"/>
+<circle cx="196" cy="513" r="3" opacity="1" fill="#F472B6" stroke="none" stroke-width="1"/>
+<circle cx="274" cy="491" r="3" opacity="1" fill="#F472B6" stroke="none" stroke-width="1"/>
+<circle cx="352" cy="479" r="3" opacity="1" fill="#F472B6" stroke="none" stroke-width="1"/>
+<circle cx="430" cy="462" r="3" opacity="1" fill="#F472B6" stroke="none" stroke-width="1"/>
+<circle cx="508" cy="450" r="3" opacity="1" fill="#F472B6" stroke="none" stroke-width="1"/>
 <circle cx="586" cy="440" r="3" opacity="1" fill="#F472B6" stroke="none" stroke-width="1"/>
 <circle cx="664" cy="431" r="3" opacity="1" fill="#F472B6" stroke="none" stroke-width="1"/>
-<circle cx="742" cy="460" r="3" opacity="1" fill="#F472B6" stroke="none" stroke-width="1"/>
-<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="118,545 196,537 274,530 352,514 430,491 508,471 586,457 664,434 742,440 "/>
+<circle cx="742" cy="459" r="3" opacity="1" fill="#F472B6" stroke="none" stroke-width="1"/>
+<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="118,545 196,538 274,531 352,514 430,491 508,471 586,456 664,433 742,440 "/>
 <circle cx="118" cy="545" r="3" opacity="1" fill="#F59E0B" stroke="none" stroke-width="1"/>
-<circle cx="196" cy="537" r="3" opacity="1" fill="#F59E0B" stroke="none" stroke-width="1"/>
-<circle cx="274" cy="530" r="3" opacity="1" fill="#F59E0B" stroke="none" stroke-width="1"/>
+<circle cx="196" cy="538" r="3" opacity="1" fill="#F59E0B" stroke="none" stroke-width="1"/>
+<circle cx="274" cy="531" r="3" opacity="1" fill="#F59E0B" stroke="none" stroke-width="1"/>
 <circle cx="352" cy="514" r="3" opacity="1" fill="#F59E0B" stroke="none" stroke-width="1"/>
 <circle cx="430" cy="491" r="3" opacity="1" fill="#F59E0B" stroke="none" stroke-width="1"/>
 <circle cx="508" cy="471" r="3" opacity="1" fill="#F59E0B" stroke="none" stroke-width="1"/>
-<circle cx="586" cy="457" r="3" opacity="1" fill="#F59E0B" stroke="none" stroke-width="1"/>
-<circle cx="664" cy="434" r="3" opacity="1" fill="#F59E0B" stroke="none" stroke-width="1"/>
+<circle cx="586" cy="456" r="3" opacity="1" fill="#F59E0B" stroke="none" stroke-width="1"/>
+<circle cx="664" cy="433" r="3" opacity="1" fill="#F59E0B" stroke="none" stroke-width="1"/>
 <circle cx="742" cy="440" r="3" opacity="1" fill="#F59E0B" stroke="none" stroke-width="1"/>
-<polyline fill="none" opacity="1" stroke="#4ADE80" stroke-width="2" points="118,548 196,543 274,537 352,531 430,525 508,521 586,520 664,515 742,516 "/>
+<polyline fill="none" opacity="1" stroke="#4ADE80" stroke-width="2" points="118,548 196,543 274,537 352,531 430,524 508,520 586,520 664,514 742,516 "/>
 <circle cx="118" cy="548" r="3" opacity="1" fill="#4ADE80" stroke="none" stroke-width="1"/>
 <circle cx="196" cy="543" r="3" opacity="1" fill="#4ADE80" stroke="none" stroke-width="1"/>
 <circle cx="274" cy="537" r="3" opacity="1" fill="#4ADE80" stroke="none" stroke-width="1"/>
 <circle cx="352" cy="531" r="3" opacity="1" fill="#4ADE80" stroke="none" stroke-width="1"/>
-<circle cx="430" cy="525" r="3" opacity="1" fill="#4ADE80" stroke="none" stroke-width="1"/>
-<circle cx="508" cy="521" r="3" opacity="1" fill="#4ADE80" stroke="none" stroke-width="1"/>
+<circle cx="430" cy="524" r="3" opacity="1" fill="#4ADE80" stroke="none" stroke-width="1"/>
+<circle cx="508" cy="520" r="3" opacity="1" fill="#4ADE80" stroke="none" stroke-width="1"/>
 <circle cx="586" cy="520" r="3" opacity="1" fill="#4ADE80" stroke="none" stroke-width="1"/>
-<circle cx="664" cy="515" r="3" opacity="1" fill="#4ADE80" stroke="none" stroke-width="1"/>
+<circle cx="664" cy="514" r="3" opacity="1" fill="#4ADE80" stroke="none" stroke-width="1"/>
 <circle cx="742" cy="516" r="3" opacity="1" fill="#4ADE80" stroke="none" stroke-width="1"/>
 <rect x="90" y="606" width="700" height="220" opacity="1" fill="#161B22" stroke="none"/>
 <text x="440" y="594" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="10.483870967741936" opacity="1" fill="#E6EDF3" font-weight="bold">
@@ -269,67 +269,67 @@ xml
 <text x="82" y="744" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#7D8590">
 1000
 </text>
-<polyline fill="none" opacity="1" stroke="#21262D" stroke-width="1" points="90,702 790,702 "/>
-<text x="82" y="702" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#7D8590">
+<polyline fill="none" opacity="1" stroke="#21262D" stroke-width="1" points="90,704 790,704 "/>
+<text x="82" y="704" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#7D8590">
 1500
 </text>
-<polyline fill="none" opacity="1" stroke="#21262D" stroke-width="1" points="90,661 790,661 "/>
-<text x="82" y="661" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#7D8590">
+<polyline fill="none" opacity="1" stroke="#21262D" stroke-width="1" points="90,663 790,663 "/>
+<text x="82" y="663" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#7D8590">
 2000
 </text>
-<polyline fill="none" opacity="1" stroke="#21262D" stroke-width="1" points="90,620 790,620 "/>
-<text x="82" y="620" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#7D8590">
+<polyline fill="none" opacity="1" stroke="#21262D" stroke-width="1" points="90,622 790,622 "/>
+<text x="82" y="622" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#7D8590">
 2500
 </text>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="118,808 196,796 274,789 352,763 430,729 508,685 586,641 664,635 742,657 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="118,808 196,797 274,790 352,764 430,731 508,687 586,642 664,635 742,659 "/>
 <circle cx="118" cy="808" r="3" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
-<circle cx="196" cy="796" r="3" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
-<circle cx="274" cy="789" r="3" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
-<circle cx="352" cy="763" r="3" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
-<circle cx="430" cy="729" r="3" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
-<circle cx="508" cy="685" r="3" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
-<circle cx="586" cy="641" r="3" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
+<circle cx="196" cy="797" r="3" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
+<circle cx="274" cy="790" r="3" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
+<circle cx="352" cy="764" r="3" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
+<circle cx="430" cy="731" r="3" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
+<circle cx="508" cy="687" r="3" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
+<circle cx="586" cy="642" r="3" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
 <circle cx="664" cy="635" r="3" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
-<circle cx="742" cy="657" r="3" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
-<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="118,797 196,791 274,778 352,757 430,734 508,710 586,686 664,672 742,713 "/>
+<circle cx="742" cy="659" r="3" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
+<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="118,797 196,791 274,778 352,758 430,735 508,711 586,687 664,673 742,714 "/>
 <circle cx="118" cy="797" r="3" opacity="1" fill="#F87171" stroke="none" stroke-width="1"/>
 <circle cx="196" cy="791" r="3" opacity="1" fill="#F87171" stroke="none" stroke-width="1"/>
 <circle cx="274" cy="778" r="3" opacity="1" fill="#F87171" stroke="none" stroke-width="1"/>
-<circle cx="352" cy="757" r="3" opacity="1" fill="#F87171" stroke="none" stroke-width="1"/>
-<circle cx="430" cy="734" r="3" opacity="1" fill="#F87171" stroke="none" stroke-width="1"/>
-<circle cx="508" cy="710" r="3" opacity="1" fill="#F87171" stroke="none" stroke-width="1"/>
-<circle cx="586" cy="686" r="3" opacity="1" fill="#F87171" stroke="none" stroke-width="1"/>
-<circle cx="664" cy="672" r="3" opacity="1" fill="#F87171" stroke="none" stroke-width="1"/>
-<circle cx="742" cy="713" r="3" opacity="1" fill="#F87171" stroke="none" stroke-width="1"/>
-<polyline fill="none" opacity="1" stroke="#F472B6" stroke-width="2" points="118,798 196,794 274,783 352,764 430,745 508,724 586,704 664,703 742,731 "/>
+<circle cx="352" cy="758" r="3" opacity="1" fill="#F87171" stroke="none" stroke-width="1"/>
+<circle cx="430" cy="735" r="3" opacity="1" fill="#F87171" stroke="none" stroke-width="1"/>
+<circle cx="508" cy="711" r="3" opacity="1" fill="#F87171" stroke="none" stroke-width="1"/>
+<circle cx="586" cy="687" r="3" opacity="1" fill="#F87171" stroke="none" stroke-width="1"/>
+<circle cx="664" cy="673" r="3" opacity="1" fill="#F87171" stroke="none" stroke-width="1"/>
+<circle cx="742" cy="714" r="3" opacity="1" fill="#F87171" stroke="none" stroke-width="1"/>
+<polyline fill="none" opacity="1" stroke="#F472B6" stroke-width="2" points="118,798 196,794 274,783 352,765 430,745 508,725 586,704 664,704 742,733 "/>
 <circle cx="118" cy="798" r="3" opacity="1" fill="#F472B6" stroke="none" stroke-width="1"/>
 <circle cx="196" cy="794" r="3" opacity="1" fill="#F472B6" stroke="none" stroke-width="1"/>
 <circle cx="274" cy="783" r="3" opacity="1" fill="#F472B6" stroke="none" stroke-width="1"/>
-<circle cx="352" cy="764" r="3" opacity="1" fill="#F472B6" stroke="none" stroke-width="1"/>
+<circle cx="352" cy="765" r="3" opacity="1" fill="#F472B6" stroke="none" stroke-width="1"/>
 <circle cx="430" cy="745" r="3" opacity="1" fill="#F472B6" stroke="none" stroke-width="1"/>
-<circle cx="508" cy="724" r="3" opacity="1" fill="#F472B6" stroke="none" stroke-width="1"/>
+<circle cx="508" cy="725" r="3" opacity="1" fill="#F472B6" stroke="none" stroke-width="1"/>
 <circle cx="586" cy="704" r="3" opacity="1" fill="#F472B6" stroke="none" stroke-width="1"/>
-<circle cx="664" cy="703" r="3" opacity="1" fill="#F472B6" stroke="none" stroke-width="1"/>
-<circle cx="742" cy="731" r="3" opacity="1" fill="#F472B6" stroke="none" stroke-width="1"/>
-<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="118,816 196,811 274,806 352,792 430,771 508,747 586,720 664,711 742,719 "/>
-<circle cx="118" cy="816" r="3" opacity="1" fill="#F59E0B" stroke="none" stroke-width="1"/>
+<circle cx="664" cy="704" r="3" opacity="1" fill="#F472B6" stroke="none" stroke-width="1"/>
+<circle cx="742" cy="733" r="3" opacity="1" fill="#F472B6" stroke="none" stroke-width="1"/>
+<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="118,817 196,811 274,807 352,792 430,773 508,748 586,722 664,714 742,721 "/>
+<circle cx="118" cy="817" r="3" opacity="1" fill="#F59E0B" stroke="none" stroke-width="1"/>
 <circle cx="196" cy="811" r="3" opacity="1" fill="#F59E0B" stroke="none" stroke-width="1"/>
-<circle cx="274" cy="806" r="3" opacity="1" fill="#F59E0B" stroke="none" stroke-width="1"/>
+<circle cx="274" cy="807" r="3" opacity="1" fill="#F59E0B" stroke="none" stroke-width="1"/>
 <circle cx="352" cy="792" r="3" opacity="1" fill="#F59E0B" stroke="none" stroke-width="1"/>
-<circle cx="430" cy="771" r="3" opacity="1" fill="#F59E0B" stroke="none" stroke-width="1"/>
-<circle cx="508" cy="747" r="3" opacity="1" fill="#F59E0B" stroke="none" stroke-width="1"/>
-<circle cx="586" cy="720" r="3" opacity="1" fill="#F59E0B" stroke="none" stroke-width="1"/>
-<circle cx="664" cy="711" r="3" opacity="1" fill="#F59E0B" stroke="none" stroke-width="1"/>
-<circle cx="742" cy="719" r="3" opacity="1" fill="#F59E0B" stroke="none" stroke-width="1"/>
-<polyline fill="none" opacity="1" stroke="#4ADE80" stroke-width="2" points="118,820 196,818 274,815 352,808 430,801 508,794 586,790 664,788 742,789 "/>
+<circle cx="430" cy="773" r="3" opacity="1" fill="#F59E0B" stroke="none" stroke-width="1"/>
+<circle cx="508" cy="748" r="3" opacity="1" fill="#F59E0B" stroke="none" stroke-width="1"/>
+<circle cx="586" cy="722" r="3" opacity="1" fill="#F59E0B" stroke="none" stroke-width="1"/>
+<circle cx="664" cy="714" r="3" opacity="1" fill="#F59E0B" stroke="none" stroke-width="1"/>
+<circle cx="742" cy="721" r="3" opacity="1" fill="#F59E0B" stroke="none" stroke-width="1"/>
+<polyline fill="none" opacity="1" stroke="#4ADE80" stroke-width="2" points="118,820 196,818 274,815 352,808 430,801 508,795 586,790 664,789 742,789 "/>
 <circle cx="118" cy="820" r="3" opacity="1" fill="#4ADE80" stroke="none" stroke-width="1"/>
 <circle cx="196" cy="818" r="3" opacity="1" fill="#4ADE80" stroke="none" stroke-width="1"/>
 <circle cx="274" cy="815" r="3" opacity="1" fill="#4ADE80" stroke="none" stroke-width="1"/>
 <circle cx="352" cy="808" r="3" opacity="1" fill="#4ADE80" stroke="none" stroke-width="1"/>
 <circle cx="430" cy="801" r="3" opacity="1" fill="#4ADE80" stroke="none" stroke-width="1"/>
-<circle cx="508" cy="794" r="3" opacity="1" fill="#4ADE80" stroke="none" stroke-width="1"/>
+<circle cx="508" cy="795" r="3" opacity="1" fill="#4ADE80" stroke="none" stroke-width="1"/>
 <circle cx="586" cy="790" r="3" opacity="1" fill="#4ADE80" stroke="none" stroke-width="1"/>
-<circle cx="664" cy="788" r="3" opacity="1" fill="#4ADE80" stroke="none" stroke-width="1"/>
+<circle cx="664" cy="789" r="3" opacity="1" fill="#4ADE80" stroke="none" stroke-width="1"/>
 <circle cx="742" cy="789" r="3" opacity="1" fill="#4ADE80" stroke="none" stroke-width="1"/>
 <rect x="90" y="876" width="700" height="220" opacity="1" fill="#161B22" stroke="none"/>
 <text x="440" y="864" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="10.483870967741936" opacity="1" fill="#E6EDF3" font-weight="bold">
@@ -376,8 +376,8 @@ x-ray
 <text x="82" y="1056" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#7D8590">
 200
 </text>
-<polyline fill="none" opacity="1" stroke="#21262D" stroke-width="1" points="90,1017 790,1017 "/>
-<text x="82" y="1017" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#7D8590">
+<polyline fill="none" opacity="1" stroke="#21262D" stroke-width="1" points="90,1016 790,1016 "/>
+<text x="82" y="1016" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#7D8590">
 400
 </text>
 <polyline fill="none" opacity="1" stroke="#21262D" stroke-width="1" points="90,977 790,977 "/>
@@ -392,55 +392,55 @@ x-ray
 <text x="82" y="897" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#7D8590">
 1000
 </text>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="118,1063 196,1038 274,1005 352,970 430,949 508,926 586,905 664,919 742,928 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="118,1063 196,1039 274,1005 352,970 430,949 508,927 586,905 664,919 742,928 "/>
 <circle cx="118" cy="1063" r="3" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
-<circle cx="196" cy="1038" r="3" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
+<circle cx="196" cy="1039" r="3" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
 <circle cx="274" cy="1005" r="3" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
 <circle cx="352" cy="970" r="3" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
 <circle cx="430" cy="949" r="3" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
-<circle cx="508" cy="926" r="3" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
+<circle cx="508" cy="927" r="3" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
 <circle cx="586" cy="905" r="3" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
 <circle cx="664" cy="919" r="3" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
 <circle cx="742" cy="928" r="3" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
-<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="118,1046 196,1025 274,1009 352,997 430,991 508,989 586,986 664,990 742,1003 "/>
-<circle cx="118" cy="1046" r="3" opacity="1" fill="#F87171" stroke="none" stroke-width="1"/>
-<circle cx="196" cy="1025" r="3" opacity="1" fill="#F87171" stroke="none" stroke-width="1"/>
-<circle cx="274" cy="1009" r="3" opacity="1" fill="#F87171" stroke="none" stroke-width="1"/>
-<circle cx="352" cy="997" r="3" opacity="1" fill="#F87171" stroke="none" stroke-width="1"/>
-<circle cx="430" cy="991" r="3" opacity="1" fill="#F87171" stroke="none" stroke-width="1"/>
+<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="118,1044 196,1024 274,1008 352,996 430,990 508,989 586,986 664,989 742,1003 "/>
+<circle cx="118" cy="1044" r="3" opacity="1" fill="#F87171" stroke="none" stroke-width="1"/>
+<circle cx="196" cy="1024" r="3" opacity="1" fill="#F87171" stroke="none" stroke-width="1"/>
+<circle cx="274" cy="1008" r="3" opacity="1" fill="#F87171" stroke="none" stroke-width="1"/>
+<circle cx="352" cy="996" r="3" opacity="1" fill="#F87171" stroke="none" stroke-width="1"/>
+<circle cx="430" cy="990" r="3" opacity="1" fill="#F87171" stroke="none" stroke-width="1"/>
 <circle cx="508" cy="989" r="3" opacity="1" fill="#F87171" stroke="none" stroke-width="1"/>
 <circle cx="586" cy="986" r="3" opacity="1" fill="#F87171" stroke="none" stroke-width="1"/>
-<circle cx="664" cy="990" r="3" opacity="1" fill="#F87171" stroke="none" stroke-width="1"/>
+<circle cx="664" cy="989" r="3" opacity="1" fill="#F87171" stroke="none" stroke-width="1"/>
 <circle cx="742" cy="1003" r="3" opacity="1" fill="#F87171" stroke="none" stroke-width="1"/>
-<polyline fill="none" opacity="1" stroke="#F472B6" stroke-width="2" points="118,1048 196,1030 274,1017 352,1007 430,1003 508,1002 586,1000 664,1008 742,1016 "/>
-<circle cx="118" cy="1048" r="3" opacity="1" fill="#F472B6" stroke="none" stroke-width="1"/>
-<circle cx="196" cy="1030" r="3" opacity="1" fill="#F472B6" stroke="none" stroke-width="1"/>
-<circle cx="274" cy="1017" r="3" opacity="1" fill="#F472B6" stroke="none" stroke-width="1"/>
-<circle cx="352" cy="1007" r="3" opacity="1" fill="#F472B6" stroke="none" stroke-width="1"/>
-<circle cx="430" cy="1003" r="3" opacity="1" fill="#F472B6" stroke="none" stroke-width="1"/>
-<circle cx="508" cy="1002" r="3" opacity="1" fill="#F472B6" stroke="none" stroke-width="1"/>
-<circle cx="586" cy="1000" r="3" opacity="1" fill="#F472B6" stroke="none" stroke-width="1"/>
-<circle cx="664" cy="1008" r="3" opacity="1" fill="#F472B6" stroke="none" stroke-width="1"/>
+<polyline fill="none" opacity="1" stroke="#F472B6" stroke-width="2" points="118,1047 196,1029 274,1016 352,1006 430,1002 508,1003 586,999 664,1007 742,1016 "/>
+<circle cx="118" cy="1047" r="3" opacity="1" fill="#F472B6" stroke="none" stroke-width="1"/>
+<circle cx="196" cy="1029" r="3" opacity="1" fill="#F472B6" stroke="none" stroke-width="1"/>
+<circle cx="274" cy="1016" r="3" opacity="1" fill="#F472B6" stroke="none" stroke-width="1"/>
+<circle cx="352" cy="1006" r="3" opacity="1" fill="#F472B6" stroke="none" stroke-width="1"/>
+<circle cx="430" cy="1002" r="3" opacity="1" fill="#F472B6" stroke="none" stroke-width="1"/>
+<circle cx="508" cy="1003" r="3" opacity="1" fill="#F472B6" stroke="none" stroke-width="1"/>
+<circle cx="586" cy="999" r="3" opacity="1" fill="#F472B6" stroke="none" stroke-width="1"/>
+<circle cx="664" cy="1007" r="3" opacity="1" fill="#F472B6" stroke="none" stroke-width="1"/>
 <circle cx="742" cy="1016" r="3" opacity="1" fill="#F472B6" stroke="none" stroke-width="1"/>
-<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="118,1078 196,1065 274,1042 352,1021 430,1006 508,987 586,968 664,976 742,980 "/>
+<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="118,1078 196,1063 274,1041 352,1019 430,1005 508,985 586,967 664,975 742,980 "/>
 <circle cx="118" cy="1078" r="3" opacity="1" fill="#F59E0B" stroke="none" stroke-width="1"/>
-<circle cx="196" cy="1065" r="3" opacity="1" fill="#F59E0B" stroke="none" stroke-width="1"/>
-<circle cx="274" cy="1042" r="3" opacity="1" fill="#F59E0B" stroke="none" stroke-width="1"/>
-<circle cx="352" cy="1021" r="3" opacity="1" fill="#F59E0B" stroke="none" stroke-width="1"/>
-<circle cx="430" cy="1006" r="3" opacity="1" fill="#F59E0B" stroke="none" stroke-width="1"/>
-<circle cx="508" cy="987" r="3" opacity="1" fill="#F59E0B" stroke="none" stroke-width="1"/>
-<circle cx="586" cy="968" r="3" opacity="1" fill="#F59E0B" stroke="none" stroke-width="1"/>
-<circle cx="664" cy="976" r="3" opacity="1" fill="#F59E0B" stroke="none" stroke-width="1"/>
+<circle cx="196" cy="1063" r="3" opacity="1" fill="#F59E0B" stroke="none" stroke-width="1"/>
+<circle cx="274" cy="1041" r="3" opacity="1" fill="#F59E0B" stroke="none" stroke-width="1"/>
+<circle cx="352" cy="1019" r="3" opacity="1" fill="#F59E0B" stroke="none" stroke-width="1"/>
+<circle cx="430" cy="1005" r="3" opacity="1" fill="#F59E0B" stroke="none" stroke-width="1"/>
+<circle cx="508" cy="985" r="3" opacity="1" fill="#F59E0B" stroke="none" stroke-width="1"/>
+<circle cx="586" cy="967" r="3" opacity="1" fill="#F59E0B" stroke="none" stroke-width="1"/>
+<circle cx="664" cy="975" r="3" opacity="1" fill="#F59E0B" stroke="none" stroke-width="1"/>
 <circle cx="742" cy="980" r="3" opacity="1" fill="#F59E0B" stroke="none" stroke-width="1"/>
-<polyline fill="none" opacity="1" stroke="#4ADE80" stroke-width="2" points="118,1085 196,1080 274,1074 352,1070 430,1067 508,1065 586,1063 664,1065 742,1066 "/>
-<circle cx="118" cy="1085" r="3" opacity="1" fill="#4ADE80" stroke="none" stroke-width="1"/>
+<polyline fill="none" opacity="1" stroke="#4ADE80" stroke-width="2" points="118,1086 196,1080 274,1074 352,1070 430,1068 508,1066 586,1064 664,1066 742,1066 "/>
+<circle cx="118" cy="1086" r="3" opacity="1" fill="#4ADE80" stroke="none" stroke-width="1"/>
 <circle cx="196" cy="1080" r="3" opacity="1" fill="#4ADE80" stroke="none" stroke-width="1"/>
 <circle cx="274" cy="1074" r="3" opacity="1" fill="#4ADE80" stroke="none" stroke-width="1"/>
 <circle cx="352" cy="1070" r="3" opacity="1" fill="#4ADE80" stroke="none" stroke-width="1"/>
-<circle cx="430" cy="1067" r="3" opacity="1" fill="#4ADE80" stroke="none" stroke-width="1"/>
-<circle cx="508" cy="1065" r="3" opacity="1" fill="#4ADE80" stroke="none" stroke-width="1"/>
-<circle cx="586" cy="1063" r="3" opacity="1" fill="#4ADE80" stroke="none" stroke-width="1"/>
-<circle cx="664" cy="1065" r="3" opacity="1" fill="#4ADE80" stroke="none" stroke-width="1"/>
+<circle cx="430" cy="1068" r="3" opacity="1" fill="#4ADE80" stroke="none" stroke-width="1"/>
+<circle cx="508" cy="1066" r="3" opacity="1" fill="#4ADE80" stroke="none" stroke-width="1"/>
+<circle cx="586" cy="1064" r="3" opacity="1" fill="#4ADE80" stroke="none" stroke-width="1"/>
+<circle cx="664" cy="1066" r="3" opacity="1" fill="#4ADE80" stroke="none" stroke-width="1"/>
 <circle cx="742" cy="1066" r="3" opacity="1" fill="#4ADE80" stroke="none" stroke-width="1"/>
 <text x="20" y="581" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="9.67741935483871" opacity="1" fill="#E6EDF3" font-weight="bold" transform="rotate(270, 20, 581)">
 decode MB/s

--- a/doc/charts/x86_64/small_encode.svg
+++ b/doc/charts/x86_64/small_encode.svg
@@ -4,7 +4,7 @@
 Encode Throughput vs Input Size (Silesia small-input slices)
 </text>
 <text x="415" y="36" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#7D8590">
-Linux VM on a 2018 Mac Mini, Intel Core i7-8700B @ 3.20GHz, performance governor, turbo off
+Linux VM on a 2018 Mac Mini, Intel Core i7-8700B @ 3.20GHz, 12 cores, performance governor, turbo off
 </text>
 <rect x="90" y="66" width="700" height="220" opacity="1" fill="#161B22" stroke="none"/>
 <text x="440" y="54" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="10.483870967741936" opacity="1" fill="#E6EDF3" font-weight="bold">
@@ -59,326 +59,328 @@ dickens
 <text x="778" y="302" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#7D8590">
 1M
 </text>
-<polyline fill="none" opacity="1" stroke="#21262D" stroke-width="1" points="90,230 790,230 "/>
-<text x="82" y="230" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#7D8590">
+<polyline fill="none" opacity="1" stroke="#21262D" stroke-width="1" points="90,229 790,229 "/>
+<text x="82" y="229" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#7D8590">
 50
 </text>
-<polyline fill="none" opacity="1" stroke="#21262D" stroke-width="1" points="90,187 790,187 "/>
-<text x="82" y="187" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#7D8590">
+<polyline fill="none" opacity="1" stroke="#21262D" stroke-width="1" points="90,186 790,186 "/>
+<text x="82" y="186" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#7D8590">
 100
 </text>
-<polyline fill="none" opacity="1" stroke="#21262D" stroke-width="1" points="90,144 790,144 "/>
-<text x="82" y="144" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#7D8590">
+<polyline fill="none" opacity="1" stroke="#21262D" stroke-width="1" points="90,143 790,143 "/>
+<text x="82" y="143" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#7D8590">
 200
 </text>
-<polyline fill="none" opacity="1" stroke="#21262D" stroke-width="1" points="90,87 790,87 "/>
-<text x="82" y="87" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#7D8590">
+<polyline fill="none" opacity="1" stroke="#21262D" stroke-width="1" points="90,86 790,86 "/>
+<text x="82" y="86" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#7D8590">
 500
 </text>
-<polyline fill="none" opacity="0.35" stroke="#60A5FA" stroke-width="1" points="112,141 172,114 233,89 293,80 354,75 415,84 475,103 536,115 596,119 657,132 718,114 778,113 "/>
-<polyline fill="none" opacity="0.35" stroke="#60A5FA" stroke-width="1" points="112,146 172,115 233,95 293,85 354,81 415,90 475,108 536,119 596,123 657,135 718,117 778,116 "/>
-<polyline fill="none" opacity="0.35" stroke="#60A5FA" stroke-width="1" points="112,146 172,116 233,100 293,90 354,89 415,101 475,115 536,125 596,127 657,138 718,121 778,120 "/>
-<polyline fill="none" opacity="0.35" stroke="#60A5FA" stroke-width="1" points="112,150 172,122 233,105 293,99 354,96 415,109 475,122 536,128 596,132 657,141 718,126 778,125 "/>
-<polyline fill="none" opacity="0.35" stroke="#60A5FA" stroke-width="1" points="112,153 172,128 233,110 293,105 354,104 415,115 475,129 536,134 596,136 657,144 718,130 778,129 "/>
-<polyline fill="none" opacity="0.35" stroke="#60A5FA" stroke-width="1" points="112,157 172,133 233,123 293,115 354,113 415,126 475,135 536,139 596,140 657,147 718,134 778,133 "/>
-<polyline fill="none" opacity="0.35" stroke="#60A5FA" stroke-width="1" points="112,163 172,141 233,132 293,126 354,126 415,135 475,140 536,144 596,145 657,150 718,139 778,138 "/>
-<text x="784" y="138" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="6.451612903225807" opacity="1" fill="#60A5FA" font-weight="bold">
+<polyline fill="none" opacity="0.35" stroke="#60A5FA" stroke-width="1" points="112,140 172,113 233,89 293,80 354,75 415,83 475,103 536,115 596,119 657,132 718,113 778,112 "/>
+<polyline fill="none" opacity="0.35" stroke="#60A5FA" stroke-width="1" points="112,146 172,115 233,93 293,84 354,82 415,89 475,108 536,119 596,122 657,135 718,117 778,115 "/>
+<polyline fill="none" opacity="0.35" stroke="#60A5FA" stroke-width="1" points="112,145 172,116 233,98 293,89 354,87 415,99 475,115 536,125 596,127 657,138 718,121 778,119 "/>
+<polyline fill="none" opacity="0.35" stroke="#60A5FA" stroke-width="1" points="112,149 172,121 233,104 293,98 354,95 415,108 475,122 536,128 596,131 657,141 718,125 778,124 "/>
+<polyline fill="none" opacity="0.35" stroke="#60A5FA" stroke-width="1" points="112,153 172,127 233,109 293,104 354,103 415,115 475,128 536,133 596,135 657,144 718,129 778,128 "/>
+<polyline fill="none" opacity="0.35" stroke="#60A5FA" stroke-width="1" points="112,156 172,133 233,122 293,113 354,112 415,125 475,134 536,138 596,140 657,147 718,133 778,132 "/>
+<polyline fill="none" opacity="0.35" stroke="#60A5FA" stroke-width="1" points="112,162 172,140 233,131 293,126 354,126 415,134 475,140 536,143 596,144 657,150 718,138 778,137 "/>
+<text x="784" y="137" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="6.451612903225807" opacity="1" fill="#60A5FA" font-weight="bold">
 L-1
 </text>
-<polyline fill="none" opacity="0.35" stroke="#60A5FA" stroke-width="1" points="112,198 172,170 233,154 293,142 354,139 415,145 475,138 536,141 596,142 657,148 718,142 778,141 "/>
-<polyline fill="none" opacity="0.35" stroke="#60A5FA" stroke-width="1" points="112,201 172,174 233,158 293,149 354,146 415,154 475,150 536,151 596,151 657,161 718,157 778,157 "/>
-<polyline fill="none" opacity="0.35" stroke="#60A5FA" stroke-width="1" points="112,211 172,184 233,170 293,162 354,159 415,165 475,163 536,165 596,166 657,168 718,170 778,170 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="112,141 172,114 233,89 293,80 354,75 415,84 475,103 536,115 596,119 657,132 718,114 778,113 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="112,230 116,228 "/>
+<polyline fill="none" opacity="0.35" stroke="#60A5FA" stroke-width="1" points="112,198 172,170 233,153 293,143 354,138 415,146 475,138 536,141 596,142 657,148 718,142 778,142 "/>
+<polyline fill="none" opacity="0.35" stroke="#60A5FA" stroke-width="1" points="112,200 172,173 233,157 293,148 354,145 415,154 475,150 536,153 596,153 657,162 718,158 778,159 "/>
+<polyline fill="none" opacity="0.35" stroke="#60A5FA" stroke-width="1" points="112,208 172,183 233,169 293,162 354,159 415,167 475,165 536,167 596,169 657,170 718,171 778,173 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="112,140 172,113 233,89 293,80 354,75 415,83 475,103 536,115 596,119 657,132 718,113 778,112 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="112,229 116,228 "/>
 <polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="120,227 125,225 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="129,224 133,223 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="137,221 142,220 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="146,219 151,217 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="154,216 159,214 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="163,213 168,211 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="171,210 172,210 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="172,210 177,209 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="129,224 133,222 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="137,221 142,219 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="146,218 151,217 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="154,215 159,214 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="163,212 168,211 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="171,210 172,209 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="172,209 177,209 "/>
 <polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="181,208 186,207 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="190,206 195,206 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="190,206 195,205 "/>
 <polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="199,205 204,204 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="208,203 212,202 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="216,202 221,201 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="208,203 213,202 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="216,201 221,200 "/>
 <polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="225,200 230,199 "/>
 <polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="233,198 238,198 "/>
 <polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="242,198 247,198 "/>
 <polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="251,198 256,198 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="260,198 265,197 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="260,198 265,198 "/>
 <polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="269,197 274,197 "/>
 <polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="278,197 283,197 "/>
 <polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="287,197 292,197 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="293,197 298,197 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="293,197 298,198 "/>
 <polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="302,198 307,199 "/>
 <polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="311,199 316,200 "/>
 <polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="320,201 325,201 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="329,202 334,203 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="329,202 334,202 "/>
 <polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="338,203 343,204 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="347,205 352,205 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="354,206 359,206 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="347,204 352,205 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="354,205 359,206 "/>
 <polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="363,206 368,207 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="372,207 377,207 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="372,207 377,208 "/>
 <polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="381,208 386,208 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="390,208 395,209 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="399,209 404,209 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="408,210 413,210 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="415,210 419,207 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="422,205 426,202 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="430,200 434,197 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="437,195 441,192 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="444,190 449,187 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="452,185 456,182 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="459,180 464,177 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="467,175 471,172 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="474,170 475,169 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="475,169 480,170 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="484,170 489,170 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="493,170 498,170 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="502,170 507,170 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="511,171 516,171 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="520,171 525,171 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="529,171 534,171 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="536,171 541,171 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="545,171 550,171 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="554,171 559,171 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="563,171 568,171 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="572,171 577,171 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="581,171 586,171 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="590,171 595,171 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="596,171 601,173 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="604,175 609,178 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="612,180 616,182 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="620,184 624,187 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="628,189 632,191 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="635,193 640,196 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="643,198 648,200 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="651,202 655,205 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="657,206 661,203 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="665,201 669,199 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="672,197 677,194 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="680,192 685,189 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="688,187 692,185 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="696,183 700,180 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="703,178 708,176 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="711,174 715,171 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="718,170 723,170 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="727,170 732,171 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="736,171 741,171 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="745,171 750,172 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="754,172 759,172 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="390,209 395,209 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="399,210 404,210 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="408,211 413,211 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="415,211 419,209 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="422,206 426,204 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="430,201 434,199 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="437,196 441,194 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="445,192 449,189 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="452,187 456,184 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="460,182 464,179 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="467,177 471,174 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="475,172 475,172 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="475,172 480,172 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="484,172 489,172 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="493,172 498,173 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="502,173 507,173 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="511,173 516,174 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="520,174 525,174 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="529,174 534,174 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="536,175 541,175 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="545,175 550,175 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="554,175 559,175 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="563,175 568,175 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="572,175 577,175 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="581,175 586,175 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="590,175 595,175 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="596,175 601,177 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="604,179 609,181 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="612,183 617,185 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="620,187 625,189 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="628,191 633,193 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="636,195 641,198 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="644,199 649,202 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="652,204 657,206 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="657,206 661,204 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="665,202 669,199 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="673,197 677,195 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="681,193 685,190 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="688,188 693,186 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="696,184 701,182 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="704,180 708,177 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="712,175 716,173 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="718,172 723,172 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="727,172 732,172 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="736,172 741,172 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="745,172 750,173 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="754,173 759,173 "/>
 <polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="763,173 768,173 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="772,173 776,173 "/>
-<circle cx="112" cy="141" r="3" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
-<circle cx="172" cy="114" r="3" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="772,173 777,173 "/>
+<circle cx="112" cy="140" r="3" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
+<circle cx="172" cy="113" r="3" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
 <circle cx="233" cy="89" r="3" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
 <circle cx="293" cy="80" r="3" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
 <circle cx="354" cy="75" r="3" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
-<circle cx="415" cy="84" r="3" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
+<circle cx="415" cy="83" r="3" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
 <circle cx="475" cy="103" r="3" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
 <circle cx="536" cy="115" r="3" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
 <circle cx="596" cy="119" r="3" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
 <circle cx="657" cy="132" r="3" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
-<circle cx="718" cy="114" r="3" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
-<circle cx="778" cy="113" r="3" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
-<text x="784" y="113" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="6.451612903225807" opacity="1" fill="#60A5FA" font-weight="bold">
+<circle cx="718" cy="113" r="3" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
+<circle cx="778" cy="112" r="3" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
+<text x="784" y="112" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="6.451612903225807" opacity="1" fill="#60A5FA" font-weight="bold">
 L-7
 </text>
-<circle cx="112" cy="230" r="3" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
-<circle cx="172" cy="210" r="3" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
+<circle cx="112" cy="229" r="3" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
+<circle cx="172" cy="209" r="3" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
 <circle cx="233" cy="198" r="3" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
 <circle cx="293" cy="197" r="3" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
-<circle cx="354" cy="206" r="3" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
-<circle cx="415" cy="210" r="3" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
-<circle cx="475" cy="169" r="3" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
-<circle cx="536" cy="171" r="3" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
-<circle cx="596" cy="171" r="3" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
+<circle cx="354" cy="205" r="3" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
+<circle cx="415" cy="211" r="3" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
+<circle cx="475" cy="172" r="3" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
+<circle cx="536" cy="175" r="3" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
+<circle cx="596" cy="175" r="3" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
 <circle cx="657" cy="206" r="3" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
-<circle cx="718" cy="170" r="3" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
-<circle cx="778" cy="174" r="3" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
-<text x="784" y="174" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="6.451612903225807" opacity="1" fill="#60A5FA" font-weight="bold">
+<circle cx="718" cy="172" r="3" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
+<circle cx="778" cy="173" r="3" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
+<text x="784" y="173" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="6.451612903225807" opacity="1" fill="#60A5FA" font-weight="bold">
 L4
 </text>
-<polyline fill="none" opacity="0.35" stroke="#F87171" stroke-width="1" points="112,116 172,114 233,97 293,93 354,93 415,102 475,135 536,143 596,149 657,153 718,156 778,157 "/>
-<polyline fill="none" opacity="0.35" stroke="#F87171" stroke-width="1" points="112,113 172,105 233,91 293,83 354,86 415,106 475,144 536,150 596,155 657,158 718,159 778,160 "/>
-<polyline fill="none" opacity="0.35" stroke="#F87171" stroke-width="1" points="112,116 172,114 233,97 293,93 354,93 415,138 475,148 536,153 596,157 657,159 718,161 778,162 "/>
-<polyline fill="none" opacity="0.35" stroke="#F87171" stroke-width="1" points="112,118 172,116 233,102 293,99 354,99 415,143 475,152 536,157 596,160 657,162 718,163 778,163 "/>
-<polyline fill="none" opacity="0.35" stroke="#F87171" stroke-width="1" points="112,125 172,117 233,108 293,105 354,105 415,151 475,156 536,161 596,163 657,164 718,165 778,165 "/>
-<polyline fill="none" opacity="0.35" stroke="#F87171" stroke-width="1" points="112,131 172,128 233,116 293,113 354,114 415,158 475,161 536,164 596,166 657,166 718,167 778,168 "/>
-<polyline fill="none" opacity="0.35" stroke="#F87171" stroke-width="1" points="112,136 172,134 233,125 293,124 354,123 415,163 475,166 536,167 596,168 657,169 718,169 778,170 "/>
-<text x="784" y="170" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="6.451612903225807" opacity="1" fill="#F87171" font-weight="bold">
+<polyline fill="none" opacity="0.35" stroke="#F87171" stroke-width="1" points="112,115 172,113 233,96 293,92 354,94 415,106 475,133 536,141 596,148 657,152 718,154 778,155 "/>
+<polyline fill="none" opacity="0.35" stroke="#F87171" stroke-width="1" points="112,112 172,104 233,90 293,81 354,88 415,103 475,142 536,149 596,153 657,156 718,158 778,159 "/>
+<polyline fill="none" opacity="0.35" stroke="#F87171" stroke-width="1" points="112,115 172,113 233,96 293,92 354,94 415,134 475,146 536,152 596,155 657,158 718,160 778,161 "/>
+<polyline fill="none" opacity="0.35" stroke="#F87171" stroke-width="1" points="112,117 172,115 233,100 293,97 354,101 415,144 475,151 536,155 596,158 657,160 718,161 778,163 "/>
+<polyline fill="none" opacity="0.35" stroke="#F87171" stroke-width="1" points="112,124 172,116 233,106 293,104 354,108 415,149 475,154 536,159 596,161 657,163 718,164 778,165 "/>
+<polyline fill="none" opacity="0.35" stroke="#F87171" stroke-width="1" points="112,130 172,126 233,114 293,111 354,116 415,158 475,160 536,163 596,164 657,165 718,166 778,167 "/>
+<polyline fill="none" opacity="0.35" stroke="#F87171" stroke-width="1" points="112,135 172,133 233,123 293,122 354,126 415,161 475,164 536,166 596,167 657,167 718,168 778,169 "/>
+<text x="784" y="169" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="6.451612903225807" opacity="1" fill="#F87171" font-weight="bold">
 L-1
 </text>
-<polyline fill="none" opacity="0.35" stroke="#F87171" stroke-width="1" points="112,206 172,189 233,185 293,177 354,175 415,177 475,176 536,173 596,171 657,170 718,169 778,169 "/>
-<polyline fill="none" opacity="0.35" stroke="#F87171" stroke-width="1" points="112,206 172,190 233,185 293,177 354,175 415,177 475,176 536,175 596,174 657,172 718,171 778,170 "/>
-<polyline fill="none" opacity="0.35" stroke="#F87171" stroke-width="1" points="112,212 172,196 233,194 293,187 354,181 415,188 475,189 536,191 596,192 657,191 718,189 778,189 "/>
-<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="112,113 172,105 233,91 293,83 354,86 415,94 475,125 536,138 596,145 657,148 718,150 778,150 "/>
-<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="112,214 116,213 "/>
-<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="120,212 125,211 "/>
-<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="129,210 134,208 "/>
-<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="138,207 143,206 "/>
-<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="146,205 151,204 "/>
-<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="155,203 160,201 "/>
-<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="164,200 169,199 "/>
-<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="172,198 177,198 "/>
-<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="181,198 186,197 "/>
-<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="190,197 195,197 "/>
-<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="199,197 204,197 "/>
-<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="208,196 213,196 "/>
-<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="217,196 222,196 "/>
-<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="226,196 231,195 "/>
-<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="233,195 238,195 "/>
-<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="242,194 247,194 "/>
-<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="251,193 256,192 "/>
-<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="260,192 265,191 "/>
-<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="269,191 273,190 "/>
-<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="277,190 282,189 "/>
-<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="286,189 291,188 "/>
-<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="293,188 298,187 "/>
-<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="302,187 307,187 "/>
-<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="311,186 316,186 "/>
-<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="320,186 325,185 "/>
-<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="329,185 334,185 "/>
-<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="338,184 343,184 "/>
-<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="347,184 352,183 "/>
-<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="354,183 359,184 "/>
-<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="363,184 368,185 "/>
-<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="372,185 377,185 "/>
-<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="381,186 386,186 "/>
-<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="390,187 395,187 "/>
-<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="399,187 404,188 "/>
-<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="408,188 413,189 "/>
-<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="415,189 420,189 "/>
-<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="424,189 429,189 "/>
-<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="433,189 438,190 "/>
-<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="442,190 447,190 "/>
-<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="451,190 456,190 "/>
-<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="460,190 465,190 "/>
-<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="469,190 474,191 "/>
-<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="475,191 480,191 "/>
-<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="484,191 489,191 "/>
-<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="493,192 498,192 "/>
-<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="502,192 507,192 "/>
-<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="511,192 516,193 "/>
-<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="520,193 525,193 "/>
-<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="529,193 534,194 "/>
-<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="536,194 541,194 "/>
-<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="545,194 550,194 "/>
-<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="554,194 559,194 "/>
-<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="563,194 568,194 "/>
-<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="572,194 577,194 "/>
-<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="581,194 586,194 "/>
-<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="590,194 595,194 "/>
-<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="596,194 601,194 "/>
-<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="605,194 610,194 "/>
-<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="614,194 619,194 "/>
-<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="623,194 628,194 "/>
-<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="632,194 637,193 "/>
-<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="641,193 646,193 "/>
-<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="650,193 655,193 "/>
-<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="657,193 662,193 "/>
-<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="666,193 671,193 "/>
-<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="675,193 680,193 "/>
-<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="684,193 689,193 "/>
-<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="693,192 698,192 "/>
-<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="702,192 707,192 "/>
-<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="711,192 716,192 "/>
-<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="718,192 723,192 "/>
-<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="727,192 732,192 "/>
-<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="736,193 741,193 "/>
-<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="745,193 750,193 "/>
-<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="754,193 759,193 "/>
-<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="763,193 768,194 "/>
-<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="772,194 777,194 "/>
-<circle cx="112" cy="113" r="3" opacity="1" fill="#F87171" stroke="none" stroke-width="1"/>
-<circle cx="172" cy="105" r="3" opacity="1" fill="#F87171" stroke="none" stroke-width="1"/>
-<circle cx="233" cy="91" r="3" opacity="1" fill="#F87171" stroke="none" stroke-width="1"/>
-<circle cx="293" cy="83" r="3" opacity="1" fill="#F87171" stroke="none" stroke-width="1"/>
-<circle cx="354" cy="86" r="3" opacity="1" fill="#F87171" stroke="none" stroke-width="1"/>
-<circle cx="415" cy="94" r="3" opacity="1" fill="#F87171" stroke="none" stroke-width="1"/>
+<polyline fill="none" opacity="0.35" stroke="#F87171" stroke-width="1" points="112,96 172,174 233,173 293,169 354,158 415,176 475,175 536,173 596,171 657,169 718,168 778,169 "/>
+<polyline fill="none" opacity="0.35" stroke="#F87171" stroke-width="1" points="112,96 172,174 233,173 293,170 354,158 415,176 475,174 536,172 596,173 657,171 718,169 778,169 "/>
+<polyline fill="none" opacity="0.35" stroke="#F87171" stroke-width="1" points="112,104 172,177 233,183 293,179 354,170 415,184 475,187 536,189 596,190 657,189 718,187 778,187 "/>
+<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="112,96 172,104 233,90 293,81 354,88 415,97 475,125 536,138 596,144 657,148 718,150 778,150 "/>
+<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="112,135 116,138 "/>
+<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="119,140 123,143 "/>
+<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="126,146 131,148 "/>
+<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="134,151 138,153 "/>
+<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="141,156 145,159 "/>
+<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="149,161 153,164 "/>
+<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="156,166 160,169 "/>
+<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="164,171 168,174 "/>
+<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="171,176 172,177 "/>
+<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="172,177 177,177 "/>
+<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="181,178 186,178 "/>
+<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="190,179 195,179 "/>
+<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="199,180 204,180 "/>
+<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="208,181 213,181 "/>
+<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="217,182 222,182 "/>
+<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="226,183 231,183 "/>
+<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="233,183 238,183 "/>
+<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="242,183 247,182 "/>
+<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="251,182 256,182 "/>
+<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="260,182 265,182 "/>
+<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="269,181 274,181 "/>
+<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="278,181 283,181 "/>
+<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="287,180 292,180 "/>
+<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="293,180 298,179 "/>
+<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="302,179 307,178 "/>
+<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="311,177 316,177 "/>
+<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="320,176 325,175 "/>
+<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="329,175 334,174 "/>
+<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="338,173 343,173 "/>
+<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="347,172 352,171 "/>
+<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="354,171 359,172 "/>
+<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="363,173 368,174 "/>
+<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="372,175 376,176 "/>
+<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="380,177 385,178 "/>
+<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="389,179 394,180 "/>
+<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="398,181 403,182 "/>
+<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="407,183 412,184 "/>
+<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="415,184 420,185 "/>
+<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="424,185 429,185 "/>
+<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="433,186 438,186 "/>
+<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="442,186 447,187 "/>
+<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="451,187 456,187 "/>
+<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="459,187 464,188 "/>
+<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="468,188 473,188 "/>
+<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="475,188 480,189 "/>
+<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="484,189 489,189 "/>
+<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="493,189 498,189 "/>
+<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="502,189 507,190 "/>
+<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="511,190 516,190 "/>
+<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="520,190 525,190 "/>
+<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="529,190 534,191 "/>
+<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="536,191 541,191 "/>
+<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="545,191 550,191 "/>
+<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="554,191 559,191 "/>
+<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="563,191 568,191 "/>
+<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="572,191 577,192 "/>
+<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="581,192 586,192 "/>
+<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="590,192 595,192 "/>
+<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="596,192 601,192 "/>
+<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="605,192 610,192 "/>
+<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="614,192 619,192 "/>
+<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="623,192 628,192 "/>
+<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="632,191 637,191 "/>
+<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="641,191 646,191 "/>
+<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="650,191 655,191 "/>
+<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="657,191 662,191 "/>
+<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="666,191 671,191 "/>
+<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="675,190 680,190 "/>
+<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="684,190 689,190 "/>
+<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="693,190 698,190 "/>
+<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="702,190 707,190 "/>
+<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="711,189 716,189 "/>
+<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="718,189 723,189 "/>
+<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="727,189 732,189 "/>
+<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="736,190 741,190 "/>
+<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="745,190 750,190 "/>
+<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="754,190 759,190 "/>
+<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="763,190 768,190 "/>
+<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="772,190 777,190 "/>
+<circle cx="112" cy="96" r="3" opacity="1" fill="#F87171" stroke="none" stroke-width="1"/>
+<circle cx="172" cy="104" r="3" opacity="1" fill="#F87171" stroke="none" stroke-width="1"/>
+<circle cx="233" cy="90" r="3" opacity="1" fill="#F87171" stroke="none" stroke-width="1"/>
+<circle cx="293" cy="81" r="3" opacity="1" fill="#F87171" stroke="none" stroke-width="1"/>
+<circle cx="354" cy="88" r="3" opacity="1" fill="#F87171" stroke="none" stroke-width="1"/>
+<circle cx="415" cy="97" r="3" opacity="1" fill="#F87171" stroke="none" stroke-width="1"/>
 <circle cx="475" cy="125" r="3" opacity="1" fill="#F87171" stroke="none" stroke-width="1"/>
 <circle cx="536" cy="138" r="3" opacity="1" fill="#F87171" stroke="none" stroke-width="1"/>
-<circle cx="596" cy="145" r="3" opacity="1" fill="#F87171" stroke="none" stroke-width="1"/>
+<circle cx="596" cy="144" r="3" opacity="1" fill="#F87171" stroke="none" stroke-width="1"/>
 <circle cx="657" cy="148" r="3" opacity="1" fill="#F87171" stroke="none" stroke-width="1"/>
 <circle cx="718" cy="150" r="3" opacity="1" fill="#F87171" stroke="none" stroke-width="1"/>
 <circle cx="778" cy="150" r="3" opacity="1" fill="#F87171" stroke="none" stroke-width="1"/>
 <text x="784" y="150" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="6.451612903225807" opacity="1" fill="#F87171" font-weight="bold">
 L-8
 </text>
-<circle cx="112" cy="214" r="3" opacity="1" fill="#F87171" stroke="none" stroke-width="1"/>
-<circle cx="172" cy="198" r="3" opacity="1" fill="#F87171" stroke="none" stroke-width="1"/>
-<circle cx="233" cy="195" r="3" opacity="1" fill="#F87171" stroke="none" stroke-width="1"/>
-<circle cx="293" cy="188" r="3" opacity="1" fill="#F87171" stroke="none" stroke-width="1"/>
-<circle cx="354" cy="183" r="3" opacity="1" fill="#F87171" stroke="none" stroke-width="1"/>
-<circle cx="415" cy="189" r="3" opacity="1" fill="#F87171" stroke="none" stroke-width="1"/>
-<circle cx="475" cy="191" r="3" opacity="1" fill="#F87171" stroke="none" stroke-width="1"/>
-<circle cx="536" cy="194" r="3" opacity="1" fill="#F87171" stroke="none" stroke-width="1"/>
-<circle cx="596" cy="194" r="3" opacity="1" fill="#F87171" stroke="none" stroke-width="1"/>
-<circle cx="657" cy="193" r="3" opacity="1" fill="#F87171" stroke="none" stroke-width="1"/>
-<circle cx="718" cy="192" r="3" opacity="1" fill="#F87171" stroke="none" stroke-width="1"/>
-<circle cx="778" cy="194" r="3" opacity="1" fill="#F87171" stroke="none" stroke-width="1"/>
-<text x="784" y="194" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="6.451612903225807" opacity="1" fill="#F87171" font-weight="bold">
+<circle cx="112" cy="135" r="3" opacity="1" fill="#F87171" stroke="none" stroke-width="1"/>
+<circle cx="172" cy="177" r="3" opacity="1" fill="#F87171" stroke="none" stroke-width="1"/>
+<circle cx="233" cy="183" r="3" opacity="1" fill="#F87171" stroke="none" stroke-width="1"/>
+<circle cx="293" cy="180" r="3" opacity="1" fill="#F87171" stroke="none" stroke-width="1"/>
+<circle cx="354" cy="171" r="3" opacity="1" fill="#F87171" stroke="none" stroke-width="1"/>
+<circle cx="415" cy="184" r="3" opacity="1" fill="#F87171" stroke="none" stroke-width="1"/>
+<circle cx="475" cy="188" r="3" opacity="1" fill="#F87171" stroke="none" stroke-width="1"/>
+<circle cx="536" cy="191" r="3" opacity="1" fill="#F87171" stroke="none" stroke-width="1"/>
+<circle cx="596" cy="192" r="3" opacity="1" fill="#F87171" stroke="none" stroke-width="1"/>
+<circle cx="657" cy="191" r="3" opacity="1" fill="#F87171" stroke="none" stroke-width="1"/>
+<circle cx="718" cy="189" r="3" opacity="1" fill="#F87171" stroke="none" stroke-width="1"/>
+<circle cx="778" cy="190" r="3" opacity="1" fill="#F87171" stroke="none" stroke-width="1"/>
+<text x="784" y="190" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="6.451612903225807" opacity="1" fill="#F87171" font-weight="bold">
 L4
 </text>
-<polyline fill="none" opacity="0.35" stroke="#F59E0B" stroke-width="1" points="112,166 172,145 233,135 293,126 354,120 415,135 475,149 536,152 596,153 657,163 718,147 778,146 "/>
-<polyline fill="none" opacity="0.35" stroke="#F59E0B" stroke-width="1" points="112,170 172,146 233,137 293,129 354,125 415,140 475,152 536,154 596,155 657,165 718,148 778,147 "/>
-<polyline fill="none" opacity="0.35" stroke="#F59E0B" stroke-width="1" points="112,159 172,144 233,140 293,132 354,131 415,149 475,158 536,160 596,159 657,168 718,152 778,151 "/>
-<polyline fill="none" opacity="0.35" stroke="#F59E0B" stroke-width="1" points="112,173 172,151 233,146 293,140 354,139 415,157 475,162 536,162 596,163 657,171 718,156 778,155 "/>
-<polyline fill="none" opacity="0.35" stroke="#F59E0B" stroke-width="1" points="112,177 172,171 233,159 293,144 354,146 415,165 475,167 536,167 596,167 657,174 718,160 778,158 "/>
-<polyline fill="none" opacity="0.35" stroke="#F59E0B" stroke-width="1" points="112,179 172,175 233,165 293,153 354,156 415,172 475,171 536,171 596,171 657,177 718,163 778,162 "/>
-<polyline fill="none" opacity="0.35" stroke="#F59E0B" stroke-width="1" points="112,183 172,180 233,171 293,165 354,167 415,179 475,177 536,176 596,175 657,180 718,167 778,166 "/>
-<text x="784" y="166" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="6.451612903225807" opacity="1" fill="#F59E0B" font-weight="bold">
+<polyline fill="none" opacity="0.35" stroke="#F59E0B" stroke-width="1" points="112,169 172,144 233,135 293,127 354,120 415,135 475,149 536,152 596,153 657,163 718,147 778,146 "/>
+<polyline fill="none" opacity="0.35" stroke="#F59E0B" stroke-width="1" points="112,172 172,145 233,137 293,130 354,126 415,139 475,152 536,154 596,155 657,165 718,148 778,147 "/>
+<polyline fill="none" opacity="0.35" stroke="#F59E0B" stroke-width="1" points="112,162 172,144 233,140 293,134 354,132 415,149 475,158 536,159 596,159 657,168 718,152 778,152 "/>
+<polyline fill="none" opacity="0.35" stroke="#F59E0B" stroke-width="1" points="112,173 172,151 233,146 293,141 354,140 415,157 475,162 536,162 596,163 657,170 718,156 778,155 "/>
+<polyline fill="none" opacity="0.35" stroke="#F59E0B" stroke-width="1" points="112,178 172,171 233,159 293,146 354,149 415,165 475,167 536,167 596,167 657,174 718,160 778,159 "/>
+<polyline fill="none" opacity="0.35" stroke="#F59E0B" stroke-width="1" points="112,183 172,175 233,165 293,155 354,157 415,173 475,172 536,171 596,171 657,177 718,163 778,163 "/>
+<polyline fill="none" opacity="0.35" stroke="#F59E0B" stroke-width="1" points="112,184 172,179 233,172 293,167 354,169 415,180 475,177 536,176 596,175 657,180 718,167 778,167 "/>
+<text x="784" y="167" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="6.451612903225807" opacity="1" fill="#F59E0B" font-weight="bold">
 L-1
 </text>
-<polyline fill="none" opacity="0.35" stroke="#F59E0B" stroke-width="1" points="112,230 172,213 233,196 293,185 354,181 415,185 475,182 536,178 596,175 657,178 718,168 778,168 "/>
-<polyline fill="none" opacity="0.35" stroke="#F59E0B" stroke-width="1" points="112,244 172,226 233,209 293,198 354,194 415,194 475,185 536,185 596,184 657,213 718,184 778,184 "/>
-<polyline fill="none" opacity="0.35" stroke="#F59E0B" stroke-width="1" points="112,249 172,233 233,223 293,225 354,222 415,221 475,219 536,218 596,217 657,215 718,212 778,210 "/>
-<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="112,159 172,144 233,135 293,126 354,120 415,135 475,149 536,152 596,153 657,163 718,147 778,146 "/>
+<polyline fill="none" opacity="0.35" stroke="#F59E0B" stroke-width="1" points="112,229 172,213 233,196 293,186 354,181 415,185 475,182 536,177 596,174 657,178 718,168 778,170 "/>
+<polyline fill="none" opacity="0.35" stroke="#F59E0B" stroke-width="1" points="112,243 172,225 233,208 293,196 354,191 415,193 475,186 536,186 596,185 657,213 718,184 778,184 "/>
+<polyline fill="none" opacity="0.35" stroke="#F59E0B" stroke-width="1" points="112,248 172,232 233,224 293,225 354,222 415,221 475,219 536,219 596,218 657,215 718,213 778,211 "/>
+<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="112,162 172,144 233,135 293,127 354,120 415,135 475,149 536,152 596,153 657,163 718,147 778,146 "/>
 <polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="112,277 116,276 "/>
 <polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="120,274 125,273 "/>
 <polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="129,271 133,270 "/>
-<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="137,269 142,267 "/>
-<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="146,266 150,264 "/>
-<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="154,263 159,261 "/>
+<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="137,268 142,267 "/>
+<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="146,265 150,264 "/>
+<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="154,262 159,261 "/>
 <polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="163,260 167,258 "/>
 <polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="171,257 172,256 "/>
-<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="172,256 177,256 "/>
-<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="181,255 186,255 "/>
+<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="172,256 177,255 "/>
+<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="181,255 186,254 "/>
 <polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="190,254 195,253 "/>
 <polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="199,253 204,252 "/>
-<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="208,252 213,251 "/>
+<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="208,251 213,251 "/>
 <polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="217,250 222,250 "/>
-<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="226,249 231,249 "/>
+<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="226,249 231,248 "/>
 <polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="233,248 238,248 "/>
 <polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="242,248 247,248 "/>
 <polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="251,248 256,248 "/>
 <polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="260,247 265,247 "/>
 <polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="269,247 274,247 "/>
 <polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="278,247 283,247 "/>
-<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="287,247 292,246 "/>
+<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="287,247 292,247 "/>
 <polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="293,246 298,246 "/>
 <polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="302,246 307,246 "/>
 <polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="311,246 316,246 "/>
 <polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="320,245 325,245 "/>
 <polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="329,245 334,245 "/>
-<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="338,245 343,245 "/>
+<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="338,245 343,244 "/>
 <polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="347,244 352,244 "/>
 <polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="354,244 359,244 "/>
 <polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="363,244 368,244 "/>
 <polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="372,244 377,244 "/>
-<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="381,244 386,244 "/>
-<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="390,244 395,244 "/>
-<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="399,244 404,244 "/>
+<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="381,244 386,245 "/>
+<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="390,245 395,245 "/>
+<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="399,245 404,245 "/>
 <polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="408,245 413,245 "/>
 <polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="415,245 419,243 "/>
 <polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="423,241 427,239 "/>
 <polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="431,238 436,236 "/>
 <polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="439,234 444,232 "/>
-<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="448,230 452,228 "/>
+<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="448,231 452,229 "/>
 <polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="456,227 461,225 "/>
-<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="464,223 469,221 "/>
+<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="464,224 469,222 "/>
 <polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="473,220 475,219 "/>
 <polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="475,219 480,219 "/>
 <polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="484,219 489,219 "/>
@@ -387,40 +389,40 @@ L-1
 <polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="511,219 516,219 "/>
 <polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="520,219 525,219 "/>
 <polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="529,219 534,219 "/>
-<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="536,218 541,218 "/>
-<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="545,218 550,218 "/>
-<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="554,218 559,218 "/>
-<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="563,218 568,218 "/>
-<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="572,218 577,217 "/>
-<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="581,217 586,217 "/>
-<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="590,217 595,217 "/>
-<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="596,217 601,219 "/>
-<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="605,220 609,222 "/>
-<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="613,224 618,225 "/>
+<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="536,219 541,219 "/>
+<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="545,219 550,219 "/>
+<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="554,219 559,219 "/>
+<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="563,219 568,218 "/>
+<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="572,218 577,218 "/>
+<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="581,218 586,218 "/>
+<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="590,218 595,218 "/>
+<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="596,218 601,219 "/>
+<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="605,221 610,223 "/>
+<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="613,224 618,226 "/>
 <polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="622,227 626,229 "/>
 <polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="630,230 635,232 "/>
-<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="638,233 643,235 "/>
-<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="647,237 651,238 "/>
-<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="655,240 657,241 "/>
-<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="657,241 662,238 "/>
-<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="665,237 670,235 "/>
+<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="639,233 643,235 "/>
+<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="647,236 652,238 "/>
+<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="655,240 657,240 "/>
+<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="657,240 662,238 "/>
+<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="665,236 670,234 "/>
 <polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="673,233 678,231 "/>
-<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="681,229 686,227 "/>
+<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="682,229 686,227 "/>
 <polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="690,225 694,223 "/>
-<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="698,221 702,219 "/>
-<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="706,218 710,215 "/>
-<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="714,214 718,212 "/>
-<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="718,212 723,212 "/>
-<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="727,212 732,212 "/>
-<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="736,212 741,211 "/>
-<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="745,211 750,211 "/>
-<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="754,211 759,211 "/>
-<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="763,211 768,211 "/>
+<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="698,222 703,220 "/>
+<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="706,218 711,216 "/>
+<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="714,214 718,213 "/>
+<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="718,213 723,213 "/>
+<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="727,213 732,212 "/>
+<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="736,212 741,212 "/>
+<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="745,212 750,212 "/>
+<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="754,212 759,212 "/>
+<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="763,212 768,211 "/>
 <polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="772,211 777,211 "/>
-<circle cx="112" cy="159" r="3" opacity="1" fill="#F59E0B" stroke="none" stroke-width="1"/>
+<circle cx="112" cy="162" r="3" opacity="1" fill="#F59E0B" stroke="none" stroke-width="1"/>
 <circle cx="172" cy="144" r="3" opacity="1" fill="#F59E0B" stroke="none" stroke-width="1"/>
 <circle cx="233" cy="135" r="3" opacity="1" fill="#F59E0B" stroke="none" stroke-width="1"/>
-<circle cx="293" cy="126" r="3" opacity="1" fill="#F59E0B" stroke="none" stroke-width="1"/>
+<circle cx="293" cy="127" r="3" opacity="1" fill="#F59E0B" stroke="none" stroke-width="1"/>
 <circle cx="354" cy="120" r="3" opacity="1" fill="#F59E0B" stroke="none" stroke-width="1"/>
 <circle cx="415" cy="135" r="3" opacity="1" fill="#F59E0B" stroke="none" stroke-width="1"/>
 <circle cx="475" cy="149" r="3" opacity="1" fill="#F59E0B" stroke="none" stroke-width="1"/>
@@ -439,12 +441,12 @@ L-7
 <circle cx="354" cy="244" r="3" opacity="1" fill="#F59E0B" stroke="none" stroke-width="1"/>
 <circle cx="415" cy="245" r="3" opacity="1" fill="#F59E0B" stroke="none" stroke-width="1"/>
 <circle cx="475" cy="219" r="3" opacity="1" fill="#F59E0B" stroke="none" stroke-width="1"/>
-<circle cx="536" cy="218" r="3" opacity="1" fill="#F59E0B" stroke="none" stroke-width="1"/>
-<circle cx="596" cy="217" r="3" opacity="1" fill="#F59E0B" stroke="none" stroke-width="1"/>
-<circle cx="657" cy="241" r="3" opacity="1" fill="#F59E0B" stroke="none" stroke-width="1"/>
-<circle cx="718" cy="212" r="3" opacity="1" fill="#F59E0B" stroke="none" stroke-width="1"/>
-<circle cx="778" cy="210" r="3" opacity="1" fill="#F59E0B" stroke="none" stroke-width="1"/>
-<text x="784" y="210" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="6.451612903225807" opacity="1" fill="#F59E0B" font-weight="bold">
+<circle cx="536" cy="219" r="3" opacity="1" fill="#F59E0B" stroke="none" stroke-width="1"/>
+<circle cx="596" cy="218" r="3" opacity="1" fill="#F59E0B" stroke="none" stroke-width="1"/>
+<circle cx="657" cy="240" r="3" opacity="1" fill="#F59E0B" stroke="none" stroke-width="1"/>
+<circle cx="718" cy="213" r="3" opacity="1" fill="#F59E0B" stroke="none" stroke-width="1"/>
+<circle cx="778" cy="211" r="3" opacity="1" fill="#F59E0B" stroke="none" stroke-width="1"/>
+<text x="784" y="211" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="6.451612903225807" opacity="1" fill="#F59E0B" font-weight="bold">
 L4
 </text>
 <rect x="90" y="336" width="700" height="220" opacity="1" fill="#161B22" stroke="none"/>
@@ -520,97 +522,97 @@ nci
 <text x="82" y="347" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#7D8590">
 1000
 </text>
-<polyline fill="none" opacity="0.35" stroke="#60A5FA" stroke-width="1" points="112,450 172,415 233,388 293,373 354,357 415,348 475,348 536,344 596,352 657,354 718,358 778,357 "/>
-<polyline fill="none" opacity="0.35" stroke="#60A5FA" stroke-width="1" points="112,448 172,414 233,387 293,374 354,359 415,349 475,350 536,346 596,356 657,358 718,363 778,363 "/>
-<polyline fill="none" opacity="0.35" stroke="#60A5FA" stroke-width="1" points="112,450 172,416 233,391 293,379 354,362 415,354 475,351 536,349 596,359 657,362 718,365 778,365 "/>
-<polyline fill="none" opacity="0.35" stroke="#60A5FA" stroke-width="1" points="112,451 172,417 233,392 293,380 354,364 415,355 475,353 536,353 596,364 657,366 718,369 778,369 "/>
-<polyline fill="none" opacity="0.35" stroke="#60A5FA" stroke-width="1" points="112,451 172,418 233,392 293,382 354,365 415,357 475,354 536,355 596,365 657,366 718,371 778,371 "/>
-<polyline fill="none" opacity="0.35" stroke="#60A5FA" stroke-width="1" points="112,452 172,418 233,392 293,381 354,365 415,357 475,356 536,360 596,368 657,368 718,375 778,375 "/>
-<polyline fill="none" opacity="0.35" stroke="#60A5FA" stroke-width="1" points="112,453 172,420 233,394 293,384 354,368 415,359 475,358 536,360 596,370 657,370 718,377 778,378 "/>
+<polyline fill="none" opacity="0.35" stroke="#60A5FA" stroke-width="1" points="112,450 172,416 233,388 293,374 354,357 415,349 475,348 536,344 596,353 657,355 718,358 778,357 "/>
+<polyline fill="none" opacity="0.35" stroke="#60A5FA" stroke-width="1" points="112,449 172,415 233,388 293,375 354,359 415,350 475,349 536,346 596,357 657,359 718,363 778,363 "/>
+<polyline fill="none" opacity="0.35" stroke="#60A5FA" stroke-width="1" points="112,451 172,417 233,391 293,379 354,362 415,354 475,350 536,349 596,359 657,362 718,366 778,365 "/>
+<polyline fill="none" opacity="0.35" stroke="#60A5FA" stroke-width="1" points="112,451 172,418 233,392 293,381 354,364 415,356 475,353 536,354 596,365 657,366 718,369 778,369 "/>
+<polyline fill="none" opacity="0.35" stroke="#60A5FA" stroke-width="1" points="112,452 172,419 233,392 293,383 354,366 415,357 475,354 536,355 596,365 657,366 718,371 778,371 "/>
+<polyline fill="none" opacity="0.35" stroke="#60A5FA" stroke-width="1" points="112,452 172,420 233,392 293,381 354,365 415,358 475,356 536,360 596,368 657,369 718,375 778,375 "/>
+<polyline fill="none" opacity="0.35" stroke="#60A5FA" stroke-width="1" points="112,454 172,421 233,394 293,384 354,368 415,360 475,358 536,360 596,370 657,371 718,378 778,378 "/>
 <text x="784" y="378" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="6.451612903225807" opacity="1" fill="#60A5FA" font-weight="bold">
 L-1
 </text>
-<polyline fill="none" opacity="0.35" stroke="#60A5FA" stroke-width="1" points="112,486 172,450 233,418 293,401 354,381 415,369 475,365 536,360 596,370 657,371 718,381 778,382 "/>
-<polyline fill="none" opacity="0.35" stroke="#60A5FA" stroke-width="1" points="112,487 172,451 233,419 293,402 354,382 415,371 475,366 536,364 596,372 657,379 718,381 778,384 "/>
-<polyline fill="none" opacity="0.35" stroke="#60A5FA" stroke-width="1" points="112,490 172,455 233,426 293,408 354,389 415,379 475,374 536,369 596,378 657,383 718,389 778,391 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="112,448 172,414 233,387 293,373 354,357 415,348 475,348 536,344 596,352 657,354 718,358 778,357 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="112,498 116,496 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="120,494 124,492 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="128,490 132,488 "/>
+<polyline fill="none" opacity="0.35" stroke="#60A5FA" stroke-width="1" points="112,486 172,450 233,419 293,402 354,382 415,371 475,365 536,360 596,370 657,371 718,381 778,382 "/>
+<polyline fill="none" opacity="0.35" stroke="#60A5FA" stroke-width="1" points="112,488 172,452 233,420 293,403 354,383 415,372 475,366 536,365 596,373 657,380 718,381 778,385 "/>
+<polyline fill="none" opacity="0.35" stroke="#60A5FA" stroke-width="1" points="112,489 172,455 233,427 293,408 354,391 415,380 475,376 536,371 596,380 657,384 718,389 778,391 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="112,449 172,415 233,388 293,374 354,357 415,349 475,348 536,344 596,353 657,355 718,358 778,357 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="112,499 116,496 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="120,495 124,492 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="128,491 132,488 "/>
 <polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="136,486 140,484 "/>
 <polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="144,482 148,480 "/>
 <polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="152,478 156,476 "/>
 <polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="160,474 164,472 "/>
 <polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="168,470 172,468 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="172,468 177,467 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="172,468 177,466 "/>
 <polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="181,465 185,463 "/>
 <polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="189,462 194,460 "/>
 <polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="198,459 202,457 "/>
 <polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="206,456 211,454 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="214,453 219,451 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="215,453 219,451 "/>
 <polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="223,450 228,448 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="231,446 233,446 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="231,447 233,446 "/>
 <polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="233,446 238,445 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="242,444 247,444 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="251,443 255,442 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="259,441 264,441 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="268,440 273,439 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="277,438 282,438 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="286,437 291,436 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="242,445 247,444 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="251,443 256,442 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="259,442 264,441 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="268,440 273,440 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="277,439 282,438 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="286,438 291,437 "/>
 <polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="293,436 298,435 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="302,434 307,433 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="311,432 316,431 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="320,431 325,430 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="329,429 334,428 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="338,427 343,426 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="346,425 351,425 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="354,424 359,424 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="363,423 368,423 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="372,422 377,422 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="381,421 386,421 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="390,421 395,420 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="399,420 404,419 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="408,419 413,418 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="415,418 419,415 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="422,413 426,410 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="430,408 434,406 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="437,403 441,401 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="445,398 449,396 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="452,393 456,391 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="460,388 464,386 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="467,384 471,381 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="475,379 475,378 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="475,378 480,378 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="484,378 489,377 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="493,377 498,377 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="502,376 507,376 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="511,376 516,375 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="520,375 525,375 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="529,374 534,374 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="536,374 541,375 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="545,375 550,376 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="554,376 559,377 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="563,377 568,378 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="572,378 576,379 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="580,380 585,380 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="589,381 594,381 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="596,382 600,385 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="603,388 606,392 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="609,395 612,398 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="615,401 619,405 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="621,408 625,411 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="628,414 631,418 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="634,421 637,424 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="640,427 644,431 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="646,434 650,437 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="653,440 656,444 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="302,435 307,434 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="311,433 316,432 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="320,431 325,431 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="329,430 334,429 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="338,428 343,427 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="346,426 351,426 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="354,425 359,425 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="363,424 368,424 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="372,423 377,423 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="381,423 386,422 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="390,422 395,421 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="399,421 404,421 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="408,420 413,420 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="415,420 419,417 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="422,415 426,412 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="430,410 434,407 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="437,405 441,402 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="445,400 449,397 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="452,395 456,392 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="460,390 464,387 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="467,385 471,382 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="475,380 475,380 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="475,380 480,379 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="484,379 489,379 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="493,379 498,378 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="502,378 507,378 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="511,377 516,377 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="520,377 525,377 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="529,376 534,376 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="536,376 541,377 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="545,377 550,378 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="554,378 559,379 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="563,379 568,380 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="572,380 576,381 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="580,381 585,382 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="589,383 594,383 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="596,383 600,387 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="603,390 606,393 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="609,396 613,400 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="615,403 619,406 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="622,409 625,412 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="628,415 632,419 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="634,422 638,425 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="641,428 644,432 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="647,435 651,438 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="653,441 657,444 "/>
 <polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="657,445 661,441 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="664,439 667,435 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="664,438 667,435 "/>
 <polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="670,432 674,429 "/>
 <polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="677,426 681,423 "/>
 <polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="684,420 687,417 "/>
 <polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="690,414 694,411 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="697,408 700,405 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="697,408 701,405 "/>
 <polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="703,402 707,399 "/>
 <polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="710,396 714,393 "/>
 <polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="717,390 718,389 "/>
@@ -618,66 +620,66 @@ L-1
 <polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="727,389 732,390 "/>
 <polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="736,390 741,390 "/>
 <polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="745,390 750,390 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="754,390 759,391 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="754,390 759,390 "/>
 <polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="763,391 768,391 "/>
 <polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="772,391 777,391 "/>
-<circle cx="112" cy="448" r="3" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
-<circle cx="172" cy="414" r="3" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
-<circle cx="233" cy="387" r="3" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
-<circle cx="293" cy="373" r="3" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
+<circle cx="112" cy="449" r="3" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
+<circle cx="172" cy="415" r="3" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
+<circle cx="233" cy="388" r="3" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
+<circle cx="293" cy="374" r="3" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
 <circle cx="354" cy="357" r="3" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
-<circle cx="415" cy="348" r="3" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
+<circle cx="415" cy="349" r="3" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
 <circle cx="475" cy="348" r="3" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
 <circle cx="536" cy="344" r="3" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
-<circle cx="596" cy="352" r="3" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
-<circle cx="657" cy="354" r="3" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
+<circle cx="596" cy="353" r="3" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
+<circle cx="657" cy="355" r="3" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
 <circle cx="718" cy="358" r="3" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
 <circle cx="778" cy="357" r="3" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
 <text x="784" y="357" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="6.451612903225807" opacity="1" fill="#60A5FA" font-weight="bold">
 L-7
 </text>
-<circle cx="112" cy="498" r="3" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
+<circle cx="112" cy="499" r="3" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
 <circle cx="172" cy="468" r="3" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
 <circle cx="233" cy="446" r="3" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
 <circle cx="293" cy="436" r="3" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
-<circle cx="354" cy="424" r="3" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
-<circle cx="415" cy="418" r="3" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
-<circle cx="475" cy="378" r="3" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
-<circle cx="536" cy="374" r="3" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
-<circle cx="596" cy="382" r="3" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
+<circle cx="354" cy="425" r="3" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
+<circle cx="415" cy="420" r="3" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
+<circle cx="475" cy="380" r="3" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
+<circle cx="536" cy="376" r="3" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
+<circle cx="596" cy="383" r="3" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
 <circle cx="657" cy="445" r="3" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
 <circle cx="718" cy="389" r="3" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
 <circle cx="778" cy="391" r="3" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
 <text x="784" y="391" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="6.451612903225807" opacity="1" fill="#60A5FA" font-weight="bold">
 L4
 </text>
-<polyline fill="none" opacity="0.35" stroke="#F87171" stroke-width="1" points="112,423 172,415 233,390 293,379 354,370 415,364 475,381 536,383 596,382 657,382 718,386 778,386 "/>
-<polyline fill="none" opacity="0.35" stroke="#F87171" stroke-width="1" points="112,422 172,415 233,390 293,377 354,367 415,362 475,381 536,382 596,382 657,382 718,386 778,386 "/>
-<polyline fill="none" opacity="0.35" stroke="#F87171" stroke-width="1" points="112,423 172,415 233,390 293,379 354,370 415,397 475,384 536,386 596,385 657,385 718,389 778,390 "/>
-<polyline fill="none" opacity="0.35" stroke="#F87171" stroke-width="1" points="112,426 172,418 233,395 293,384 354,372 415,398 475,383 536,383 596,384 657,385 718,390 778,391 "/>
-<polyline fill="none" opacity="0.35" stroke="#F87171" stroke-width="1" points="112,425 172,417 233,395 293,387 354,375 415,398 475,387 536,389 596,389 657,389 718,395 778,397 "/>
-<polyline fill="none" opacity="0.35" stroke="#F87171" stroke-width="1" points="112,430 172,421 233,397 293,389 354,378 415,397 475,398 536,390 596,391 657,391 718,397 778,399 "/>
-<polyline fill="none" opacity="0.35" stroke="#F87171" stroke-width="1" points="112,430 172,420 233,397 293,387 354,377 415,394 475,397 536,392 596,393 657,394 718,399 778,401 "/>
+<polyline fill="none" opacity="0.35" stroke="#F87171" stroke-width="1" points="112,423 172,416 233,391 293,380 354,372 415,366 475,381 536,383 596,382 657,382 718,386 778,387 "/>
+<polyline fill="none" opacity="0.35" stroke="#F87171" stroke-width="1" points="112,422 172,415 233,390 293,377 354,369 415,362 475,381 536,382 596,382 657,382 718,386 778,386 "/>
+<polyline fill="none" opacity="0.35" stroke="#F87171" stroke-width="1" points="112,423 172,416 233,391 293,379 354,371 415,397 475,384 536,386 596,385 657,385 718,389 778,390 "/>
+<polyline fill="none" opacity="0.35" stroke="#F87171" stroke-width="1" points="112,426 172,418 233,395 293,384 354,374 415,398 475,383 536,384 596,384 657,386 718,390 778,391 "/>
+<polyline fill="none" opacity="0.35" stroke="#F87171" stroke-width="1" points="112,425 172,418 233,396 293,388 354,377 415,398 475,387 536,389 596,390 657,390 718,395 778,397 "/>
+<polyline fill="none" opacity="0.35" stroke="#F87171" stroke-width="1" points="112,430 172,421 233,398 293,389 354,379 415,397 475,397 536,390 596,391 657,391 718,397 778,399 "/>
+<polyline fill="none" opacity="0.35" stroke="#F87171" stroke-width="1" points="112,432 172,421 233,397 293,387 354,379 415,395 475,397 536,393 596,393 657,394 718,399 778,401 "/>
 <text x="784" y="401" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="6.451612903225807" opacity="1" fill="#F87171" font-weight="bold">
 L-1
 </text>
-<polyline fill="none" opacity="0.35" stroke="#F87171" stroke-width="1" points="112,478 172,454 233,445 293,430 354,409 415,397 475,402 536,397 596,397 657,399 718,405 778,407 "/>
-<polyline fill="none" opacity="0.35" stroke="#F87171" stroke-width="1" points="112,477 172,454 233,445 293,430 354,409 415,396 475,401 536,399 596,400 657,401 718,407 778,408 "/>
-<polyline fill="none" opacity="0.35" stroke="#F87171" stroke-width="1" points="112,483 172,458 233,450 293,436 354,417 415,406 475,415 536,410 596,410 657,411 718,414 778,414 "/>
-<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="112,422 172,415 233,390 293,377 354,367 415,362 475,363 536,365 596,372 657,373 718,376 778,376 "/>
-<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="112,483 116,481 "/>
-<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="120,480 125,478 "/>
-<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="128,476 133,474 "/>
-<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="137,473 141,471 "/>
-<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="145,470 150,468 "/>
-<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="153,466 158,465 "/>
-<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="162,463 166,461 "/>
-<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="170,460 172,459 "/>
-<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="172,459 177,458 "/>
-<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="181,458 186,457 "/>
-<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="190,456 195,456 "/>
-<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="199,455 204,454 "/>
-<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="208,454 213,453 "/>
+<polyline fill="none" opacity="0.35" stroke="#F87171" stroke-width="1" points="112,478 172,453 233,444 293,428 354,408 415,398 475,400 536,397 596,397 657,399 718,405 778,407 "/>
+<polyline fill="none" opacity="0.35" stroke="#F87171" stroke-width="1" points="112,478 172,453 233,444 293,428 354,408 415,398 475,402 536,399 596,400 657,400 718,405 778,407 "/>
+<polyline fill="none" opacity="0.35" stroke="#F87171" stroke-width="1" points="112,482 172,458 233,450 293,436 354,416 415,406 475,413 536,409 596,410 657,411 718,414 778,414 "/>
+<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="112,422 172,415 233,390 293,377 354,369 415,362 475,367 536,369 596,372 657,373 718,376 778,377 "/>
+<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="112,482 116,480 "/>
+<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="120,479 125,477 "/>
+<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="128,475 133,473 "/>
+<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="137,472 141,470 "/>
+<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="145,469 150,467 "/>
+<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="153,465 158,463 "/>
+<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="162,462 166,460 "/>
+<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="170,459 172,458 "/>
+<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="172,458 177,457 "/>
+<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="181,457 186,456 "/>
+<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="190,456 195,455 "/>
+<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="199,454 204,454 "/>
+<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="208,453 213,453 "/>
 <polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="217,452 222,452 "/>
 <polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="226,451 231,450 "/>
 <polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="233,450 238,449 "/>
@@ -685,47 +687,47 @@ L-1
 <polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="250,446 255,445 "/>
 <polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="259,444 264,443 "/>
 <polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="268,442 273,441 "/>
-<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="277,440 282,439 "/>
+<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="277,440 281,439 "/>
 <polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="285,438 290,437 "/>
 <polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="293,436 298,435 "/>
 <polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="302,433 307,432 "/>
-<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="311,431 315,429 "/>
+<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="310,430 315,429 "/>
 <polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="319,428 324,426 "/>
-<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="328,425 332,424 "/>
-<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="336,423 341,421 "/>
-<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="345,420 350,418 "/>
-<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="353,417 354,417 "/>
-<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="354,417 359,416 "/>
+<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="328,425 332,423 "/>
+<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="336,422 341,420 "/>
+<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="345,419 349,418 "/>
+<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="353,416 354,416 "/>
+<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="354,416 359,415 "/>
 <polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="363,415 368,414 "/>
-<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="372,414 377,413 "/>
-<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="381,412 385,411 "/>
-<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="389,410 394,410 "/>
+<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="372,413 377,412 "/>
+<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="381,412 386,411 "/>
+<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="389,410 394,409 "/>
 <polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="398,409 403,408 "/>
 <polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="407,407 412,406 "/>
 <polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="415,406 420,407 "/>
-<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="423,407 428,408 "/>
+<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="424,407 428,408 "/>
 <polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="432,408 437,409 "/>
-<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="441,410 446,411 "/>
-<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="450,411 455,412 "/>
-<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="459,412 464,413 "/>
-<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="468,414 473,415 "/>
-<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="475,415 480,414 "/>
-<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="484,414 489,414 "/>
-<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="493,413 498,413 "/>
-<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="502,413 507,412 "/>
-<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="511,412 516,412 "/>
-<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="520,411 525,411 "/>
-<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="529,411 534,410 "/>
-<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="536,410 541,410 "/>
-<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="545,410 550,410 "/>
-<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="554,410 559,410 "/>
-<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="563,410 568,410 "/>
+<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="441,409 446,410 "/>
+<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="450,410 455,411 "/>
+<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="459,411 464,412 "/>
+<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="468,412 473,413 "/>
+<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="475,413 480,413 "/>
+<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="484,413 489,412 "/>
+<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="493,412 498,412 "/>
+<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="502,411 507,411 "/>
+<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="511,411 516,410 "/>
+<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="520,410 525,410 "/>
+<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="529,409 534,409 "/>
+<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="536,409 541,409 "/>
+<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="545,409 550,409 "/>
+<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="554,409 559,409 "/>
+<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="563,409 568,409 "/>
 <polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="572,410 577,410 "/>
 <polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="581,410 586,410 "/>
 <polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="590,410 595,410 "/>
 <polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="596,410 601,410 "/>
 <polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="605,410 610,410 "/>
-<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="614,411 619,411 "/>
+<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="614,410 619,410 "/>
 <polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="623,411 628,411 "/>
 <polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="632,411 637,411 "/>
 <polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="641,411 646,411 "/>
@@ -734,9 +736,9 @@ L-1
 <polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="666,412 671,412 "/>
 <polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="675,413 680,413 "/>
 <polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="684,413 689,414 "/>
-<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="693,414 698,414 "/>
+<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="693,414 698,415 "/>
 <polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="702,415 707,415 "/>
-<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="711,415 716,416 "/>
+<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="711,416 716,416 "/>
 <polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="718,416 723,416 "/>
 <polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="727,416 732,416 "/>
 <polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="736,416 741,416 "/>
@@ -748,25 +750,25 @@ L-1
 <circle cx="172" cy="415" r="3" opacity="1" fill="#F87171" stroke="none" stroke-width="1"/>
 <circle cx="233" cy="390" r="3" opacity="1" fill="#F87171" stroke="none" stroke-width="1"/>
 <circle cx="293" cy="377" r="3" opacity="1" fill="#F87171" stroke="none" stroke-width="1"/>
-<circle cx="354" cy="367" r="3" opacity="1" fill="#F87171" stroke="none" stroke-width="1"/>
+<circle cx="354" cy="369" r="3" opacity="1" fill="#F87171" stroke="none" stroke-width="1"/>
 <circle cx="415" cy="362" r="3" opacity="1" fill="#F87171" stroke="none" stroke-width="1"/>
-<circle cx="475" cy="363" r="3" opacity="1" fill="#F87171" stroke="none" stroke-width="1"/>
-<circle cx="536" cy="365" r="3" opacity="1" fill="#F87171" stroke="none" stroke-width="1"/>
+<circle cx="475" cy="367" r="3" opacity="1" fill="#F87171" stroke="none" stroke-width="1"/>
+<circle cx="536" cy="369" r="3" opacity="1" fill="#F87171" stroke="none" stroke-width="1"/>
 <circle cx="596" cy="372" r="3" opacity="1" fill="#F87171" stroke="none" stroke-width="1"/>
 <circle cx="657" cy="373" r="3" opacity="1" fill="#F87171" stroke="none" stroke-width="1"/>
 <circle cx="718" cy="376" r="3" opacity="1" fill="#F87171" stroke="none" stroke-width="1"/>
-<circle cx="778" cy="376" r="3" opacity="1" fill="#F87171" stroke="none" stroke-width="1"/>
-<text x="784" y="376" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="6.451612903225807" opacity="1" fill="#F87171" font-weight="bold">
+<circle cx="778" cy="377" r="3" opacity="1" fill="#F87171" stroke="none" stroke-width="1"/>
+<text x="784" y="377" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="6.451612903225807" opacity="1" fill="#F87171" font-weight="bold">
 L-8
 </text>
-<circle cx="112" cy="483" r="3" opacity="1" fill="#F87171" stroke="none" stroke-width="1"/>
-<circle cx="172" cy="459" r="3" opacity="1" fill="#F87171" stroke="none" stroke-width="1"/>
+<circle cx="112" cy="482" r="3" opacity="1" fill="#F87171" stroke="none" stroke-width="1"/>
+<circle cx="172" cy="458" r="3" opacity="1" fill="#F87171" stroke="none" stroke-width="1"/>
 <circle cx="233" cy="450" r="3" opacity="1" fill="#F87171" stroke="none" stroke-width="1"/>
 <circle cx="293" cy="436" r="3" opacity="1" fill="#F87171" stroke="none" stroke-width="1"/>
-<circle cx="354" cy="417" r="3" opacity="1" fill="#F87171" stroke="none" stroke-width="1"/>
+<circle cx="354" cy="416" r="3" opacity="1" fill="#F87171" stroke="none" stroke-width="1"/>
 <circle cx="415" cy="406" r="3" opacity="1" fill="#F87171" stroke="none" stroke-width="1"/>
-<circle cx="475" cy="415" r="3" opacity="1" fill="#F87171" stroke="none" stroke-width="1"/>
-<circle cx="536" cy="410" r="3" opacity="1" fill="#F87171" stroke="none" stroke-width="1"/>
+<circle cx="475" cy="413" r="3" opacity="1" fill="#F87171" stroke="none" stroke-width="1"/>
+<circle cx="536" cy="409" r="3" opacity="1" fill="#F87171" stroke="none" stroke-width="1"/>
 <circle cx="596" cy="410" r="3" opacity="1" fill="#F87171" stroke="none" stroke-width="1"/>
 <circle cx="657" cy="411" r="3" opacity="1" fill="#F87171" stroke="none" stroke-width="1"/>
 <circle cx="718" cy="416" r="3" opacity="1" fill="#F87171" stroke="none" stroke-width="1"/>
@@ -774,53 +776,53 @@ L-8
 <text x="784" y="417" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="6.451612903225807" opacity="1" fill="#F87171" font-weight="bold">
 L4
 </text>
-<polyline fill="none" opacity="0.35" stroke="#F59E0B" stroke-width="1" points="112,498 172,463 233,445 293,431 354,409 415,396 475,398 536,398 596,399 657,400 718,402 778,401 "/>
-<polyline fill="none" opacity="0.35" stroke="#F59E0B" stroke-width="1" points="112,494 172,476 233,444 293,424 354,410 415,398 475,400 536,399 596,402 657,402 718,406 778,405 "/>
-<polyline fill="none" opacity="0.35" stroke="#F59E0B" stroke-width="1" points="112,512 172,477 233,448 293,427 354,413 415,402 475,401 536,402 596,403 657,405 718,407 778,406 "/>
-<polyline fill="none" opacity="0.35" stroke="#F59E0B" stroke-width="1" points="112,497 172,478 233,448 293,428 354,415 415,405 475,405 536,404 596,408 657,408 718,410 778,409 "/>
-<polyline fill="none" opacity="0.35" stroke="#F59E0B" stroke-width="1" points="112,499 172,465 233,449 293,430 354,416 415,407 475,409 536,407 596,410 657,409 718,412 778,412 "/>
-<polyline fill="none" opacity="0.35" stroke="#F59E0B" stroke-width="1" points="112,499 172,478 233,448 293,429 354,416 415,407 475,411 536,410 596,412 657,411 718,414 778,414 "/>
-<polyline fill="none" opacity="0.35" stroke="#F59E0B" stroke-width="1" points="112,500 172,479 233,450 293,431 354,417 415,410 475,413 536,410 596,413 657,413 718,417 778,417 "/>
+<polyline fill="none" opacity="0.35" stroke="#F59E0B" stroke-width="1" points="112,496 172,462 233,445 293,432 354,408 415,396 475,398 536,398 596,399 657,400 718,402 778,401 "/>
+<polyline fill="none" opacity="0.35" stroke="#F59E0B" stroke-width="1" points="112,494 172,475 233,444 293,424 354,410 415,398 475,399 536,399 596,401 657,402 718,406 778,405 "/>
+<polyline fill="none" opacity="0.35" stroke="#F59E0B" stroke-width="1" points="112,511 172,476 233,447 293,427 354,412 415,401 475,401 536,402 596,403 657,404 718,407 778,406 "/>
+<polyline fill="none" opacity="0.35" stroke="#F59E0B" stroke-width="1" points="112,496 172,477 233,448 293,428 354,414 415,404 475,406 536,405 596,407 657,408 718,409 778,409 "/>
+<polyline fill="none" opacity="0.35" stroke="#F59E0B" stroke-width="1" points="112,498 172,464 233,449 293,431 354,415 415,406 475,409 536,407 596,409 657,409 718,412 778,411 "/>
+<polyline fill="none" opacity="0.35" stroke="#F59E0B" stroke-width="1" points="112,499 172,478 233,449 293,429 354,415 415,407 475,412 536,410 596,411 657,410 718,414 778,414 "/>
+<polyline fill="none" opacity="0.35" stroke="#F59E0B" stroke-width="1" points="112,499 172,478 233,449 293,431 354,417 415,409 475,413 536,410 596,413 657,413 718,416 778,417 "/>
 <text x="784" y="417" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="6.451612903225807" opacity="1" fill="#F59E0B" font-weight="bold">
 L-1
 </text>
-<polyline fill="none" opacity="0.35" stroke="#F59E0B" stroke-width="1" points="112,532 172,504 233,472 293,449 354,432 415,423 475,421 536,413 596,416 657,416 718,419 778,420 "/>
-<polyline fill="none" opacity="0.35" stroke="#F59E0B" stroke-width="1" points="112,532 172,505 233,472 293,450 354,433 415,424 475,422 536,413 596,415 657,435 718,420 778,421 "/>
-<polyline fill="none" opacity="0.35" stroke="#F59E0B" stroke-width="1" points="112,540 172,511 233,481 293,464 354,452 415,443 475,442 536,432 596,434 657,434 718,439 778,441 "/>
-<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="112,494 172,463 233,444 293,424 354,409 415,396 475,398 536,398 596,399 657,400 718,402 778,401 "/>
+<polyline fill="none" opacity="0.35" stroke="#F59E0B" stroke-width="1" points="112,531 172,503 233,471 293,449 354,432 415,423 475,420 536,412 596,415 657,416 718,419 778,420 "/>
+<polyline fill="none" opacity="0.35" stroke="#F59E0B" stroke-width="1" points="112,531 172,504 233,471 293,449 354,433 415,424 475,422 536,413 596,414 657,435 718,420 778,422 "/>
+<polyline fill="none" opacity="0.35" stroke="#F59E0B" stroke-width="1" points="112,538 172,511 233,481 293,465 354,451 415,443 475,442 536,432 596,434 657,434 718,439 778,441 "/>
+<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="112,494 172,462 233,444 293,424 354,408 415,396 475,398 536,398 596,399 657,400 718,402 778,401 "/>
 <polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="112,548 116,546 "/>
 <polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="120,544 124,542 "/>
-<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="128,540 133,539 "/>
+<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="128,540 133,538 "/>
 <polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="136,537 141,535 "/>
 <polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="145,533 149,531 "/>
-<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="153,530 158,528 "/>
+<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="153,530 157,528 "/>
 <polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="161,526 166,524 "/>
-<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="170,523 172,522 "/>
-<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="172,522 177,520 "/>
+<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="169,523 172,521 "/>
+<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="172,521 177,519 "/>
 <polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="180,518 185,516 "/>
-<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="189,515 193,513 "/>
+<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="189,514 193,512 "/>
 <polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="197,511 202,509 "/>
-<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="205,508 210,506 "/>
+<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="205,507 210,505 "/>
 <polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="214,504 218,502 "/>
-<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="222,500 226,498 "/>
+<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="222,500 227,498 "/>
 <polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="230,497 233,496 "/>
 <polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="233,496 238,495 "/>
 <polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="242,494 247,493 "/>
-<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="251,493 255,492 "/>
+<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="251,492 255,492 "/>
 <polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="259,491 264,490 "/>
-<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="268,490 273,489 "/>
+<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="268,489 273,488 "/>
 <polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="277,488 282,487 "/>
-<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="286,486 291,486 "/>
-<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="293,485 298,485 "/>
+<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="286,486 291,485 "/>
+<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="293,485 298,484 "/>
 <polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="302,484 307,484 "/>
-<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="311,484 316,483 "/>
-<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="320,483 325,483 "/>
-<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="329,482 334,482 "/>
-<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="338,481 343,481 "/>
-<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="347,481 352,480 "/>
-<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="354,480 359,480 "/>
-<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="363,480 368,480 "/>
-<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="372,480 377,480 "/>
+<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="311,483 316,483 "/>
+<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="320,482 325,482 "/>
+<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="329,482 334,481 "/>
+<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="338,481 343,480 "/>
+<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="347,480 352,480 "/>
+<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="354,479 359,479 "/>
+<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="363,479 368,479 "/>
+<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="372,479 377,480 "/>
 <polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="381,480 386,480 "/>
 <polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="390,480 395,480 "/>
 <polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="399,480 404,480 "/>
@@ -829,53 +831,53 @@ L-1
 <polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="422,475 427,472 "/>
 <polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="430,470 434,467 "/>
 <polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="438,465 442,463 "/>
-<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="445,461 450,458 "/>
+<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="445,461 449,458 "/>
 <polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="453,456 457,453 "/>
 <polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="461,451 465,449 "/>
-<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="468,447 473,444 "/>
+<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="468,446 472,444 "/>
 <polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="475,442 480,441 "/>
 <polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="484,441 489,440 "/>
 <polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="493,439 498,439 "/>
 <polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="502,438 507,437 "/>
 <polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="511,437 516,436 "/>
 <polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="520,435 525,435 "/>
-<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="529,434 533,433 "/>
+<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="529,434 534,433 "/>
 <polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="536,433 541,433 "/>
-<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="545,433 550,433 "/>
-<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="554,433 559,434 "/>
+<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="545,433 550,434 "/>
+<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="554,434 559,434 "/>
 <polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="563,434 568,434 "/>
-<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="572,434 577,434 "/>
+<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="572,435 577,435 "/>
 <polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="581,435 586,435 "/>
-<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="590,435 595,435 "/>
-<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="596,435 601,438 "/>
-<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="604,440 608,443 "/>
-<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="611,445 615,448 "/>
-<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="619,450 623,453 "/>
-<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="626,455 630,458 "/>
-<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="634,460 638,463 "/>
-<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="641,465 645,468 "/>
-<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="649,470 653,473 "/>
-<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="656,475 657,476 "/>
-<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="657,476 661,474 "/>
+<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="590,435 595,436 "/>
+<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="596,436 601,438 "/>
+<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="604,441 608,443 "/>
+<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="611,446 616,448 "/>
+<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="619,451 623,453 "/>
+<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="626,456 631,458 "/>
+<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="634,461 638,463 "/>
+<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="641,466 646,468 "/>
+<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="649,471 653,473 "/>
+<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="656,476 657,476 "/>
+<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="657,476 661,473 "/>
 <polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="665,471 669,469 "/>
 <polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="672,467 677,464 "/>
-<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="680,462 684,460 "/>
+<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="680,462 684,459 "/>
 <polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="688,457 692,455 "/>
 <polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="695,453 700,450 "/>
-<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="703,448 707,446 "/>
+<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="703,448 707,445 "/>
 <polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="711,443 715,441 "/>
-<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="718,439 723,440 "/>
-<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="727,440 732,440 "/>
+<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="718,439 723,439 "/>
+<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="727,439 732,440 "/>
 <polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="736,440 741,440 "/>
 <polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="745,440 750,440 "/>
 <polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="754,440 759,440 "/>
-<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="763,441 768,441 "/>
+<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="763,440 768,441 "/>
 <polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="772,441 777,441 "/>
 <circle cx="112" cy="494" r="3" opacity="1" fill="#F59E0B" stroke="none" stroke-width="1"/>
-<circle cx="172" cy="463" r="3" opacity="1" fill="#F59E0B" stroke="none" stroke-width="1"/>
+<circle cx="172" cy="462" r="3" opacity="1" fill="#F59E0B" stroke="none" stroke-width="1"/>
 <circle cx="233" cy="444" r="3" opacity="1" fill="#F59E0B" stroke="none" stroke-width="1"/>
 <circle cx="293" cy="424" r="3" opacity="1" fill="#F59E0B" stroke="none" stroke-width="1"/>
-<circle cx="354" cy="409" r="3" opacity="1" fill="#F59E0B" stroke="none" stroke-width="1"/>
+<circle cx="354" cy="408" r="3" opacity="1" fill="#F59E0B" stroke="none" stroke-width="1"/>
 <circle cx="415" cy="396" r="3" opacity="1" fill="#F59E0B" stroke="none" stroke-width="1"/>
 <circle cx="475" cy="398" r="3" opacity="1" fill="#F59E0B" stroke="none" stroke-width="1"/>
 <circle cx="536" cy="398" r="3" opacity="1" fill="#F59E0B" stroke="none" stroke-width="1"/>
@@ -887,14 +889,14 @@ L-1
 L-7
 </text>
 <circle cx="112" cy="548" r="3" opacity="1" fill="#F59E0B" stroke="none" stroke-width="1"/>
-<circle cx="172" cy="522" r="3" opacity="1" fill="#F59E0B" stroke="none" stroke-width="1"/>
+<circle cx="172" cy="521" r="3" opacity="1" fill="#F59E0B" stroke="none" stroke-width="1"/>
 <circle cx="233" cy="496" r="3" opacity="1" fill="#F59E0B" stroke="none" stroke-width="1"/>
 <circle cx="293" cy="485" r="3" opacity="1" fill="#F59E0B" stroke="none" stroke-width="1"/>
-<circle cx="354" cy="480" r="3" opacity="1" fill="#F59E0B" stroke="none" stroke-width="1"/>
+<circle cx="354" cy="479" r="3" opacity="1" fill="#F59E0B" stroke="none" stroke-width="1"/>
 <circle cx="415" cy="480" r="3" opacity="1" fill="#F59E0B" stroke="none" stroke-width="1"/>
 <circle cx="475" cy="442" r="3" opacity="1" fill="#F59E0B" stroke="none" stroke-width="1"/>
 <circle cx="536" cy="433" r="3" opacity="1" fill="#F59E0B" stroke="none" stroke-width="1"/>
-<circle cx="596" cy="435" r="3" opacity="1" fill="#F59E0B" stroke="none" stroke-width="1"/>
+<circle cx="596" cy="436" r="3" opacity="1" fill="#F59E0B" stroke="none" stroke-width="1"/>
 <circle cx="657" cy="476" r="3" opacity="1" fill="#F59E0B" stroke="none" stroke-width="1"/>
 <circle cx="718" cy="439" r="3" opacity="1" fill="#F59E0B" stroke="none" stroke-width="1"/>
 <circle cx="778" cy="441" r="3" opacity="1" fill="#F59E0B" stroke="none" stroke-width="1"/>
@@ -974,36 +976,36 @@ xml
 <text x="82" y="613" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#7D8590">
 1000
 </text>
-<polyline fill="none" opacity="0.35" stroke="#60A5FA" stroke-width="1" points="112,717 172,686 233,671 293,653 354,640 415,624 475,618 536,623 596,634 657,635 718,616 778,651 "/>
-<polyline fill="none" opacity="0.35" stroke="#60A5FA" stroke-width="1" points="112,717 172,688 233,671 293,658 354,642 415,628 475,619 536,624 596,635 657,636 718,617 778,652 "/>
-<polyline fill="none" opacity="0.35" stroke="#60A5FA" stroke-width="1" points="112,711 172,692 233,679 293,656 354,641 415,626 475,624 536,626 596,635 657,637 718,616 778,653 "/>
-<polyline fill="none" opacity="0.35" stroke="#60A5FA" stroke-width="1" points="112,712 172,692 233,682 293,662 354,644 415,627 475,618 536,622 596,632 657,635 718,617 778,655 "/>
-<polyline fill="none" opacity="0.35" stroke="#60A5FA" stroke-width="1" points="112,718 172,696 233,680 293,662 354,641 415,625 475,615 536,619 596,632 657,636 718,616 778,657 "/>
-<polyline fill="none" opacity="0.35" stroke="#60A5FA" stroke-width="1" points="112,720 172,700 233,686 293,662 354,644 415,626 475,618 536,623 596,635 657,637 718,619 778,660 "/>
-<polyline fill="none" opacity="0.35" stroke="#60A5FA" stroke-width="1" points="112,721 172,704 233,690 293,664 354,646 415,628 475,621 536,627 596,637 657,638 718,621 778,664 "/>
+<polyline fill="none" opacity="0.35" stroke="#60A5FA" stroke-width="1" points="112,717 172,687 233,671 293,654 354,640 415,625 475,618 536,624 596,634 657,636 718,617 778,650 "/>
+<polyline fill="none" opacity="0.35" stroke="#60A5FA" stroke-width="1" points="112,718 172,689 233,671 293,659 354,642 415,628 475,618 536,624 596,635 657,636 718,618 778,652 "/>
+<polyline fill="none" opacity="0.35" stroke="#60A5FA" stroke-width="1" points="112,712 172,692 233,679 293,656 354,641 415,627 475,625 536,626 596,636 657,637 718,617 778,653 "/>
+<polyline fill="none" opacity="0.35" stroke="#60A5FA" stroke-width="1" points="112,713 172,692 233,683 293,663 354,643 415,627 475,620 536,622 596,633 657,635 718,617 778,655 "/>
+<polyline fill="none" opacity="0.35" stroke="#60A5FA" stroke-width="1" points="112,719 172,696 233,680 293,663 354,641 415,625 475,615 536,619 596,633 657,636 718,617 778,657 "/>
+<polyline fill="none" opacity="0.35" stroke="#60A5FA" stroke-width="1" points="112,721 172,700 233,686 293,662 354,644 415,626 475,619 536,623 596,636 657,637 718,619 778,661 "/>
+<polyline fill="none" opacity="0.35" stroke="#60A5FA" stroke-width="1" points="112,722 172,705 233,690 293,664 354,646 415,628 475,621 536,627 596,638 657,639 718,621 778,664 "/>
 <text x="784" y="664" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="6.451612903225807" opacity="1" fill="#60A5FA" font-weight="bold">
 L-1
 </text>
-<polyline fill="none" opacity="0.35" stroke="#60A5FA" stroke-width="1" points="112,761 172,738 233,714 293,683 354,661 415,641 475,628 536,626 596,635 657,635 718,618 778,667 "/>
-<polyline fill="none" opacity="0.35" stroke="#60A5FA" stroke-width="1" points="112,761 172,739 233,715 293,685 354,663 415,645 475,632 536,633 596,639 657,640 718,622 778,679 "/>
-<polyline fill="none" opacity="0.35" stroke="#60A5FA" stroke-width="1" points="112,765 172,746 233,722 293,691 354,667 415,651 475,641 536,642 596,646 657,641 718,625 778,690 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="112,711 172,686 233,671 293,653 354,640 415,624 475,615 536,619 596,632 657,635 718,616 778,651 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="112,774 117,774 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="121,774 126,774 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="130,773 135,773 "/>
+<polyline fill="none" opacity="0.35" stroke="#60A5FA" stroke-width="1" points="112,762 172,739 233,714 293,684 354,661 415,641 475,628 536,626 596,636 657,636 718,619 778,667 "/>
+<polyline fill="none" opacity="0.35" stroke="#60A5FA" stroke-width="1" points="112,761 172,740 233,716 293,685 354,663 415,646 475,632 536,634 596,641 657,641 718,623 778,679 "/>
+<polyline fill="none" opacity="0.35" stroke="#60A5FA" stroke-width="1" points="112,765 172,746 233,723 293,691 354,668 415,652 475,643 536,643 596,648 657,642 718,626 778,689 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="112,712 172,687 233,671 293,654 354,640 415,625 475,615 536,619 596,633 657,635 718,617 778,650 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="112,775 117,775 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="121,775 126,774 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="130,774 135,774 "/>
 <polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="139,773 144,773 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="148,772 153,772 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="157,772 161,772 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="165,771 170,771 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="172,771 177,769 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="181,768 185,766 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="148,773 152,772 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="156,772 161,772 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="165,772 170,771 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="172,771 177,770 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="181,768 185,767 "/>
 <polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="189,765 194,764 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="198,762 203,761 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="206,759 211,758 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="198,763 202,761 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="206,760 211,758 "/>
 <polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="215,757 220,755 "/>
 <polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="223,754 228,752 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="232,751 233,750 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="233,750 237,749 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="232,751 233,751 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="233,751 237,749 "/>
 <polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="241,747 246,745 "/>
 <polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="249,744 254,742 "/>
 <polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="258,740 262,738 "/>
@@ -1013,210 +1015,210 @@ L-1
 <polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="291,726 293,725 "/>
 <polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="293,725 298,724 "/>
 <polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="302,723 307,722 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="311,721 316,719 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="320,718 324,717 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="311,721 316,720 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="320,719 324,717 "/>
 <polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="328,716 333,715 "/>
 <polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="337,714 342,713 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="346,712 350,710 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="354,709 359,709 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="363,708 368,707 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="372,707 377,706 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="381,706 386,705 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="390,704 395,704 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="399,703 403,702 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="407,702 412,701 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="415,701 418,697 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="421,695 425,691 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="428,688 431,685 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="434,682 438,679 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="441,676 445,673 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="447,670 451,666 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="454,664 458,660 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="461,658 464,654 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="467,651 471,648 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="474,645 475,644 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="475,644 480,644 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="484,644 489,644 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="493,644 498,644 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="502,644 507,644 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="511,644 516,643 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="520,643 525,643 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="529,643 534,643 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="536,643 541,644 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="545,644 550,644 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="554,645 559,645 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="563,645 568,645 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="572,646 577,646 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="581,646 586,647 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="590,647 595,647 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="596,647 600,651 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="602,654 606,658 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="609,661 612,664 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="615,667 618,671 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="621,674 624,678 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="627,681 630,684 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="633,687 636,691 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="639,694 642,698 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="645,701 648,704 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="651,707 654,711 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="346,712 351,711 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="354,710 359,709 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="363,709 368,708 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="372,708 377,707 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="381,706 386,706 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="390,705 395,705 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="399,704 404,704 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="408,703 413,703 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="415,702 418,699 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="421,696 425,693 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="428,690 431,687 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="434,684 438,680 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="441,678 445,674 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="447,672 451,668 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="454,665 458,662 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="461,659 464,656 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="467,653 471,650 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="474,647 475,645 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="475,645 480,645 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="484,645 489,645 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="493,645 498,645 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="502,645 507,645 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="511,645 516,645 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="520,645 525,645 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="529,645 534,645 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="536,645 541,646 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="545,646 550,646 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="554,647 559,647 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="563,647 568,648 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="572,648 577,648 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="581,649 586,649 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="590,649 595,650 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="596,650 600,654 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="603,656 606,660 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="609,663 612,667 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="615,670 618,673 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="621,676 625,680 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="627,683 631,686 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="634,689 637,693 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="640,696 643,699 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="646,702 649,706 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="652,709 656,712 "/>
 <polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="657,714 660,710 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="662,706 665,702 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="662,707 665,702 "/>
 <polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="667,699 670,695 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="672,691 675,687 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="672,692 675,688 "/>
 <polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="677,684 680,680 "/>
 <polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="682,677 685,673 "/>
 <polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="688,669 690,665 "/>
 <polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="693,662 695,658 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="698,654 701,650 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="698,655 701,651 "/>
 <polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="703,647 706,643 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="708,640 711,635 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="708,640 711,636 "/>
 <polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="713,632 716,628 "/>
 <polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="718,626 721,629 "/>
 <polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="724,632 727,636 "/>
 <polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="730,639 733,642 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="736,645 739,649 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="736,645 740,649 "/>
 <polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="742,652 746,655 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="748,658 752,662 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="755,665 758,669 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="749,658 752,662 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="755,665 758,668 "/>
 <polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="761,671 764,675 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="767,678 770,682 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="773,685 776,688 "/>
-<circle cx="112" cy="711" r="3" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
-<circle cx="172" cy="686" r="3" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="767,678 771,682 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="773,684 777,688 "/>
+<circle cx="112" cy="712" r="3" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
+<circle cx="172" cy="687" r="3" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
 <circle cx="233" cy="671" r="3" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
-<circle cx="293" cy="653" r="3" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
+<circle cx="293" cy="654" r="3" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
 <circle cx="354" cy="640" r="3" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
-<circle cx="415" cy="624" r="3" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
+<circle cx="415" cy="625" r="3" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
 <circle cx="475" cy="615" r="3" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
 <circle cx="536" cy="619" r="3" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
-<circle cx="596" cy="632" r="3" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
+<circle cx="596" cy="633" r="3" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
 <circle cx="657" cy="635" r="3" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
-<circle cx="718" cy="616" r="3" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
-<circle cx="778" cy="651" r="3" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
-<text x="784" y="651" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="6.451612903225807" opacity="1" fill="#60A5FA" font-weight="bold">
+<circle cx="718" cy="617" r="3" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
+<circle cx="778" cy="650" r="3" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
+<text x="784" y="650" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="6.451612903225807" opacity="1" fill="#60A5FA" font-weight="bold">
 L-7
 </text>
-<circle cx="112" cy="774" r="3" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
+<circle cx="112" cy="775" r="3" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
 <circle cx="172" cy="771" r="3" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
-<circle cx="233" cy="750" r="3" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
+<circle cx="233" cy="751" r="3" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
 <circle cx="293" cy="725" r="3" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
-<circle cx="354" cy="709" r="3" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
-<circle cx="415" cy="701" r="3" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
-<circle cx="475" cy="644" r="3" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
-<circle cx="536" cy="643" r="3" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
-<circle cx="596" cy="647" r="3" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
+<circle cx="354" cy="710" r="3" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
+<circle cx="415" cy="702" r="3" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
+<circle cx="475" cy="645" r="3" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
+<circle cx="536" cy="645" r="3" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
+<circle cx="596" cy="650" r="3" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
 <circle cx="657" cy="714" r="3" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
 <circle cx="718" cy="626" r="3" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
 <circle cx="778" cy="690" r="3" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
 <text x="784" y="690" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="6.451612903225807" opacity="1" fill="#60A5FA" font-weight="bold">
 L4
 </text>
-<polyline fill="none" opacity="0.35" stroke="#F87171" stroke-width="1" points="112,679 172,691 233,679 293,666 354,653 415,641 475,658 536,656 596,659 657,657 718,643 778,685 "/>
-<polyline fill="none" opacity="0.35" stroke="#F87171" stroke-width="1" points="112,678 172,690 233,676 293,660 354,651 415,641 475,660 536,660 596,661 657,658 718,643 778,687 "/>
-<polyline fill="none" opacity="0.35" stroke="#F87171" stroke-width="1" points="112,679 172,691 233,679 293,666 354,653 415,679 475,671 536,660 596,660 657,658 718,644 778,689 "/>
-<polyline fill="none" opacity="0.35" stroke="#F87171" stroke-width="1" points="112,676 172,696 233,681 293,662 354,651 415,678 475,671 536,661 596,661 657,658 718,645 778,690 "/>
-<polyline fill="none" opacity="0.35" stroke="#F87171" stroke-width="1" points="112,678 172,696 233,683 293,669 354,653 415,677 475,667 536,659 596,659 657,656 718,644 778,691 "/>
-<polyline fill="none" opacity="0.35" stroke="#F87171" stroke-width="1" points="112,684 172,701 233,690 293,672 354,655 415,677 475,667 536,660 596,660 657,659 718,645 778,693 "/>
-<polyline fill="none" opacity="0.35" stroke="#F87171" stroke-width="1" points="112,685 172,704 233,690 293,668 354,655 415,674 475,667 536,661 596,661 657,659 718,645 778,695 "/>
-<text x="784" y="695" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="6.451612903225807" opacity="1" fill="#F87171" font-weight="bold">
+<polyline fill="none" opacity="0.35" stroke="#F87171" stroke-width="1" points="112,680 172,692 233,679 293,666 354,657 415,647 475,658 536,656 596,658 657,657 718,642 778,684 "/>
+<polyline fill="none" opacity="0.35" stroke="#F87171" stroke-width="1" points="112,678 172,690 233,676 293,660 354,654 415,640 475,660 536,661 596,660 657,658 718,642 778,687 "/>
+<polyline fill="none" opacity="0.35" stroke="#F87171" stroke-width="1" points="112,680 172,692 233,679 293,666 354,657 415,678 475,671 536,660 596,660 657,657 718,644 778,688 "/>
+<polyline fill="none" opacity="0.35" stroke="#F87171" stroke-width="1" points="112,677 172,697 233,681 293,662 354,655 415,679 475,671 536,661 596,661 657,658 718,644 778,689 "/>
+<polyline fill="none" opacity="0.35" stroke="#F87171" stroke-width="1" points="112,679 172,696 233,683 293,669 354,657 415,677 475,667 536,658 596,658 657,656 718,643 778,691 "/>
+<polyline fill="none" opacity="0.35" stroke="#F87171" stroke-width="1" points="112,684 172,702 233,690 293,672 354,658 415,677 475,666 536,659 596,660 657,658 718,645 778,693 "/>
+<polyline fill="none" opacity="0.35" stroke="#F87171" stroke-width="1" points="112,686 172,705 233,690 293,669 354,658 415,673 475,666 536,660 596,660 657,659 718,644 778,694 "/>
+<text x="784" y="694" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="6.451612903225807" opacity="1" fill="#F87171" font-weight="bold">
 L-1
 </text>
-<polyline fill="none" opacity="0.35" stroke="#F87171" stroke-width="1" points="112,745 172,764 233,754 293,718 354,694 415,677 475,676 536,672 596,668 657,666 718,650 778,696 "/>
-<polyline fill="none" opacity="0.35" stroke="#F87171" stroke-width="1" points="112,744 172,763 233,754 293,718 354,695 415,677 475,675 536,674 596,671 657,667 718,652 778,697 "/>
-<polyline fill="none" opacity="0.35" stroke="#F87171" stroke-width="1" points="112,747 172,770 233,760 293,724 354,699 415,678 475,681 536,680 596,676 657,671 718,653 778,710 "/>
-<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="112,676 172,689 233,676 293,660 354,651 415,639 475,639 536,648 596,654 657,652 718,637 778,679 "/>
-<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="112,748 116,750 "/>
-<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="120,751 125,753 "/>
-<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="128,754 133,756 "/>
-<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="137,758 141,759 "/>
+<polyline fill="none" opacity="0.35" stroke="#F87171" stroke-width="1" points="112,747 172,765 233,754 293,722 354,694 415,679 475,676 536,671 596,668 657,666 718,651 778,696 "/>
+<polyline fill="none" opacity="0.35" stroke="#F87171" stroke-width="1" points="112,746 172,764 233,754 293,722 354,693 415,678 475,678 536,675 596,671 657,667 718,652 778,698 "/>
+<polyline fill="none" opacity="0.35" stroke="#F87171" stroke-width="1" points="112,749 172,772 233,760 293,727 354,700 415,678 475,680 536,679 596,677 657,672 718,653 778,712 "/>
+<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="112,677 172,690 233,676 293,660 354,654 415,640 475,648 536,649 596,654 657,652 718,637 778,679 "/>
+<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="112,749 116,750 "/>
+<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="120,752 125,754 "/>
+<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="128,755 133,757 "/>
+<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="137,758 141,760 "/>
 <polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="145,761 150,763 "/>
-<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="154,764 158,766 "/>
-<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="162,767 167,769 "/>
-<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="170,771 172,771 "/>
-<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="172,771 177,770 "/>
+<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="154,765 158,766 "/>
+<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="162,768 167,770 "/>
+<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="170,771 172,772 "/>
+<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="172,772 177,771 "/>
 <polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="181,770 186,769 "/>
-<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="190,768 195,767 "/>
+<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="190,768 195,768 "/>
 <polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="199,767 204,766 "/>
 <polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="208,765 213,764 "/>
-<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="217,763 221,763 "/>
+<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="216,764 221,763 "/>
 <polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="225,762 230,761 "/>
-<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="233,761 237,758 "/>
+<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="233,760 237,758 "/>
 <polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="241,756 245,754 "/>
-<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="248,752 253,749 "/>
+<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="249,752 253,749 "/>
 <polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="256,747 261,745 "/>
-<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="264,743 268,740 "/>
-<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="272,738 276,736 "/>
-<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="280,734 284,731 "/>
-<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="287,729 292,727 "/>
-<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="293,726 298,724 "/>
-<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="302,722 306,721 "/>
-<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="310,719 315,717 "/>
-<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="318,716 323,714 "/>
-<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="327,712 331,710 "/>
-<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="335,709 340,707 "/>
-<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="343,705 348,703 "/>
-<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="352,702 354,701 "/>
-<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="354,701 359,699 "/>
-<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="362,698 367,696 "/>
-<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="371,695 376,693 "/>
+<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="264,743 269,741 "/>
+<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="272,739 277,736 "/>
+<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="280,734 284,732 "/>
+<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="288,730 292,728 "/>
+<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="293,727 298,725 "/>
+<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="302,724 306,722 "/>
+<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="310,720 315,718 "/>
+<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="318,716 323,715 "/>
+<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="326,713 331,711 "/>
+<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="335,709 339,707 "/>
+<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="343,706 348,704 "/>
+<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="351,702 354,701 "/>
+<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="354,701 359,700 "/>
+<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="363,698 367,697 "/>
+<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="371,695 376,694 "/>
 <polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="380,692 384,691 "/>
-<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="388,689 393,688 "/>
-<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="397,686 401,685 "/>
-<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="405,683 410,682 "/>
-<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="414,680 415,680 "/>
-<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="415,680 420,680 "/>
-<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="424,680 429,681 "/>
+<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="388,690 393,688 "/>
+<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="397,687 401,685 "/>
+<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="405,684 410,682 "/>
+<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="414,681 415,680 "/>
+<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="415,680 420,681 "/>
+<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="424,681 429,681 "/>
 <polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="433,681 438,681 "/>
 <polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="442,681 447,681 "/>
-<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="451,681 456,682 "/>
-<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="460,682 465,682 "/>
-<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="469,682 474,682 "/>
-<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="475,682 480,682 "/>
-<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="484,682 489,682 "/>
-<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="493,682 498,682 "/>
-<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="502,682 507,681 "/>
-<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="511,681 516,681 "/>
-<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="520,681 525,681 "/>
-<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="529,681 534,681 "/>
-<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="536,681 541,680 "/>
-<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="545,680 550,680 "/>
+<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="451,681 456,681 "/>
+<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="460,681 465,681 "/>
+<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="469,681 474,681 "/>
+<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="475,681 480,681 "/>
+<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="484,681 489,680 "/>
+<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="493,680 498,680 "/>
+<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="502,680 507,680 "/>
+<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="511,680 516,680 "/>
+<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="520,680 525,680 "/>
+<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="529,680 534,679 "/>
+<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="536,679 541,679 "/>
+<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="545,679 550,679 "/>
 <polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="554,679 559,679 "/>
-<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="563,679 568,679 "/>
+<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="563,678 568,678 "/>
 <polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="572,678 577,678 "/>
-<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="581,678 586,677 "/>
+<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="581,678 586,678 "/>
 <polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="590,677 595,677 "/>
-<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="596,677 601,676 "/>
-<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="605,676 610,675 "/>
-<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="614,675 619,675 "/>
-<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="623,674 628,674 "/>
-<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="632,674 637,673 "/>
+<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="596,677 601,677 "/>
+<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="605,676 610,676 "/>
+<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="614,676 619,675 "/>
+<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="623,675 628,675 "/>
+<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="632,674 637,674 "/>
 <polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="641,673 646,673 "/>
-<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="650,672 655,672 "/>
-<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="657,672 662,670 "/>
-<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="666,669 670,668 "/>
-<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="674,667 679,665 "/>
-<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="683,664 688,663 "/>
-<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="692,662 696,661 "/>
-<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="700,659 705,658 "/>
-<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="709,657 714,656 "/>
-<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="718,655 721,658 "/>
-<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="724,661 728,664 "/>
-<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="731,667 734,671 "/>
-<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="737,673 741,677 "/>
-<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="743,680 747,683 "/>
-<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="750,686 753,689 "/>
-<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="756,692 760,696 "/>
-<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="763,699 766,702 "/>
-<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="769,705 773,708 "/>
-<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="776,711 778,714 "/>
-<circle cx="112" cy="676" r="3" opacity="1" fill="#F87171" stroke="none" stroke-width="1"/>
-<circle cx="172" cy="689" r="3" opacity="1" fill="#F87171" stroke="none" stroke-width="1"/>
+<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="650,673 655,672 "/>
+<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="657,672 662,671 "/>
+<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="666,670 671,668 "/>
+<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="674,667 679,666 "/>
+<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="683,665 688,664 "/>
+<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="692,663 697,661 "/>
+<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="700,660 705,659 "/>
+<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="709,658 714,657 "/>
+<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="718,656 721,659 "/>
+<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="724,662 728,666 "/>
+<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="730,668 734,672 "/>
+<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="737,675 740,678 "/>
+<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="743,681 747,685 "/>
+<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="750,687 753,691 "/>
+<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="756,694 760,697 "/>
+<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="763,700 766,704 "/>
+<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="769,706 772,710 "/>
+<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="775,713 778,715 "/>
+<circle cx="112" cy="677" r="3" opacity="1" fill="#F87171" stroke="none" stroke-width="1"/>
+<circle cx="172" cy="690" r="3" opacity="1" fill="#F87171" stroke="none" stroke-width="1"/>
 <circle cx="233" cy="676" r="3" opacity="1" fill="#F87171" stroke="none" stroke-width="1"/>
 <circle cx="293" cy="660" r="3" opacity="1" fill="#F87171" stroke="none" stroke-width="1"/>
-<circle cx="354" cy="651" r="3" opacity="1" fill="#F87171" stroke="none" stroke-width="1"/>
-<circle cx="415" cy="639" r="3" opacity="1" fill="#F87171" stroke="none" stroke-width="1"/>
-<circle cx="475" cy="639" r="3" opacity="1" fill="#F87171" stroke="none" stroke-width="1"/>
-<circle cx="536" cy="648" r="3" opacity="1" fill="#F87171" stroke="none" stroke-width="1"/>
+<circle cx="354" cy="654" r="3" opacity="1" fill="#F87171" stroke="none" stroke-width="1"/>
+<circle cx="415" cy="640" r="3" opacity="1" fill="#F87171" stroke="none" stroke-width="1"/>
+<circle cx="475" cy="648" r="3" opacity="1" fill="#F87171" stroke="none" stroke-width="1"/>
+<circle cx="536" cy="649" r="3" opacity="1" fill="#F87171" stroke="none" stroke-width="1"/>
 <circle cx="596" cy="654" r="3" opacity="1" fill="#F87171" stroke="none" stroke-width="1"/>
 <circle cx="657" cy="652" r="3" opacity="1" fill="#F87171" stroke="none" stroke-width="1"/>
 <circle cx="718" cy="637" r="3" opacity="1" fill="#F87171" stroke="none" stroke-width="1"/>
@@ -1224,48 +1226,48 @@ L-1
 <text x="784" y="679" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="6.451612903225807" opacity="1" fill="#F87171" font-weight="bold">
 L-8
 </text>
-<circle cx="112" cy="748" r="3" opacity="1" fill="#F87171" stroke="none" stroke-width="1"/>
-<circle cx="172" cy="771" r="3" opacity="1" fill="#F87171" stroke="none" stroke-width="1"/>
-<circle cx="233" cy="761" r="3" opacity="1" fill="#F87171" stroke="none" stroke-width="1"/>
-<circle cx="293" cy="726" r="3" opacity="1" fill="#F87171" stroke="none" stroke-width="1"/>
+<circle cx="112" cy="749" r="3" opacity="1" fill="#F87171" stroke="none" stroke-width="1"/>
+<circle cx="172" cy="772" r="3" opacity="1" fill="#F87171" stroke="none" stroke-width="1"/>
+<circle cx="233" cy="760" r="3" opacity="1" fill="#F87171" stroke="none" stroke-width="1"/>
+<circle cx="293" cy="727" r="3" opacity="1" fill="#F87171" stroke="none" stroke-width="1"/>
 <circle cx="354" cy="701" r="3" opacity="1" fill="#F87171" stroke="none" stroke-width="1"/>
 <circle cx="415" cy="680" r="3" opacity="1" fill="#F87171" stroke="none" stroke-width="1"/>
-<circle cx="475" cy="682" r="3" opacity="1" fill="#F87171" stroke="none" stroke-width="1"/>
-<circle cx="536" cy="681" r="3" opacity="1" fill="#F87171" stroke="none" stroke-width="1"/>
+<circle cx="475" cy="681" r="3" opacity="1" fill="#F87171" stroke="none" stroke-width="1"/>
+<circle cx="536" cy="679" r="3" opacity="1" fill="#F87171" stroke="none" stroke-width="1"/>
 <circle cx="596" cy="677" r="3" opacity="1" fill="#F87171" stroke="none" stroke-width="1"/>
 <circle cx="657" cy="672" r="3" opacity="1" fill="#F87171" stroke="none" stroke-width="1"/>
-<circle cx="718" cy="655" r="3" opacity="1" fill="#F87171" stroke="none" stroke-width="1"/>
-<circle cx="778" cy="714" r="3" opacity="1" fill="#F87171" stroke="none" stroke-width="1"/>
-<text x="784" y="714" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="6.451612903225807" opacity="1" fill="#F87171" font-weight="bold">
+<circle cx="718" cy="656" r="3" opacity="1" fill="#F87171" stroke="none" stroke-width="1"/>
+<circle cx="778" cy="715" r="3" opacity="1" fill="#F87171" stroke="none" stroke-width="1"/>
+<text x="784" y="715" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="6.451612903225807" opacity="1" fill="#F87171" font-weight="bold">
 L4
 </text>
-<polyline fill="none" opacity="0.35" stroke="#F59E0B" stroke-width="1" points="112,739 172,735 233,715 293,703 354,693 415,678 475,675 536,676 596,678 657,677 718,658 778,687 "/>
-<polyline fill="none" opacity="0.35" stroke="#F59E0B" stroke-width="1" points="112,740 172,737 233,715 293,707 354,695 415,682 475,675 536,676 596,679 657,677 718,659 778,688 "/>
-<polyline fill="none" opacity="0.35" stroke="#F59E0B" stroke-width="1" points="112,735 172,739 233,718 293,705 354,693 415,681 475,680 536,678 596,680 657,678 718,659 778,690 "/>
-<polyline fill="none" opacity="0.35" stroke="#F59E0B" stroke-width="1" points="112,736 172,738 233,733 293,710 354,696 415,681 475,675 536,675 596,677 657,677 718,659 778,691 "/>
-<polyline fill="none" opacity="0.35" stroke="#F59E0B" stroke-width="1" points="112,740 172,742 233,718 293,710 354,693 415,680 475,673 536,674 596,678 657,678 718,659 778,693 "/>
-<polyline fill="none" opacity="0.35" stroke="#F59E0B" stroke-width="1" points="112,742 172,744 233,735 293,709 354,696 415,680 475,676 536,677 596,681 657,679 718,661 778,696 "/>
-<polyline fill="none" opacity="0.35" stroke="#F59E0B" stroke-width="1" points="112,743 172,746 233,737 293,709 354,696 415,680 475,679 536,680 596,683 657,681 718,663 778,699 "/>
+<polyline fill="none" opacity="0.35" stroke="#F59E0B" stroke-width="1" points="112,739 172,735 233,716 293,703 354,694 415,679 475,677 536,676 596,679 657,678 718,658 778,688 "/>
+<polyline fill="none" opacity="0.35" stroke="#F59E0B" stroke-width="1" points="112,739 172,738 233,716 293,708 354,695 415,683 475,678 536,677 596,680 657,678 718,659 778,689 "/>
+<polyline fill="none" opacity="0.35" stroke="#F59E0B" stroke-width="1" points="112,735 172,740 233,718 293,705 354,694 415,682 475,682 536,679 596,681 657,679 718,659 778,690 "/>
+<polyline fill="none" opacity="0.35" stroke="#F59E0B" stroke-width="1" points="112,737 172,739 233,733 293,710 354,696 415,682 475,676 536,675 596,678 657,677 718,659 778,692 "/>
+<polyline fill="none" opacity="0.35" stroke="#F59E0B" stroke-width="1" points="112,740 172,743 233,719 293,711 354,694 415,681 475,675 536,674 596,679 657,678 718,659 778,694 "/>
+<polyline fill="none" opacity="0.35" stroke="#F59E0B" stroke-width="1" points="112,742 172,745 233,735 293,710 354,696 415,680 475,678 536,677 596,681 657,680 718,661 778,696 "/>
+<polyline fill="none" opacity="0.35" stroke="#F59E0B" stroke-width="1" points="112,743 172,746 233,737 293,709 354,696 415,681 475,681 536,681 596,684 657,682 718,663 778,699 "/>
 <text x="784" y="699" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="6.451612903225807" opacity="1" fill="#F59E0B" font-weight="bold">
 L-1
 </text>
-<polyline fill="none" opacity="0.35" stroke="#F59E0B" stroke-width="1" points="112,794 172,786 233,764 293,732 354,714 415,696 475,688 536,684 596,684 657,680 718,661 778,701 "/>
-<polyline fill="none" opacity="0.35" stroke="#F59E0B" stroke-width="1" points="112,794 172,787 233,766 293,734 354,712 415,699 475,689 536,683 596,684 657,698 718,666 778,712 "/>
-<polyline fill="none" opacity="0.35" stroke="#F59E0B" stroke-width="1" points="112,801 172,799 233,781 293,751 354,731 415,719 475,711 536,705 596,705 657,698 718,680 778,739 "/>
-<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="112,735 172,735 233,715 293,703 354,693 415,678 475,673 536,674 596,677 657,677 718,658 778,687 "/>
+<polyline fill="none" opacity="0.35" stroke="#F59E0B" stroke-width="1" points="112,793 172,785 233,764 293,732 354,714 415,698 475,687 536,683 596,684 657,680 718,661 778,702 "/>
+<polyline fill="none" opacity="0.35" stroke="#F59E0B" stroke-width="1" points="112,794 172,786 233,765 293,733 354,711 415,701 475,690 536,683 596,684 657,699 718,667 778,713 "/>
+<polyline fill="none" opacity="0.35" stroke="#F59E0B" stroke-width="1" points="112,800 172,799 233,780 293,751 354,732 415,719 475,711 536,706 596,705 657,699 718,681 778,739 "/>
+<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="112,735 172,735 233,716 293,703 354,694 415,679 475,675 536,674 596,678 657,677 718,658 778,688 "/>
 <polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="112,813 117,813 "/>
-<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="121,813 126,814 "/>
+<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="121,814 126,814 "/>
 <polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="130,814 135,814 "/>
-<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="139,814 144,815 "/>
-<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="148,815 152,815 "/>
-<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="156,816 161,816 "/>
+<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="139,815 144,815 "/>
+<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="148,815 153,816 "/>
+<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="157,816 161,816 "/>
 <polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="165,816 170,817 "/>
 <polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="172,817 177,815 "/>
 <polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="181,814 186,813 "/>
-<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="190,812 194,811 "/>
+<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="190,812 194,810 "/>
 <polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="198,809 203,808 "/>
 <polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="207,807 212,806 "/>
-<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="216,805 220,803 "/>
+<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="215,804 220,803 "/>
 <polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="224,802 229,801 "/>
 <polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="233,800 237,798 "/>
 <polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="241,796 246,794 "/>
@@ -1273,7 +1275,7 @@ L-1
 <polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="258,789 262,787 "/>
 <polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="266,786 271,784 "/>
 <polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="274,782 279,780 "/>
-<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="282,779 287,777 "/>
+<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="283,779 287,777 "/>
 <polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="291,775 293,774 "/>
 <polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="293,774 298,773 "/>
 <polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="302,772 307,771 "/>
@@ -1281,30 +1283,30 @@ L-1
 <polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="320,768 325,767 "/>
 <polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="328,766 333,765 "/>
 <polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="337,764 342,763 "/>
-<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="346,762 351,760 "/>
-<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="354,760 359,759 "/>
+<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="346,762 351,761 "/>
+<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="354,760 359,760 "/>
 <polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="363,759 368,759 "/>
-<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="372,758 377,758 "/>
-<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="381,757 386,757 "/>
-<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="390,757 395,756 "/>
-<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="399,756 404,755 "/>
-<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="408,755 413,755 "/>
+<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="372,759 377,758 "/>
+<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="381,758 386,757 "/>
+<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="390,757 395,757 "/>
+<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="399,756 404,756 "/>
+<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="408,756 413,755 "/>
 <polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="415,755 419,752 "/>
-<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="422,749 426,746 "/>
+<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="422,750 426,747 "/>
 <polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="429,744 433,741 "/>
-<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="436,739 440,736 "/>
-<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="444,733 448,731 "/>
-<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="451,728 455,725 "/>
+<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="436,739 441,736 "/>
+<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="444,734 448,731 "/>
+<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="451,729 455,726 "/>
 <polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="458,723 462,720 "/>
 <polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="466,718 470,715 "/>
-<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="473,712 475,711 "/>
-<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="475,711 480,710 "/>
+<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="473,713 475,711 "/>
+<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="475,711 480,711 "/>
 <polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="484,710 489,710 "/>
-<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="493,709 498,709 "/>
-<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="502,709 507,708 "/>
-<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="511,708 516,707 "/>
-<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="520,707 525,707 "/>
-<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="529,706 534,706 "/>
+<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="493,710 498,709 "/>
+<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="502,709 507,709 "/>
+<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="511,708 516,708 "/>
+<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="520,708 525,707 "/>
+<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="529,707 534,706 "/>
 <polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="536,706 541,706 "/>
 <polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="545,706 550,706 "/>
 <polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="554,706 559,706 "/>
@@ -1313,46 +1315,46 @@ L-1
 <polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="581,706 586,706 "/>
 <polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="590,706 595,706 "/>
 <polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="596,706 601,709 "/>
-<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="604,711 608,713 "/>
-<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="612,716 616,718 "/>
-<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="619,720 623,723 "/>
-<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="627,725 631,728 "/>
-<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="634,730 639,733 "/>
-<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="642,735 646,737 "/>
-<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="650,740 654,742 "/>
+<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="604,711 608,714 "/>
+<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="612,716 616,719 "/>
+<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="619,721 623,723 "/>
+<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="627,726 631,728 "/>
+<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="635,730 639,733 "/>
+<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="642,735 646,738 "/>
+<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="650,740 654,743 "/>
 <polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="657,744 660,741 "/>
 <polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="663,738 667,734 "/>
-<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="670,731 673,728 "/>
+<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="670,732 673,728 "/>
 <polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="676,725 679,721 "/>
-<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="682,718 686,715 "/>
-<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="688,712 692,708 "/>
-<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="695,705 698,702 "/>
-<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="701,699 704,695 "/>
-<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="707,692 711,689 "/>
-<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="713,686 717,682 "/>
+<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="682,719 686,715 "/>
+<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="688,712 692,709 "/>
+<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="695,706 698,702 "/>
+<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="701,699 704,696 "/>
+<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="707,693 711,689 "/>
+<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="713,686 717,683 "/>
 <polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="718,682 721,685 "/>
 <polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="724,688 728,691 "/>
-<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="731,694 734,697 "/>
+<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="731,694 734,698 "/>
 <polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="737,700 741,704 "/>
-<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="744,706 747,710 "/>
-<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="750,712 754,716 "/>
+<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="744,707 747,710 "/>
+<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="750,713 754,716 "/>
 <polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="757,719 760,722 "/>
-<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="763,725 767,728 "/>
-<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="770,731 774,734 "/>
-<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="776,737 778,739 "/>
+<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="763,725 767,729 "/>
+<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="770,731 773,735 "/>
+<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="776,738 778,739 "/>
 <circle cx="112" cy="735" r="3" opacity="1" fill="#F59E0B" stroke="none" stroke-width="1"/>
 <circle cx="172" cy="735" r="3" opacity="1" fill="#F59E0B" stroke="none" stroke-width="1"/>
-<circle cx="233" cy="715" r="3" opacity="1" fill="#F59E0B" stroke="none" stroke-width="1"/>
+<circle cx="233" cy="716" r="3" opacity="1" fill="#F59E0B" stroke="none" stroke-width="1"/>
 <circle cx="293" cy="703" r="3" opacity="1" fill="#F59E0B" stroke="none" stroke-width="1"/>
-<circle cx="354" cy="693" r="3" opacity="1" fill="#F59E0B" stroke="none" stroke-width="1"/>
-<circle cx="415" cy="678" r="3" opacity="1" fill="#F59E0B" stroke="none" stroke-width="1"/>
-<circle cx="475" cy="673" r="3" opacity="1" fill="#F59E0B" stroke="none" stroke-width="1"/>
+<circle cx="354" cy="694" r="3" opacity="1" fill="#F59E0B" stroke="none" stroke-width="1"/>
+<circle cx="415" cy="679" r="3" opacity="1" fill="#F59E0B" stroke="none" stroke-width="1"/>
+<circle cx="475" cy="675" r="3" opacity="1" fill="#F59E0B" stroke="none" stroke-width="1"/>
 <circle cx="536" cy="674" r="3" opacity="1" fill="#F59E0B" stroke="none" stroke-width="1"/>
-<circle cx="596" cy="677" r="3" opacity="1" fill="#F59E0B" stroke="none" stroke-width="1"/>
+<circle cx="596" cy="678" r="3" opacity="1" fill="#F59E0B" stroke="none" stroke-width="1"/>
 <circle cx="657" cy="677" r="3" opacity="1" fill="#F59E0B" stroke="none" stroke-width="1"/>
 <circle cx="718" cy="658" r="3" opacity="1" fill="#F59E0B" stroke="none" stroke-width="1"/>
-<circle cx="778" cy="687" r="3" opacity="1" fill="#F59E0B" stroke="none" stroke-width="1"/>
-<text x="784" y="687" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="6.451612903225807" opacity="1" fill="#F59E0B" font-weight="bold">
+<circle cx="778" cy="688" r="3" opacity="1" fill="#F59E0B" stroke="none" stroke-width="1"/>
+<text x="784" y="688" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="6.451612903225807" opacity="1" fill="#F59E0B" font-weight="bold">
 L-7
 </text>
 <circle cx="112" cy="813" r="3" opacity="1" fill="#F59E0B" stroke="none" stroke-width="1"/>
@@ -1427,399 +1429,401 @@ x-ray
 <text x="82" y="1064" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#7D8590">
 50
 </text>
-<polyline fill="none" opacity="1" stroke="#21262D" stroke-width="1" points="90,1037 790,1037 "/>
-<text x="82" y="1037" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#7D8590">
+<polyline fill="none" opacity="1" stroke="#21262D" stroke-width="1" points="90,1039 790,1039 "/>
+<text x="82" y="1039" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#7D8590">
 100
 </text>
-<polyline fill="none" opacity="1" stroke="#21262D" stroke-width="1" points="90,1011 790,1011 "/>
-<text x="82" y="1011" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#7D8590">
+<polyline fill="none" opacity="1" stroke="#21262D" stroke-width="1" points="90,1013 790,1013 "/>
+<text x="82" y="1013" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#7D8590">
 200
 </text>
-<polyline fill="none" opacity="1" stroke="#21262D" stroke-width="1" points="90,976 790,976 "/>
-<text x="82" y="976" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#7D8590">
+<polyline fill="none" opacity="1" stroke="#21262D" stroke-width="1" points="90,979 790,979 "/>
+<text x="82" y="979" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#7D8590">
 500
 </text>
-<polyline fill="none" opacity="1" stroke="#21262D" stroke-width="1" points="90,950 790,950 "/>
-<text x="82" y="950" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#7D8590">
+<polyline fill="none" opacity="1" stroke="#21262D" stroke-width="1" points="90,954 790,954 "/>
+<text x="82" y="954" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#7D8590">
 1000
 </text>
-<polyline fill="none" opacity="1" stroke="#21262D" stroke-width="1" points="90,924 790,924 "/>
-<text x="82" y="924" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#7D8590">
+<polyline fill="none" opacity="1" stroke="#21262D" stroke-width="1" points="90,928 790,928 "/>
+<text x="82" y="928" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#7D8590">
 2000
 </text>
-<polyline fill="none" opacity="1" stroke="#21262D" stroke-width="1" points="90,889 790,889 "/>
-<text x="82" y="889" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#7D8590">
+<polyline fill="none" opacity="1" stroke="#21262D" stroke-width="1" points="90,894 790,894 "/>
+<text x="82" y="894" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#7D8590">
 5000
 </text>
-<polyline fill="none" opacity="0.35" stroke="#60A5FA" stroke-width="1" points="112,1008 172,987 233,966 293,946 354,934 415,928 475,919 536,921 596,927 657,950 718,894 778,900 "/>
-<polyline fill="none" opacity="0.35" stroke="#60A5FA" stroke-width="1" points="112,1012 172,991 233,970 293,949 354,929 415,921 475,914 536,922 596,930 657,950 718,895 778,899 "/>
-<polyline fill="none" opacity="0.35" stroke="#60A5FA" stroke-width="1" points="112,1013 172,993 233,972 293,952 354,932 415,921 475,912 536,919 596,925 657,957 718,886 778,899 "/>
-<polyline fill="none" opacity="0.35" stroke="#60A5FA" stroke-width="1" points="112,1013 172,992 233,972 293,951 354,942 415,931 475,931 536,937 596,938 657,964 718,892 778,901 "/>
-<polyline fill="none" opacity="0.35" stroke="#60A5FA" stroke-width="1" points="112,1012 172,991 233,971 293,959 354,939 415,920 475,935 536,945 596,945 657,970 718,885 778,903 "/>
-<polyline fill="none" opacity="0.35" stroke="#60A5FA" stroke-width="1" points="112,1017 172,996 233,976 293,955 354,934 415,916 475,925 536,948 596,953 657,977 718,898 778,906 "/>
-<polyline fill="none" opacity="0.35" stroke="#60A5FA" stroke-width="1" points="112,1019 172,1000 233,979 293,958 354,956 415,963 475,965 536,972 596,973 657,990 718,905 778,909 "/>
-<text x="784" y="909" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="6.451612903225807" opacity="1" fill="#60A5FA" font-weight="bold">
+<polyline fill="none" opacity="0.35" stroke="#60A5FA" stroke-width="1" points="112,1011 172,989 233,969 293,949 354,937 415,932 475,924 536,925 596,931 657,955 718,900 778,906 "/>
+<polyline fill="none" opacity="0.35" stroke="#60A5FA" stroke-width="1" points="112,1015 172,993 233,972 293,953 354,933 415,924 475,918 536,926 596,934 657,956 718,901 778,904 "/>
+<polyline fill="none" opacity="0.35" stroke="#60A5FA" stroke-width="1" points="112,1016 172,996 233,976 293,955 354,936 415,925 475,917 536,924 596,929 657,962 718,892 778,904 "/>
+<polyline fill="none" opacity="0.35" stroke="#60A5FA" stroke-width="1" points="112,1016 172,995 233,974 293,955 354,946 415,935 475,935 536,941 596,942 657,969 718,898 778,907 "/>
+<polyline fill="none" opacity="0.35" stroke="#60A5FA" stroke-width="1" points="112,1015 172,994 233,975 293,963 354,943 415,924 475,939 536,949 596,948 657,975 718,892 778,908 "/>
+<polyline fill="none" opacity="0.35" stroke="#60A5FA" stroke-width="1" points="112,1019 172,998 233,979 293,958 354,938 415,920 475,929 536,951 596,956 657,981 718,903 778,911 "/>
+<polyline fill="none" opacity="0.35" stroke="#60A5FA" stroke-width="1" points="112,1021 172,1002 233,982 293,961 354,959 415,967 475,968 536,975 596,976 657,994 718,910 778,914 "/>
+<text x="784" y="914" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="6.451612903225807" opacity="1" fill="#60A5FA" font-weight="bold">
 L-1
 </text>
-<polyline fill="none" opacity="0.35" stroke="#60A5FA" stroke-width="1" points="112,1050 172,1033 233,1013 293,996 354,988 415,989 475,962 536,960 596,957 657,961 718,972 778,971 "/>
-<polyline fill="none" opacity="0.35" stroke="#60A5FA" stroke-width="1" points="112,1050 172,1034 233,1013 293,996 354,989 415,992 475,994 536,1001 596,1003 657,1016 718,990 778,999 "/>
-<polyline fill="none" opacity="0.35" stroke="#60A5FA" stroke-width="1" points="112,1055 172,1040 233,1027 293,1020 354,1016 415,1017 475,1013 536,1019 596,1023 657,1034 718,1034 778,1035 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="112,1008 172,987 233,966 293,946 354,929 415,916 475,912 536,919 596,925 657,950 718,885 778,899 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="112,1066 117,1065 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="120,1065 125,1064 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="129,1063 134,1063 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="138,1062 143,1061 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="147,1061 152,1060 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="156,1059 161,1059 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="165,1058 170,1057 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="172,1057 177,1056 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="181,1056 186,1055 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="190,1055 195,1054 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="199,1054 204,1053 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="208,1053 213,1052 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="217,1051 222,1051 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="226,1050 231,1050 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="233,1050 238,1049 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="242,1049 247,1049 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="251,1049 256,1049 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="260,1049 265,1049 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="269,1048 274,1048 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="278,1048 283,1048 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="287,1048 292,1048 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="293,1048 298,1048 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="302,1048 307,1048 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="311,1049 316,1049 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="320,1049 325,1049 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="329,1049 334,1050 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="338,1050 343,1050 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="347,1050 352,1050 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="354,1050 359,1051 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="363,1051 368,1052 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="372,1052 377,1053 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="381,1053 386,1054 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="390,1055 395,1055 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="399,1056 404,1056 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="408,1057 413,1057 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="415,1057 419,1055 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="422,1053 427,1051 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="430,1049 435,1046 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="438,1044 443,1042 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="446,1040 451,1038 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="454,1036 458,1033 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="462,1031 466,1029 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="470,1027 474,1025 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="475,1024 480,1024 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="484,1025 489,1025 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="493,1025 498,1026 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="502,1026 507,1026 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="511,1026 516,1027 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="520,1027 525,1027 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="529,1028 534,1028 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="536,1028 541,1028 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="545,1029 550,1029 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="554,1029 559,1030 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="563,1030 568,1030 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="572,1031 577,1031 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="581,1031 586,1032 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="590,1032 595,1032 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="596,1033 601,1034 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="605,1036 610,1037 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="613,1039 618,1040 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="622,1042 626,1044 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="630,1045 635,1047 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="639,1048 643,1050 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="647,1051 652,1053 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="656,1054 657,1055 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="657,1055 662,1053 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="666,1052 670,1050 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="674,1049 679,1048 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="683,1046 687,1045 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="691,1043 696,1042 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="700,1041 704,1039 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="708,1038 713,1036 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="717,1035 718,1035 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="718,1035 723,1035 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="727,1035 732,1035 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="736,1035 741,1035 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="745,1035 750,1036 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="754,1036 759,1036 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="763,1036 768,1036 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="772,1036 777,1036 "/>
-<circle cx="112" cy="1008" r="3" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
-<circle cx="172" cy="987" r="3" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
-<circle cx="233" cy="966" r="3" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
-<circle cx="293" cy="946" r="3" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
-<circle cx="354" cy="929" r="3" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
-<circle cx="415" cy="916" r="3" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
-<circle cx="475" cy="912" r="3" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
-<circle cx="536" cy="919" r="3" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
-<circle cx="596" cy="925" r="3" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
-<circle cx="657" cy="950" r="3" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
-<circle cx="718" cy="885" r="3" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
-<circle cx="778" cy="899" r="3" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
-<text x="784" y="899" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="6.451612903225807" opacity="1" fill="#60A5FA" font-weight="bold">
+<polyline fill="none" opacity="0.35" stroke="#60A5FA" stroke-width="1" points="112,1051 172,1034 233,1015 293,998 354,991 415,993 475,965 536,964 596,960 657,964 718,975 778,974 "/>
+<polyline fill="none" opacity="0.35" stroke="#60A5FA" stroke-width="1" points="112,1052 172,1035 233,1015 293,998 354,992 415,995 475,1000 536,1005 596,1009 657,1021 718,994 778,1003 "/>
+<polyline fill="none" opacity="0.35" stroke="#60A5FA" stroke-width="1" points="112,1056 172,1041 233,1028 293,1022 354,1019 415,1021 475,1016 536,1023 596,1027 657,1039 718,1039 778,1040 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="112,1011 172,989 233,969 293,949 354,933 415,920 475,917 536,924 596,929 657,955 718,892 778,904 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="112,1067 117,1066 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="120,1066 125,1065 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="129,1064 134,1063 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="138,1063 143,1062 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="147,1062 152,1061 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="156,1060 161,1060 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="165,1059 170,1058 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="172,1058 177,1057 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="181,1057 186,1056 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="190,1056 195,1055 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="199,1055 204,1054 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="208,1054 213,1053 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="217,1053 222,1052 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="226,1052 231,1051 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="233,1051 238,1051 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="242,1050 247,1050 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="251,1050 256,1050 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="260,1050 265,1050 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="269,1050 274,1049 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="278,1049 283,1049 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="287,1049 292,1049 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="293,1049 298,1049 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="302,1049 307,1049 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="311,1050 316,1050 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="320,1050 325,1050 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="329,1050 334,1051 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="338,1051 343,1051 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="347,1051 352,1052 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="354,1052 359,1052 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="363,1053 368,1053 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="372,1054 377,1054 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="381,1055 386,1056 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="390,1056 395,1057 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="399,1057 404,1058 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="408,1058 413,1059 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="415,1059 419,1057 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="423,1055 427,1052 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="430,1051 435,1048 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="438,1046 443,1044 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="446,1042 451,1040 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="454,1038 459,1035 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="462,1034 467,1031 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="470,1029 475,1027 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="475,1027 480,1027 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="484,1027 489,1028 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="493,1028 498,1029 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="502,1029 507,1030 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="511,1030 516,1031 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="520,1031 525,1032 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="529,1032 534,1032 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="536,1033 541,1033 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="545,1033 550,1034 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="554,1034 559,1034 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="563,1035 568,1035 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="572,1035 577,1036 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="581,1036 586,1036 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="590,1037 595,1037 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="596,1037 601,1039 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="605,1040 610,1041 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="614,1043 618,1044 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="622,1045 627,1047 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="631,1048 636,1049 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="639,1051 644,1052 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="648,1053 653,1055 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="657,1056 657,1056 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="657,1056 662,1055 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="666,1054 671,1052 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="674,1051 679,1050 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="683,1049 688,1048 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="692,1047 697,1045 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="700,1044 705,1043 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="709,1042 714,1041 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="718,1040 723,1040 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="727,1040 732,1040 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="736,1040 741,1041 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="745,1041 750,1041 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="754,1041 759,1041 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="763,1041 768,1041 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="772,1041 777,1042 "/>
+<circle cx="112" cy="1011" r="3" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
+<circle cx="172" cy="989" r="3" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
+<circle cx="233" cy="969" r="3" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
+<circle cx="293" cy="949" r="3" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
+<circle cx="354" cy="933" r="3" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
+<circle cx="415" cy="920" r="3" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
+<circle cx="475" cy="917" r="3" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
+<circle cx="536" cy="924" r="3" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
+<circle cx="596" cy="929" r="3" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
+<circle cx="657" cy="955" r="3" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
+<circle cx="718" cy="892" r="3" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
+<circle cx="778" cy="904" r="3" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
+<text x="784" y="904" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="6.451612903225807" opacity="1" fill="#60A5FA" font-weight="bold">
 L-7
 </text>
-<circle cx="112" cy="1066" r="3" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
-<circle cx="172" cy="1057" r="3" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
-<circle cx="233" cy="1050" r="3" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
-<circle cx="293" cy="1048" r="3" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
-<circle cx="354" cy="1050" r="3" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
-<circle cx="415" cy="1057" r="3" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
-<circle cx="475" cy="1024" r="3" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
-<circle cx="536" cy="1028" r="3" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
-<circle cx="596" cy="1033" r="3" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
-<circle cx="657" cy="1055" r="3" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
-<circle cx="718" cy="1035" r="3" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
-<circle cx="778" cy="1036" r="3" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
-<text x="784" y="1036" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="6.451612903225807" opacity="1" fill="#60A5FA" font-weight="bold">
+<circle cx="112" cy="1067" r="3" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
+<circle cx="172" cy="1058" r="3" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
+<circle cx="233" cy="1051" r="3" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
+<circle cx="293" cy="1049" r="3" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
+<circle cx="354" cy="1052" r="3" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
+<circle cx="415" cy="1059" r="3" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
+<circle cx="475" cy="1027" r="3" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
+<circle cx="536" cy="1033" r="3" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
+<circle cx="596" cy="1037" r="3" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
+<circle cx="657" cy="1056" r="3" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
+<circle cx="718" cy="1040" r="3" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
+<circle cx="778" cy="1042" r="3" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
+<text x="784" y="1042" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="6.451612903225807" opacity="1" fill="#60A5FA" font-weight="bold">
 L4
 </text>
-<polyline fill="none" opacity="0.35" stroke="#F87171" stroke-width="1" points="112,995 172,989 233,969 293,952 354,931 415,911 475,898 536,889 596,882 657,890 718,901 778,914 "/>
-<polyline fill="none" opacity="0.35" stroke="#F87171" stroke-width="1" points="112,991 172,986 233,967 293,949 354,930 415,914 475,902 536,898 596,897 657,901 718,911 778,920 "/>
-<polyline fill="none" opacity="0.35" stroke="#F87171" stroke-width="1" points="112,995 172,989 233,969 293,951 354,931 415,915 475,900 536,892 596,891 657,899 718,912 778,921 "/>
-<polyline fill="none" opacity="0.35" stroke="#F87171" stroke-width="1" points="112,997 172,992 233,973 293,956 354,934 415,918 475,901 536,893 596,887 657,899 718,915 778,925 "/>
-<polyline fill="none" opacity="0.35" stroke="#F87171" stroke-width="1" points="112,996 172,991 233,971 293,954 354,933 415,917 475,908 536,905 596,907 657,912 718,960 778,953 "/>
-<polyline fill="none" opacity="0.35" stroke="#F87171" stroke-width="1" points="112,998 172,992 233,973 293,964 354,940 415,923 475,906 536,893 596,906 657,914 718,984 778,996 "/>
-<polyline fill="none" opacity="0.35" stroke="#F87171" stroke-width="1" points="112,1003 172,996 233,977 293,959 354,936 415,920 475,903 536,890 596,881 657,912 718,989 778,1001 "/>
-<text x="784" y="1001" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="6.451612903225807" opacity="1" fill="#F87171" font-weight="bold">
+<polyline fill="none" opacity="0.35" stroke="#F87171" stroke-width="1" points="112,997 172,992 233,973 293,955 354,937 415,917 475,903 536,893 596,887 657,894 718,905 778,918 "/>
+<polyline fill="none" opacity="0.35" stroke="#F87171" stroke-width="1" points="112,994 172,989 233,970 293,954 354,935 415,919 475,907 536,902 596,902 657,905 718,915 778,924 "/>
+<polyline fill="none" opacity="0.35" stroke="#F87171" stroke-width="1" points="112,997 172,992 233,973 293,955 354,936 415,919 475,904 536,896 596,896 657,903 718,916 778,925 "/>
+<polyline fill="none" opacity="0.35" stroke="#F87171" stroke-width="1" points="112,999 172,995 233,977 293,959 354,939 415,922 475,906 536,897 596,891 657,904 718,919 778,929 "/>
+<polyline fill="none" opacity="0.35" stroke="#F87171" stroke-width="1" points="112,998 172,993 233,975 293,958 354,938 415,921 475,912 536,909 596,911 657,916 718,963 778,956 "/>
+<polyline fill="none" opacity="0.35" stroke="#F87171" stroke-width="1" points="112,1000 172,995 233,976 293,966 354,946 415,927 475,911 536,896 596,910 657,918 718,987 778,998 "/>
+<polyline fill="none" opacity="0.35" stroke="#F87171" stroke-width="1" points="112,1005 172,998 233,980 293,962 354,942 415,924 475,908 536,894 596,886 657,916 718,991 778,1003 "/>
+<text x="784" y="1003" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="6.451612903225807" opacity="1" fill="#F87171" font-weight="bold">
 L-1
 </text>
-<polyline fill="none" opacity="0.35" stroke="#F87171" stroke-width="1" points="112,1014 172,1012 233,1004 293,998 354,964 415,941 475,939 536,939 596,942 657,1001 718,1016 778,1020 "/>
-<polyline fill="none" opacity="0.35" stroke="#F87171" stroke-width="1" points="112,1014 172,1012 233,1004 293,998 354,963 415,940 475,939 536,944 596,952 657,1012 718,1031 778,1039 "/>
-<polyline fill="none" opacity="0.35" stroke="#F87171" stroke-width="1" points="112,1015 172,1006 233,989 293,976 354,937 415,923 475,939 536,953 596,965 657,925 718,1015 778,1032 "/>
-<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="112,991 172,986 233,967 293,949 354,930 415,910 475,898 536,889 596,881 657,890 718,901 778,911 "/>
-<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="112,1024 117,1023 "/>
-<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="121,1023 126,1023 "/>
-<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="130,1023 135,1023 "/>
-<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="139,1023 144,1023 "/>
-<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="148,1023 153,1023 "/>
-<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="157,1023 162,1023 "/>
-<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="166,1023 171,1023 "/>
-<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="172,1023 177,1022 "/>
-<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="181,1022 186,1021 "/>
-<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="190,1021 195,1020 "/>
-<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="199,1020 204,1019 "/>
-<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="208,1019 213,1019 "/>
-<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="217,1018 222,1018 "/>
-<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="226,1017 231,1017 "/>
-<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="233,1017 238,1016 "/>
-<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="242,1016 247,1015 "/>
-<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="251,1015 256,1015 "/>
-<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="260,1015 265,1014 "/>
-<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="269,1014 274,1014 "/>
-<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="278,1013 283,1013 "/>
-<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="287,1013 292,1012 "/>
-<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="293,1012 298,1010 "/>
-<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="301,1008 306,1006 "/>
-<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="309,1004 314,1002 "/>
-<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="317,1000 322,998 "/>
-<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="325,996 330,993 "/>
-<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="333,992 338,989 "/>
-<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="341,988 346,985 "/>
-<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="349,983 354,981 "/>
-<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="354,981 359,979 "/>
-<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="362,978 367,976 "/>
-<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="371,975 376,973 "/>
-<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="379,972 384,970 "/>
-<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="388,969 392,967 "/>
-<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="396,966 401,964 "/>
-<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="405,963 409,961 "/>
-<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="413,960 415,959 "/>
-<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="415,959 420,959 "/>
-<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="424,960 429,960 "/>
-<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="433,960 438,960 "/>
-<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="442,961 447,961 "/>
-<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="451,961 456,962 "/>
-<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="460,962 464,962 "/>
-<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="468,962 473,963 "/>
-<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="475,963 480,963 "/>
-<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="484,964 489,964 "/>
-<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="493,965 498,965 "/>
-<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="502,966 507,966 "/>
-<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="511,967 516,967 "/>
-<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="520,968 525,968 "/>
-<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="529,969 534,969 "/>
-<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="536,970 541,970 "/>
-<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="545,970 550,970 "/>
-<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="554,971 559,971 "/>
-<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="563,971 568,972 "/>
-<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="572,972 577,972 "/>
-<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="581,973 586,973 "/>
-<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="590,973 595,974 "/>
-<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="596,974 600,977 "/>
-<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="604,979 608,982 "/>
-<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="611,984 615,987 "/>
-<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="618,990 622,993 "/>
-<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="625,995 629,998 "/>
-<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="633,1000 637,1003 "/>
-<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="640,1006 644,1009 "/>
-<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="647,1011 651,1014 "/>
-<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="654,1016 657,1018 "/>
-<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="657,1018 662,1020 "/>
-<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="666,1021 671,1022 "/>
-<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="674,1023 679,1024 "/>
-<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="683,1025 688,1027 "/>
-<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="692,1028 697,1029 "/>
-<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="700,1030 705,1032 "/>
-<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="709,1033 714,1034 "/>
-<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="718,1035 723,1036 "/>
-<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="727,1036 731,1037 "/>
-<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="735,1037 740,1038 "/>
-<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="744,1038 749,1039 "/>
-<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="753,1039 758,1040 "/>
-<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="762,1041 767,1041 "/>
-<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="771,1042 776,1042 "/>
-<circle cx="112" cy="991" r="3" opacity="1" fill="#F87171" stroke="none" stroke-width="1"/>
-<circle cx="172" cy="986" r="3" opacity="1" fill="#F87171" stroke="none" stroke-width="1"/>
-<circle cx="233" cy="967" r="3" opacity="1" fill="#F87171" stroke="none" stroke-width="1"/>
-<circle cx="293" cy="949" r="3" opacity="1" fill="#F87171" stroke="none" stroke-width="1"/>
-<circle cx="354" cy="930" r="3" opacity="1" fill="#F87171" stroke="none" stroke-width="1"/>
-<circle cx="415" cy="910" r="3" opacity="1" fill="#F87171" stroke="none" stroke-width="1"/>
-<circle cx="475" cy="898" r="3" opacity="1" fill="#F87171" stroke="none" stroke-width="1"/>
-<circle cx="536" cy="889" r="3" opacity="1" fill="#F87171" stroke="none" stroke-width="1"/>
+<polyline fill="none" opacity="0.35" stroke="#F87171" stroke-width="1" points="112,1006 172,998 233,982 293,970 354,926 415,917 475,900 536,887 596,881 657,899 718,1003 778,1015 "/>
+<polyline fill="none" opacity="0.35" stroke="#F87171" stroke-width="1" points="112,1006 172,998 233,982 293,970 354,924 415,914 475,903 536,898 596,897 657,890 718,885 778,883 "/>
+<polyline fill="none" opacity="0.35" stroke="#F87171" stroke-width="1" points="112,1011 172,1002 233,986 293,974 354,934 415,922 475,916 536,913 596,912 657,913 718,900 778,903 "/>
+<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="112,994 172,989 233,970 293,954 354,924 415,914 475,900 536,887 596,881 657,890 718,885 778,883 "/>
+<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="112,1011 117,1010 "/>
+<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="120,1010 125,1009 "/>
+<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="129,1008 134,1008 "/>
+<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="138,1007 143,1006 "/>
+<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="147,1006 152,1005 "/>
+<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="156,1004 161,1004 "/>
+<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="165,1003 170,1003 "/>
+<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="172,1002 177,1001 "/>
+<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="181,1000 186,999 "/>
+<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="190,998 194,996 "/>
+<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="198,995 203,994 "/>
+<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="207,993 212,992 "/>
+<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="216,991 221,989 "/>
+<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="224,988 229,987 "/>
+<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="233,986 238,985 "/>
+<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="242,984 247,983 "/>
+<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="250,983 255,982 "/>
+<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="259,981 264,980 "/>
+<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="268,979 273,978 "/>
+<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="277,977 282,976 "/>
+<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="286,976 291,975 "/>
+<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="293,974 298,972 "/>
+<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="302,970 306,968 "/>
+<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="310,966 314,964 "/>
+<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="318,963 322,960 "/>
+<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="326,959 331,957 "/>
+<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="334,955 339,953 "/>
+<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="342,951 347,949 "/>
+<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="350,947 354,946 "/>
+<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="354,946 359,944 "/>
+<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="363,943 367,941 "/>
+<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="371,940 376,939 "/>
+<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="380,938 385,936 "/>
+<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="388,935 393,933 "/>
+<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="397,932 402,931 "/>
+<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="406,930 410,928 "/>
+<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="414,927 415,927 "/>
+<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="415,927 420,926 "/>
+<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="423,925 428,924 "/>
+<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="432,924 437,923 "/>
+<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="441,922 446,921 "/>
+<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="450,921 455,920 "/>
+<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="459,919 464,918 "/>
+<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="468,917 473,917 "/>
+<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="475,916 480,916 "/>
+<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="484,916 489,915 "/>
+<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="493,915 498,915 "/>
+<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="502,915 507,915 "/>
+<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="511,914 516,914 "/>
+<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="520,914 525,914 "/>
+<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="529,914 534,913 "/>
+<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="536,913 541,913 "/>
+<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="545,913 550,913 "/>
+<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="554,913 559,913 "/>
+<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="563,913 568,913 "/>
+<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="572,913 577,912 "/>
+<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="581,912 586,912 "/>
+<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="590,912 595,912 "/>
+<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="596,912 601,913 "/>
+<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="605,913 610,914 "/>
+<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="614,914 619,914 "/>
+<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="623,915 628,915 "/>
+<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="632,916 637,916 "/>
+<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="641,917 646,917 "/>
+<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="650,918 655,918 "/>
+<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="657,918 660,923 "/>
+<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="662,926 665,930 "/>
+<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="668,933 670,937 "/>
+<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="673,940 676,944 "/>
+<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="678,948 681,952 "/>
+<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="683,955 686,959 "/>
+<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="689,962 691,966 "/>
+<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="694,970 697,974 "/>
+<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="699,977 702,981 "/>
+<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="704,984 707,988 "/>
+<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="710,992 713,996 "/>
+<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="715,999 718,1003 "/>
+<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="718,1003 722,1004 "/>
+<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="726,1004 731,1006 "/>
+<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="735,1006 740,1007 "/>
+<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="744,1008 749,1009 "/>
+<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="753,1010 758,1011 "/>
+<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="762,1012 767,1013 "/>
+<polyline fill="none" opacity="1" stroke="#F87171" stroke-width="2" points="770,1014 775,1015 "/>
+<circle cx="112" cy="994" r="3" opacity="1" fill="#F87171" stroke="none" stroke-width="1"/>
+<circle cx="172" cy="989" r="3" opacity="1" fill="#F87171" stroke="none" stroke-width="1"/>
+<circle cx="233" cy="970" r="3" opacity="1" fill="#F87171" stroke="none" stroke-width="1"/>
+<circle cx="293" cy="954" r="3" opacity="1" fill="#F87171" stroke="none" stroke-width="1"/>
+<circle cx="354" cy="924" r="3" opacity="1" fill="#F87171" stroke="none" stroke-width="1"/>
+<circle cx="415" cy="914" r="3" opacity="1" fill="#F87171" stroke="none" stroke-width="1"/>
+<circle cx="475" cy="900" r="3" opacity="1" fill="#F87171" stroke="none" stroke-width="1"/>
+<circle cx="536" cy="887" r="3" opacity="1" fill="#F87171" stroke="none" stroke-width="1"/>
 <circle cx="596" cy="881" r="3" opacity="1" fill="#F87171" stroke="none" stroke-width="1"/>
 <circle cx="657" cy="890" r="3" opacity="1" fill="#F87171" stroke="none" stroke-width="1"/>
-<circle cx="718" cy="901" r="3" opacity="1" fill="#F87171" stroke="none" stroke-width="1"/>
-<circle cx="778" cy="911" r="3" opacity="1" fill="#F87171" stroke="none" stroke-width="1"/>
-<text x="784" y="911" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="6.451612903225807" opacity="1" fill="#F87171" font-weight="bold">
+<circle cx="718" cy="885" r="3" opacity="1" fill="#F87171" stroke="none" stroke-width="1"/>
+<circle cx="778" cy="883" r="3" opacity="1" fill="#F87171" stroke="none" stroke-width="1"/>
+<text x="784" y="883" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="6.451612903225807" opacity="1" fill="#F87171" font-weight="bold">
 L-8
 </text>
-<circle cx="112" cy="1024" r="3" opacity="1" fill="#F87171" stroke="none" stroke-width="1"/>
-<circle cx="172" cy="1023" r="3" opacity="1" fill="#F87171" stroke="none" stroke-width="1"/>
-<circle cx="233" cy="1017" r="3" opacity="1" fill="#F87171" stroke="none" stroke-width="1"/>
-<circle cx="293" cy="1012" r="3" opacity="1" fill="#F87171" stroke="none" stroke-width="1"/>
-<circle cx="354" cy="981" r="3" opacity="1" fill="#F87171" stroke="none" stroke-width="1"/>
-<circle cx="415" cy="959" r="3" opacity="1" fill="#F87171" stroke="none" stroke-width="1"/>
-<circle cx="475" cy="963" r="3" opacity="1" fill="#F87171" stroke="none" stroke-width="1"/>
-<circle cx="536" cy="970" r="3" opacity="1" fill="#F87171" stroke="none" stroke-width="1"/>
-<circle cx="596" cy="974" r="3" opacity="1" fill="#F87171" stroke="none" stroke-width="1"/>
-<circle cx="657" cy="1018" r="3" opacity="1" fill="#F87171" stroke="none" stroke-width="1"/>
-<circle cx="718" cy="1035" r="3" opacity="1" fill="#F87171" stroke="none" stroke-width="1"/>
-<circle cx="778" cy="1043" r="3" opacity="1" fill="#F87171" stroke="none" stroke-width="1"/>
-<text x="784" y="1043" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="6.451612903225807" opacity="1" fill="#F87171" font-weight="bold">
+<circle cx="112" cy="1011" r="3" opacity="1" fill="#F87171" stroke="none" stroke-width="1"/>
+<circle cx="172" cy="1002" r="3" opacity="1" fill="#F87171" stroke="none" stroke-width="1"/>
+<circle cx="233" cy="986" r="3" opacity="1" fill="#F87171" stroke="none" stroke-width="1"/>
+<circle cx="293" cy="974" r="3" opacity="1" fill="#F87171" stroke="none" stroke-width="1"/>
+<circle cx="354" cy="946" r="3" opacity="1" fill="#F87171" stroke="none" stroke-width="1"/>
+<circle cx="415" cy="927" r="3" opacity="1" fill="#F87171" stroke="none" stroke-width="1"/>
+<circle cx="475" cy="916" r="3" opacity="1" fill="#F87171" stroke="none" stroke-width="1"/>
+<circle cx="536" cy="913" r="3" opacity="1" fill="#F87171" stroke="none" stroke-width="1"/>
+<circle cx="596" cy="912" r="3" opacity="1" fill="#F87171" stroke="none" stroke-width="1"/>
+<circle cx="657" cy="918" r="3" opacity="1" fill="#F87171" stroke="none" stroke-width="1"/>
+<circle cx="718" cy="1003" r="3" opacity="1" fill="#F87171" stroke="none" stroke-width="1"/>
+<circle cx="778" cy="1015" r="3" opacity="1" fill="#F87171" stroke="none" stroke-width="1"/>
+<text x="784" y="1015" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="6.451612903225807" opacity="1" fill="#F87171" font-weight="bold">
 L4
 </text>
-<polyline fill="none" opacity="0.35" stroke="#F59E0B" stroke-width="1" points="112,1022 172,1000 233,978 293,958 354,952 415,939 475,921 536,934 596,947 657,973 718,918 778,923 "/>
-<polyline fill="none" opacity="0.35" stroke="#F59E0B" stroke-width="1" points="112,1026 172,1004 233,982 293,962 354,940 415,927 475,917 536,937 596,950 657,974 718,920 778,921 "/>
-<polyline fill="none" opacity="0.35" stroke="#F59E0B" stroke-width="1" points="112,1027 172,1006 233,985 293,965 354,943 415,927 475,921 536,932 596,945 657,980 718,917 778,923 "/>
-<polyline fill="none" opacity="0.35" stroke="#F59E0B" stroke-width="1" points="112,1038 172,1015 233,992 293,971 354,949 415,935 475,940 536,960 596,957 657,985 718,919 778,923 "/>
-<polyline fill="none" opacity="0.35" stroke="#F59E0B" stroke-width="1" points="112,1027 172,1005 233,983 293,978 354,956 415,934 475,945 536,967 596,962 657,990 718,927 778,929 "/>
-<polyline fill="none" opacity="0.35" stroke="#F59E0B" stroke-width="1" points="112,1029 172,1007 233,985 293,965 354,943 415,923 475,932 536,969 596,969 657,996 718,931 778,928 "/>
-<polyline fill="none" opacity="0.35" stroke="#F59E0B" stroke-width="1" points="112,1031 172,1009 233,988 293,968 354,968 415,976 475,987 536,990 596,988 657,1006 718,926 778,931 "/>
-<text x="784" y="931" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="6.451612903225807" opacity="1" fill="#F59E0B" font-weight="bold">
+<polyline fill="none" opacity="0.35" stroke="#F59E0B" stroke-width="1" points="112,1024 172,1001 233,983 293,963 354,955 415,946 475,927 536,940 596,952 657,977 718,923 778,927 "/>
+<polyline fill="none" opacity="0.35" stroke="#F59E0B" stroke-width="1" points="112,1028 172,1005 233,986 293,966 354,944 415,933 475,923 536,942 596,955 657,978 718,925 778,925 "/>
+<polyline fill="none" opacity="0.35" stroke="#F59E0B" stroke-width="1" points="112,1029 172,1008 233,988 293,970 354,948 415,932 475,928 536,937 596,950 657,984 718,922 778,928 "/>
+<polyline fill="none" opacity="0.35" stroke="#F59E0B" stroke-width="1" points="112,1040 172,1017 233,996 293,975 354,955 415,942 475,946 536,962 596,962 657,989 718,924 778,928 "/>
+<polyline fill="none" opacity="0.35" stroke="#F59E0B" stroke-width="1" points="112,1029 172,1007 233,987 293,982 354,961 415,939 475,950 536,971 596,967 657,993 718,931 778,933 "/>
+<polyline fill="none" opacity="0.35" stroke="#F59E0B" stroke-width="1" points="112,1031 172,1009 233,990 293,970 354,948 415,928 475,938 536,974 596,974 657,999 718,936 778,932 "/>
+<polyline fill="none" opacity="0.35" stroke="#F59E0B" stroke-width="1" points="112,1033 172,1012 233,992 293,973 354,973 415,981 475,990 536,994 596,992 657,1010 718,930 778,935 "/>
+<text x="784" y="935" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="6.451612903225807" opacity="1" fill="#F59E0B" font-weight="bold">
 L-1
 </text>
-<polyline fill="none" opacity="0.35" stroke="#F59E0B" stroke-width="1" points="112,1075 172,1059 233,1039 293,1021 354,1011 415,1008 475,983 536,978 596,975 657,995 718,1004 778,1005 "/>
-<polyline fill="none" opacity="0.35" stroke="#F59E0B" stroke-width="1" points="112,1075 172,1060 233,1040 293,1022 354,1013 415,1015 475,1022 536,1029 596,1027 657,1050 718,1014 778,1020 "/>
-<polyline fill="none" opacity="0.35" stroke="#F59E0B" stroke-width="1" points="112,1081 172,1067 233,1054 293,1043 354,1036 415,1026 475,1036 536,1050 596,1053 657,1060 718,1063 778,1062 "/>
-<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="112,1022 172,1000 233,978 293,958 354,940 415,923 475,917 536,932 596,945 657,973 718,917 778,921 "/>
+<polyline fill="none" opacity="0.35" stroke="#F59E0B" stroke-width="1" points="112,1075 172,1061 233,1041 293,1023 354,1015 415,1010 475,985 536,980 596,977 657,997 718,1006 778,1008 "/>
+<polyline fill="none" opacity="0.35" stroke="#F59E0B" stroke-width="1" points="112,1076 172,1062 233,1041 293,1024 354,1015 415,1017 475,1025 536,1033 596,1031 657,1051 718,1016 778,1023 "/>
+<polyline fill="none" opacity="0.35" stroke="#F59E0B" stroke-width="1" points="112,1082 172,1068 233,1055 293,1044 354,1037 415,1028 475,1038 536,1052 596,1055 657,1063 718,1065 778,1065 "/>
+<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="112,1024 172,1001 233,983 293,963 354,944 415,928 475,923 536,937 596,950 657,977 718,922 778,925 "/>
 <polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="112,1091 117,1090 "/>
-<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="120,1089 125,1088 "/>
+<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="120,1089 125,1089 "/>
 <polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="129,1088 134,1087 "/>
-<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="138,1086 143,1086 "/>
-<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="147,1085 152,1084 "/>
-<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="156,1083 161,1083 "/>
-<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="165,1082 170,1081 "/>
-<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="172,1081 177,1080 "/>
-<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="181,1079 186,1078 "/>
-<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="190,1078 195,1077 "/>
-<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="199,1076 204,1075 "/>
-<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="208,1075 213,1074 "/>
-<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="217,1073 221,1072 "/>
-<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="225,1072 230,1071 "/>
-<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="233,1070 238,1070 "/>
-<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="242,1070 247,1070 "/>
-<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="251,1069 256,1069 "/>
-<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="260,1069 265,1069 "/>
-<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="269,1069 274,1068 "/>
-<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="278,1068 283,1068 "/>
-<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="287,1068 292,1067 "/>
-<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="293,1067 298,1067 "/>
-<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="302,1067 307,1067 "/>
-<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="311,1067 316,1067 "/>
-<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="320,1067 325,1067 "/>
-<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="329,1067 334,1067 "/>
-<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="338,1067 343,1067 "/>
-<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="347,1067 352,1067 "/>
-<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="354,1067 359,1067 "/>
-<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="363,1068 368,1068 "/>
-<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="372,1068 377,1069 "/>
-<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="381,1069 386,1070 "/>
-<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="390,1070 395,1071 "/>
-<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="399,1071 404,1072 "/>
-<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="408,1072 413,1073 "/>
-<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="415,1073 419,1070 "/>
-<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="422,1068 427,1066 "/>
-<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="430,1064 434,1061 "/>
-<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="438,1059 442,1056 "/>
-<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="445,1054 450,1052 "/>
-<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="453,1050 457,1047 "/>
-<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="461,1045 465,1042 "/>
-<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="468,1040 473,1038 "/>
-<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="475,1036 480,1037 "/>
-<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="484,1038 489,1040 "/>
-<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="493,1041 498,1042 "/>
-<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="501,1043 506,1044 "/>
-<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="510,1045 515,1046 "/>
-<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="519,1047 524,1048 "/>
-<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="528,1049 532,1051 "/>
-<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="536,1051 541,1052 "/>
-<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="545,1052 550,1053 "/>
-<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="554,1054 559,1054 "/>
-<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="563,1055 568,1055 "/>
-<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="572,1056 577,1056 "/>
-<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="580,1057 585,1057 "/>
-<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="589,1058 594,1058 "/>
-<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="596,1059 601,1060 "/>
-<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="605,1061 610,1062 "/>
-<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="614,1063 619,1064 "/>
-<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="623,1065 627,1066 "/>
-<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="631,1067 636,1069 "/>
-<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="640,1070 645,1071 "/>
-<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="649,1072 654,1073 "/>
-<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="657,1074 662,1073 "/>
-<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="666,1073 671,1072 "/>
-<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="675,1072 680,1071 "/>
-<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="684,1071 689,1070 "/>
-<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="693,1070 698,1069 "/>
-<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="702,1069 707,1068 "/>
-<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="711,1068 716,1067 "/>
-<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="718,1067 723,1067 "/>
-<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="727,1067 732,1067 "/>
-<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="736,1067 741,1067 "/>
-<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="745,1067 750,1067 "/>
-<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="754,1067 759,1067 "/>
-<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="763,1067 768,1067 "/>
-<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="772,1067 777,1067 "/>
-<circle cx="112" cy="1022" r="3" opacity="1" fill="#F59E0B" stroke="none" stroke-width="1"/>
-<circle cx="172" cy="1000" r="3" opacity="1" fill="#F59E0B" stroke="none" stroke-width="1"/>
-<circle cx="233" cy="978" r="3" opacity="1" fill="#F59E0B" stroke="none" stroke-width="1"/>
-<circle cx="293" cy="958" r="3" opacity="1" fill="#F59E0B" stroke="none" stroke-width="1"/>
-<circle cx="354" cy="940" r="3" opacity="1" fill="#F59E0B" stroke="none" stroke-width="1"/>
-<circle cx="415" cy="923" r="3" opacity="1" fill="#F59E0B" stroke="none" stroke-width="1"/>
-<circle cx="475" cy="917" r="3" opacity="1" fill="#F59E0B" stroke="none" stroke-width="1"/>
-<circle cx="536" cy="932" r="3" opacity="1" fill="#F59E0B" stroke="none" stroke-width="1"/>
-<circle cx="596" cy="945" r="3" opacity="1" fill="#F59E0B" stroke="none" stroke-width="1"/>
-<circle cx="657" cy="973" r="3" opacity="1" fill="#F59E0B" stroke="none" stroke-width="1"/>
-<circle cx="718" cy="917" r="3" opacity="1" fill="#F59E0B" stroke="none" stroke-width="1"/>
-<circle cx="778" cy="921" r="3" opacity="1" fill="#F59E0B" stroke="none" stroke-width="1"/>
-<text x="784" y="921" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="6.451612903225807" opacity="1" fill="#F59E0B" font-weight="bold">
+<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="138,1087 143,1086 "/>
+<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="147,1085 152,1085 "/>
+<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="156,1084 161,1083 "/>
+<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="165,1083 170,1082 "/>
+<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="172,1082 177,1081 "/>
+<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="181,1080 186,1079 "/>
+<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="190,1079 195,1078 "/>
+<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="199,1077 204,1076 "/>
+<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="208,1076 213,1075 "/>
+<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="217,1074 221,1073 "/>
+<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="225,1073 230,1072 "/>
+<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="233,1071 238,1071 "/>
+<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="242,1071 247,1071 "/>
+<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="251,1071 256,1070 "/>
+<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="260,1070 265,1070 "/>
+<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="269,1070 274,1070 "/>
+<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="278,1069 283,1069 "/>
+<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="287,1069 292,1069 "/>
+<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="293,1069 298,1069 "/>
+<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="302,1069 307,1069 "/>
+<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="311,1070 316,1070 "/>
+<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="320,1070 325,1070 "/>
+<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="329,1070 334,1071 "/>
+<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="338,1071 343,1071 "/>
+<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="347,1071 352,1072 "/>
+<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="354,1072 359,1072 "/>
+<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="363,1072 368,1072 "/>
+<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="372,1073 377,1073 "/>
+<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="381,1073 386,1073 "/>
+<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="390,1073 395,1074 "/>
+<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="399,1074 404,1074 "/>
+<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="408,1074 413,1074 "/>
+<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="415,1074 419,1072 "/>
+<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="422,1070 427,1067 "/>
+<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="430,1065 434,1063 "/>
+<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="438,1061 442,1058 "/>
+<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="446,1056 450,1053 "/>
+<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="453,1051 458,1049 "/>
+<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="461,1047 465,1044 "/>
+<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="469,1042 473,1040 "/>
+<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="475,1038 480,1040 "/>
+<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="484,1041 489,1042 "/>
+<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="493,1043 498,1044 "/>
+<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="501,1045 506,1046 "/>
+<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="510,1047 515,1048 "/>
+<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="519,1049 524,1050 "/>
+<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="528,1051 532,1053 "/>
+<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="536,1053 541,1054 "/>
+<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="545,1055 550,1055 "/>
+<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="554,1056 559,1056 "/>
+<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="563,1057 568,1057 "/>
+<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="572,1058 576,1058 "/>
+<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="580,1059 585,1059 "/>
+<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="589,1060 594,1061 "/>
+<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="596,1061 601,1062 "/>
+<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="605,1063 610,1064 "/>
+<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="614,1065 619,1066 "/>
+<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="623,1067 628,1068 "/>
+<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="631,1069 636,1070 "/>
+<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="640,1071 645,1072 "/>
+<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="649,1073 654,1074 "/>
+<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="657,1075 662,1074 "/>
+<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="666,1074 671,1073 "/>
+<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="675,1073 680,1073 "/>
+<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="684,1072 689,1072 "/>
+<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="693,1071 698,1071 "/>
+<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="702,1070 707,1070 "/>
+<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="711,1069 716,1069 "/>
+<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="718,1069 723,1069 "/>
+<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="727,1069 732,1069 "/>
+<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="736,1069 741,1069 "/>
+<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="745,1069 750,1069 "/>
+<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="754,1069 759,1069 "/>
+<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="763,1069 768,1069 "/>
+<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="772,1069 777,1069 "/>
+<circle cx="112" cy="1024" r="3" opacity="1" fill="#F59E0B" stroke="none" stroke-width="1"/>
+<circle cx="172" cy="1001" r="3" opacity="1" fill="#F59E0B" stroke="none" stroke-width="1"/>
+<circle cx="233" cy="983" r="3" opacity="1" fill="#F59E0B" stroke="none" stroke-width="1"/>
+<circle cx="293" cy="963" r="3" opacity="1" fill="#F59E0B" stroke="none" stroke-width="1"/>
+<circle cx="354" cy="944" r="3" opacity="1" fill="#F59E0B" stroke="none" stroke-width="1"/>
+<circle cx="415" cy="928" r="3" opacity="1" fill="#F59E0B" stroke="none" stroke-width="1"/>
+<circle cx="475" cy="923" r="3" opacity="1" fill="#F59E0B" stroke="none" stroke-width="1"/>
+<circle cx="536" cy="937" r="3" opacity="1" fill="#F59E0B" stroke="none" stroke-width="1"/>
+<circle cx="596" cy="950" r="3" opacity="1" fill="#F59E0B" stroke="none" stroke-width="1"/>
+<circle cx="657" cy="977" r="3" opacity="1" fill="#F59E0B" stroke="none" stroke-width="1"/>
+<circle cx="718" cy="922" r="3" opacity="1" fill="#F59E0B" stroke="none" stroke-width="1"/>
+<circle cx="778" cy="925" r="3" opacity="1" fill="#F59E0B" stroke="none" stroke-width="1"/>
+<text x="784" y="925" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="6.451612903225807" opacity="1" fill="#F59E0B" font-weight="bold">
 L-7
 </text>
 <circle cx="112" cy="1091" r="3" opacity="1" fill="#F59E0B" stroke="none" stroke-width="1"/>
-<circle cx="172" cy="1081" r="3" opacity="1" fill="#F59E0B" stroke="none" stroke-width="1"/>
-<circle cx="233" cy="1070" r="3" opacity="1" fill="#F59E0B" stroke="none" stroke-width="1"/>
-<circle cx="293" cy="1067" r="3" opacity="1" fill="#F59E0B" stroke="none" stroke-width="1"/>
-<circle cx="354" cy="1067" r="3" opacity="1" fill="#F59E0B" stroke="none" stroke-width="1"/>
-<circle cx="415" cy="1073" r="3" opacity="1" fill="#F59E0B" stroke="none" stroke-width="1"/>
-<circle cx="475" cy="1036" r="3" opacity="1" fill="#F59E0B" stroke="none" stroke-width="1"/>
-<circle cx="536" cy="1051" r="3" opacity="1" fill="#F59E0B" stroke="none" stroke-width="1"/>
-<circle cx="596" cy="1059" r="3" opacity="1" fill="#F59E0B" stroke="none" stroke-width="1"/>
-<circle cx="657" cy="1074" r="3" opacity="1" fill="#F59E0B" stroke="none" stroke-width="1"/>
-<circle cx="718" cy="1067" r="3" opacity="1" fill="#F59E0B" stroke="none" stroke-width="1"/>
-<circle cx="778" cy="1067" r="3" opacity="1" fill="#F59E0B" stroke="none" stroke-width="1"/>
-<text x="784" y="1067" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="6.451612903225807" opacity="1" fill="#F59E0B" font-weight="bold">
+<circle cx="172" cy="1082" r="3" opacity="1" fill="#F59E0B" stroke="none" stroke-width="1"/>
+<circle cx="233" cy="1071" r="3" opacity="1" fill="#F59E0B" stroke="none" stroke-width="1"/>
+<circle cx="293" cy="1069" r="3" opacity="1" fill="#F59E0B" stroke="none" stroke-width="1"/>
+<circle cx="354" cy="1072" r="3" opacity="1" fill="#F59E0B" stroke="none" stroke-width="1"/>
+<circle cx="415" cy="1074" r="3" opacity="1" fill="#F59E0B" stroke="none" stroke-width="1"/>
+<circle cx="475" cy="1038" r="3" opacity="1" fill="#F59E0B" stroke="none" stroke-width="1"/>
+<circle cx="536" cy="1053" r="3" opacity="1" fill="#F59E0B" stroke="none" stroke-width="1"/>
+<circle cx="596" cy="1061" r="3" opacity="1" fill="#F59E0B" stroke="none" stroke-width="1"/>
+<circle cx="657" cy="1075" r="3" opacity="1" fill="#F59E0B" stroke="none" stroke-width="1"/>
+<circle cx="718" cy="1069" r="3" opacity="1" fill="#F59E0B" stroke="none" stroke-width="1"/>
+<circle cx="778" cy="1069" r="3" opacity="1" fill="#F59E0B" stroke="none" stroke-width="1"/>
+<text x="784" y="1069" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="6.451612903225807" opacity="1" fill="#F59E0B" font-weight="bold">
 L4
 </text>
 <text x="20" y="581" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="9.67741935483871" opacity="1" fill="#E6EDF3" font-weight="bold" transform="rotate(270, 20, 581)">

--- a/doc/charts/x86_64/summary.svg
+++ b/doc/charts/x86_64/summary.svg
@@ -1,50 +1,50 @@
 <svg viewBox="0 0 700 483" xmlns="http://www.w3.org/2000/svg" font-family="system-ui, -apple-system, sans-serif">
 <rect x="0" y="0" width="700" height="483" opacity="1" fill="#0D1117" stroke="none"/>
 <text x="350" y="22" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="12.096774193548388" opacity="1" fill="#E6EDF3" font-weight="bold">
-12-file Silesia: Pipeline @100 MB/s geomean, Level 1 (lower is better)
+12-file Silesia: Pipeline @100 MB/s geomean, L-7..L4 (ruzstd L1)
 </text>
 <text x="350" y="40" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#7D8590">
-Linux VM on a 2018 Mac Mini, Intel Core i7-8700B @ 3.20GHz, performance governor, turbo off
+Linux VM on a 2018 Mac Mini, Intel Core i7-8700B @ 3.20GHz, 12 cores, performance governor, turbo off
 </text>
 <text x="22" y="188" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="9.67741935483871" opacity="1" fill="#E6EDF3" font-weight="bold" transform="rotate(270, 22, 188)">
 seconds / GB
 </text>
-<polyline fill="none" opacity="1" stroke="#21262D" stroke-width="1" points="70,235 680,235 "/>
-<text x="62" y="235" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#7D8590">
+<polyline fill="none" opacity="1" stroke="#21262D" stroke-width="1" points="70,236 680,236 "/>
+<text x="62" y="236" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#7D8590">
 10.0
 </text>
 <polyline fill="none" opacity="1" stroke="#21262D" stroke-width="1" points="70,158 680,158 "/>
 <text x="62" y="158" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#7D8590">
 20.0
 </text>
-<polyline fill="none" opacity="1" stroke="#21262D" stroke-width="1" points="70,80 680,80 "/>
-<text x="62" y="80" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#7D8590">
+<polyline fill="none" opacity="1" stroke="#21262D" stroke-width="1" points="70,81 680,81 "/>
+<text x="62" y="81" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#7D8590">
 30.0
 </text>
 <polyline fill="none" opacity="1" stroke="#30363D" stroke-width="2" points="70,313 680,313 "/>
-<rect x="111" y="289" width="80" height="24" opacity="1" fill="#60A5FA" stroke="none"/>
-<rect x="111" y="263" width="80" height="26" opacity="1" fill="#4680C4" stroke="none"/>
-<rect x="111" y="256" width="80" height="7" opacity="1" fill="#60A5FA" stroke="none"/>
+<rect x="111" y="292" width="80" height="21" opacity="1" fill="#60A5FA" stroke="none"/>
+<rect x="111" y="261" width="80" height="31" opacity="1" fill="#4680C4" stroke="none"/>
+<rect x="111" y="255" width="80" height="6" opacity="1" fill="#60A5FA" stroke="none"/>
 <text x="151" y="329" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E6EDF3" font-weight="bold">
 C zstd
 </text>
-<rect x="223" y="275" width="80" height="38" opacity="1" fill="#F87171" stroke="none"/>
-<rect x="223" y="246" width="80" height="29" opacity="1" fill="#C45050" stroke="none"/>
-<rect x="223" y="231" width="80" height="15" opacity="1" fill="#F87171" stroke="none"/>
+<rect x="223" y="281" width="80" height="32" opacity="1" fill="#F87171" stroke="none"/>
+<rect x="223" y="250" width="80" height="31" opacity="1" fill="#C45050" stroke="none"/>
+<rect x="223" y="239" width="80" height="11" opacity="1" fill="#F87171" stroke="none"/>
 <text x="263" y="329" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E6EDF3" font-weight="bold">
 zrip
 </text>
-<rect x="335" y="272" width="80" height="41" opacity="1" fill="#F59E0B" stroke="none"/>
-<rect x="335" y="245" width="80" height="27" opacity="1" fill="#C47D08" stroke="none"/>
-<rect x="335" y="234" width="80" height="11" opacity="1" fill="#F59E0B" stroke="none"/>
+<rect x="335" y="270" width="80" height="43" opacity="1" fill="#F472B6" stroke="none"/>
+<rect x="335" y="238" width="80" height="32" opacity="1" fill="#C05A92" stroke="none"/>
+<rect x="335" y="225" width="80" height="13" opacity="1" fill="#F472B6" stroke="none"/>
 <text x="375" y="329" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E6EDF3" font-weight="bold">
-structured-zstd
-</text>
-<rect x="447" y="260" width="80" height="53" opacity="1" fill="#F472B6" stroke="none"/>
-<rect x="447" y="232" width="80" height="28" opacity="1" fill="#C05A92" stroke="none"/>
-<rect x="447" y="213" width="80" height="19" opacity="1" fill="#F472B6" stroke="none"/>
-<text x="487" y="329" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E6EDF3" font-weight="bold">
 zrip paranoid
+</text>
+<rect x="447" y="277" width="80" height="36" opacity="1" fill="#F59E0B" stroke="none"/>
+<rect x="447" y="245" width="80" height="32" opacity="1" fill="#C47D08" stroke="none"/>
+<rect x="447" y="236" width="80" height="9" opacity="1" fill="#F59E0B" stroke="none"/>
+<text x="487" y="329" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E6EDF3" font-weight="bold">
+structured-zstd
 </text>
 <rect x="559" y="163" width="80" height="150" opacity="1" fill="#4ADE80" stroke="none"/>
 <rect x="559" y="129" width="80" height="34" opacity="1" fill="#3AAF60" stroke="none"/>
@@ -60,13 +60,13 @@ libzstd v1.5.7 (C)
 <text x="133" y="385" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E6EDF3">
 zrip (safe SIMD + encapsulated unsafe)
 </text>
-<rect x="115" y="399" width="12" height="12" opacity="1" fill="#F59E0B" stroke="none"/>
+<rect x="115" y="399" width="12" height="12" opacity="1" fill="#F472B6" stroke="none"/>
 <text x="133" y="405" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E6EDF3">
-structured-zstd v0.0.49 (unsafe)
-</text>
-<rect x="385" y="359" width="12" height="12" opacity="1" fill="#F472B6" stroke="none"/>
-<text x="403" y="365" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E6EDF3">
 zrip paranoid (safe SIMD, no unsafe)
+</text>
+<rect x="385" y="359" width="12" height="12" opacity="1" fill="#F59E0B" stroke="none"/>
+<text x="403" y="365" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E6EDF3">
+structured-zstd v0.0.49 (unsafe)
 </text>
 <rect x="385" y="379" width="12" height="12" opacity="1" fill="#4ADE80" stroke="none"/>
 <text x="403" y="385" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E6EDF3">


### PR DESCRIPTION
- Accelerate repeated no-match scanning in the fast and dfast parsers.
- Remove the pre-block compressibility detector.
- Update benchmark chart ordering and summary geomean, then refresh charts.