### PR TITLE
Add npm WASM release workflow

### DIFF
--- a/.github/workflows/release-npm.yml
+++ b/.github/workflows/release-npm.yml
@@ -1,0 +1,121 @@
+name: Release zrip npm
+
+on:
+  push:
+    tags:
+      - "zrip-npm-v*"
+  workflow_dispatch:
+    inputs:
+      version:
+        description: npm version to publish, for example 0.5.8
+        required: true
+
+permissions:
+  contents: read
+
+jobs:
+  package:
+    name: Package npm tarball
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-unknown
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "24"
+      - name: Install wasm-pack
+        run: cargo install wasm-pack
+      - name: Resolve version
+        id: version
+        shell: bash
+        run: |
+          if [[ "${GITHUB_REF_TYPE}" == "tag" ]]; then
+            echo "version=${GITHUB_REF_NAME#zrip-npm-v}" >> "$GITHUB_OUTPUT"
+          else
+            echo "version=${{ inputs.version }}" >> "$GITHUB_OUTPUT"
+          fi
+      - name: Prepare package metadata
+        working-directory: npm
+        run: npm pkg set version="${{ steps.version.outputs.version }}"
+      - name: Test package
+        working-directory: npm
+        run: npm test
+      - name: Pack tarball
+        working-directory: npm
+        run: |
+          mkdir -p release-tarballs
+          npm pack --pack-destination release-tarballs
+          ls -l release-tarballs
+      - uses: actions/upload-artifact@v4
+        with:
+          name: npm-release-tarball
+          path: npm/release-tarballs/*.tgz
+          retention-days: 7
+
+  smoke:
+    name: Smoke npm tarball
+    runs-on: ubuntu-latest
+    needs: [package]
+    timeout-minutes: 10
+    steps:
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "24"
+      - uses: actions/download-artifact@v4
+        with:
+          name: npm-release-tarball
+          path: dist
+      - name: Install packed package
+        shell: bash
+        run: |
+          mkdir smoke
+          cd smoke
+          tarball="../dist/paddor-zrip-${{ needs.package.outputs.version }}.tgz"
+          test -f "$tarball"
+          npm init -y
+          npm install "$tarball"
+      - name: Run public API smoke
+        shell: bash
+        working-directory: smoke
+        run: |
+          node --input-type=module <<'NODE'
+          import { compress, decompress, init } from "@paddor/zrip";
+
+          await init();
+          const data = new TextEncoder().encode("npm smoke ".repeat(100));
+          const compressed = compress(data, 1);
+          const output = decompress(compressed);
+          if (Buffer.compare(Buffer.from(output), Buffer.from(data)) !== 0) {
+            throw new Error("round-trip mismatch");
+          }
+          NODE
+
+  publish:
+    name: Publish to npm
+    runs-on: ubuntu-latest
+    needs: [package, smoke]
+    timeout-minutes: 15
+    environment:
+      name: npm
+      url: https://www.npmjs.com/package/@paddor/zrip
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "24"
+          registry-url: https://registry.npmjs.org
+      - uses: actions/download-artifact@v4
+        with:
+          name: npm-release-tarball
+          path: dist
+      - name: Publish package
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm publish "./dist/paddor-zrip-${{ needs.package.outputs.version }}.tgz" --access public --provenance

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ corpus/
 Cargo.lock
 /jsr/src/pkg/
 /jsr/deno.lock
+/npm/src/pkg/
+/npm/*.tgz

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added npm package metadata, Node-compatible WASM initialization, and a dry
+  pack/test path for `@paddor/zrip`.
+- Added an npm release workflow that builds, smokes, and publishes
+  `@paddor/zrip` from GitHub Actions with OIDC provenance.
+
 ## [0.8.7]
 
 ### Changed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace]
 members = ["crates/core", "crates/encode", "crates/decode"]
-exclude = ["fuzz", "bench", "jsr"]
+exclude = ["fuzz", "bench", "jsr", "npm"]
 
 [package]
 name = "zrip"

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -29,8 +29,8 @@ GitHub releases. Configuration lives in `release-plz.toml`.
    `## [x.y.z]` section below `## [Unreleased]`. Never modify existing
    versioned sections.
 
-3. **Bump the JSR package when publishing WASM.** Update
-   `jsr/deno.json`, rebuild the package with `cd jsr && bash build.sh`, and
+3. **Bump the WASM package when publishing WASM.** Update `jsr/deno.json` and
+   `npm/package.json`, rebuild the package with `cd jsr && bash build.sh`, and
    refresh wasm32 charts if Rust codec performance changed.
 
 4. **Run any needed release audit.** Use the Miri and fuzz commands below
@@ -38,6 +38,36 @@ GitHub releases. Configuration lives in `release-plz.toml`.
 
 5. **Merge the release PR.** release-plz tags and publishes to crates.io
    automatically.
+
+### npm
+
+`@paddor/zrip` publishes to npm from `.github/workflows/release-npm.yml`.
+The workflow version comes from a `zrip-npm-v*` tag or the manual
+`workflow_dispatch` input. It builds the WASM package, runs Node tests, packs
+the tarball, smoke-tests an installed tarball, then publishes from the `npm`
+environment.
+
+Publishing uses npm trusted publishing with GitHub Actions OIDC. In npm,
+configure a trusted publisher for `@paddor/zrip` before tagging:
+
+```text
+GitHub owner: paddor
+GitHub repository: zrip
+Workflow filename: release-npm.yml
+Environment name: npm
+Allowed action: npm publish
+```
+
+If the package does not exist yet, trusted publishing may need a bootstrap
+publish first. Add a publish-capable GitHub Actions secret named `NPM_TOKEN`,
+run `.github/workflows/release-npm.yml`, then remove or rotate that token and
+configure the trusted publisher before the next CI release.
+
+```sh
+git tag -a zrip-npm-v0.5.8 -m "zrip npm 0.5.8"
+git push origin zrip-npm-v0.5.8
+gh run watch --repo paddor/zrip --exit-status
+```
 
 ## Kani
 

--- a/README.md
+++ b/README.md
@@ -30,8 +30,8 @@ small-message workloads (log lines, JSON records, RPC payloads).
 feature; `frame` requires `std`.
 
 **WebAssembly.** Available as [`@paddor/zrip`](https://jsr.io/@paddor/zrip)
-on JSR. Auto-detects WASM SIMD support. 15% faster encode than C zstd compiled
-to WASM.
+on JSR and npm. Auto-detects WASM SIMD support. 15% faster encode than C zstd
+compiled to WASM.
 
 ## Performance
 

--- a/npm/LICENSE
+++ b/npm/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Patrik Wenger
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/npm/README.md
+++ b/npm/README.md
@@ -1,0 +1,25 @@
+# @paddor/zrip
+
+Pure Rust zstd codec compiled to WebAssembly. Decodes standard zstd blocks and
+frames produced at any compression level. Encodes levels -8 through 4 for fast
+transfer pipelines. First-class dictionary support.
+
+Automatically detects WASM SIMD support and loads the appropriate binary.
+
+## Usage
+
+```js
+import { compress, decompress, init } from "@paddor/zrip";
+
+await init();
+
+const data = new TextEncoder().encode("hello world".repeat(1000));
+const compressed = compress(data, 1);
+const original = decompress(compressed);
+const bounded = decompress(compressed, { maxDecompressedSize: data.length });
+```
+
+## Source
+
+Rust source and native benchmarks:
+[github.com/paddor/zrip](https://github.com/paddor/zrip)

--- a/npm/build.sh
+++ b/npm/build.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+set -e
+cd "$(dirname "$0")"
+
+JSR_PKG=../jsr/src/pkg
+NPM_PKG=src/pkg
+
+if [ ! -f "$JSR_PKG/zrip_wasm.js" ] ||
+   [ ! -f "$JSR_PKG/zrip_wasm.d.ts" ] ||
+   [ ! -f "$JSR_PKG/zrip_wasm_bg.wasm.d.ts" ] ||
+   [ ! -f "$JSR_PKG/zrip_wasm_bg.wasm" ] ||
+   [ ! -f "$JSR_PKG/zrip_simd.wasm" ]; then
+  (cd ../jsr && bash build.sh)
+fi
+
+rm -rf "$NPM_PKG"
+mkdir -p "$NPM_PKG"
+cp "$JSR_PKG/zrip_wasm.js" "$NPM_PKG/"
+cp "$JSR_PKG/zrip_wasm.d.ts" "$NPM_PKG/"
+cp "$JSR_PKG/zrip_wasm_bg.wasm.d.ts" "$NPM_PKG/"
+cp "$JSR_PKG/zrip_wasm_bg.wasm" "$NPM_PKG/"
+cp "$JSR_PKG/zrip_simd.wasm" "$NPM_PKG/"

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,0 +1,45 @@
+{
+  "name": "@paddor/zrip",
+  "version": "0.5.7",
+  "description": "Pure Rust zstd codec compiled to WebAssembly. Decodes all zstd levels, encodes -8..4, with SIMD auto-detection.",
+  "license": "MIT",
+  "type": "module",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/paddor/zrip.git",
+    "directory": "npm"
+  },
+  "homepage": "https://github.com/paddor/zrip#readme",
+  "bugs": {
+    "url": "https://github.com/paddor/zrip/issues"
+  },
+  "keywords": [
+    "zstd",
+    "zstandard",
+    "compression",
+    "decompression",
+    "wasm",
+    "webassembly"
+  ],
+  "exports": {
+    ".": {
+      "types": "./src/mod.d.ts",
+      "import": "./src/mod.js"
+    }
+  },
+  "types": "./src/mod.d.ts",
+  "files": [
+    "src/",
+    "LICENSE",
+    "README.md"
+  ],
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
+  },
+  "scripts": {
+    "build": "bash build.sh",
+    "pack:dry": "npm run build && npm pack --dry-run",
+    "test": "npm run build && node --test"
+  }
+}

--- a/npm/src/mod.d.ts
+++ b/npm/src/mod.d.ts
@@ -1,0 +1,46 @@
+export interface DecompressOptions {
+  maxDecompressedSize?: number;
+}
+
+export class Compressor {
+  constructor(level: number);
+  static withDict(level: number, dict: Dictionary): Compressor;
+  compress(input: Uint8Array): Uint8Array;
+  compressWithDict(input: Uint8Array, dict: Dictionary): Uint8Array;
+  free(): void;
+  [Symbol.dispose](): void;
+}
+
+export class Decompressor {
+  constructor();
+  static withDict(dict: Dictionary): Decompressor;
+  decompress(input: Uint8Array, options?: DecompressOptions): Uint8Array;
+  free(): void;
+  [Symbol.dispose](): void;
+}
+
+export class Dictionary {
+  constructor(data: Uint8Array);
+  readonly id: number;
+  free(): void;
+  [Symbol.dispose](): void;
+}
+
+export function init(): Promise<void>;
+export function initSyncFromBytes(bytes: BufferSource): void;
+export function compress(input: Uint8Array, level?: number): Uint8Array;
+export function decompress(
+  input: Uint8Array,
+  options?: DecompressOptions,
+): Uint8Array;
+export function compressBound(inputLen: number): number;
+export function compressWithDict(
+  input: Uint8Array,
+  level: number,
+  dict: Dictionary,
+): Uint8Array;
+export function decompressWithDict(
+  input: Uint8Array,
+  dict: Dictionary,
+  options?: DecompressOptions,
+): Uint8Array;

--- a/npm/src/mod.js
+++ b/npm/src/mod.js
@@ -1,0 +1,154 @@
+import {
+  compress as wasmCompress,
+  compressBound as wasmCompressBound,
+  Compressor as _Compressor,
+  compressWithDict as wasmCompressWithDict,
+  decompress as wasmDecompress,
+  Decompressor as WasmDecompressor,
+  decompressWithDict as wasmDecompressWithDict,
+  Dictionary as _Dictionary,
+  initSync,
+} from "./pkg/zrip_wasm.js";
+
+export const Compressor = _Compressor;
+export const Dictionary = _Dictionary;
+
+const MAX_WASM_USIZE = 0xffff_ffff;
+
+function maxDecompressedSize(options) {
+  const max = options?.maxDecompressedSize;
+  if (max === undefined) return undefined;
+  if (!Number.isSafeInteger(max) || max < 0 || max > MAX_WASM_USIZE) {
+    throw new RangeError(
+      "maxDecompressedSize must be an integer from 0 to 4294967295",
+    );
+  }
+  return max;
+}
+
+const decompressorInner = new WeakMap();
+
+function getDecompressorInner(decompressor) {
+  const inner = decompressorInner.get(decompressor);
+  if (!inner) {
+    throw new TypeError("invalid or freed Decompressor");
+  }
+  return inner;
+}
+
+export class Decompressor {
+  constructor() {
+    decompressorInner.set(this, new WasmDecompressor());
+  }
+
+  static withDict(dict) {
+    const decompressor = new Decompressor();
+    getDecompressorInner(decompressor).free();
+    decompressorInner.set(decompressor, WasmDecompressor.withDict(dict));
+    return decompressor;
+  }
+
+  decompress(input, options) {
+    return getDecompressorInner(this).decompress(
+      input,
+      maxDecompressedSize(options),
+    );
+  }
+
+  free() {
+    const inner = decompressorInner.get(this);
+    if (!inner) return;
+    decompressorInner.delete(this);
+    inner.free();
+  }
+
+  [Symbol.dispose]() {
+    this.free();
+  }
+}
+
+const SIMD_TEST = new Uint8Array([
+  0x00,
+  0x61,
+  0x73,
+  0x6d,
+  0x01,
+  0x00,
+  0x00,
+  0x00,
+  0x01,
+  0x05,
+  0x01,
+  0x60,
+  0x00,
+  0x01,
+  0x7b,
+  0x03,
+  0x02,
+  0x01,
+  0x00,
+  0x0a,
+  0x0a,
+  0x01,
+  0x08,
+  0x00,
+  0x41,
+  0x00,
+  0xfd,
+  0x0f,
+  0xfd,
+  0x62,
+  0x0b,
+]);
+
+let initialized = false;
+
+async function loadWasmBytes(url) {
+  if (url.protocol === "file:" && globalThis.process?.versions?.node) {
+    const { readFile } = await import("node:fs/promises");
+    return readFile(url);
+  }
+
+  const response = await fetch(url);
+  if (!response.ok) {
+    throw new Error(`failed to fetch ${url}: HTTP ${response.status}`);
+  }
+  return response.arrayBuffer();
+}
+
+export async function init() {
+  if (initialized) return;
+
+  const simd = WebAssembly.validate(SIMD_TEST);
+  const wasmFile = simd ? "zrip_simd.wasm" : "zrip_wasm_bg.wasm";
+  const wasmUrl = new URL(`./pkg/${wasmFile}`, import.meta.url);
+  const bytes = await loadWasmBytes(wasmUrl);
+  initSync({ module: new WebAssembly.Module(bytes) });
+  initialized = true;
+}
+
+export function initSyncFromBytes(bytes) {
+  if (initialized) return;
+  initSync({ module: new WebAssembly.Module(bytes) });
+  initialized = true;
+}
+
+export function compress(input, level = 1) {
+  return wasmCompress(input, level);
+}
+
+export function decompress(input, options) {
+  return wasmDecompress(input, maxDecompressedSize(options));
+}
+
+export function compressBound(inputLen) {
+  return wasmCompressBound(inputLen);
+}
+
+export function compressWithDict(input, level, dict) {
+  return wasmCompressWithDict(input, level, dict);
+}
+
+export function decompressWithDict(input, dict, options) {
+  return wasmDecompressWithDict(input, dict, maxDecompressedSize(options));
+}

--- a/npm/test/mod.test.js
+++ b/npm/test/mod.test.js
@@ -1,0 +1,72 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  compress,
+  compressBound,
+  Compressor,
+  decompress,
+  Decompressor,
+  init,
+} from "../src/mod.js";
+
+await init();
+
+test("one-shot round-trip", () => {
+  const data = new TextEncoder().encode("hello world, hello zstd!".repeat(100));
+  const compressed = compress(data);
+  assert.ok(compressed.length < data.length);
+  assert.deepEqual(decompress(compressed), data);
+});
+
+test("all levels", () => {
+  const data = new TextEncoder().encode("test data for all levels".repeat(50));
+  for (let level = -8; level <= 4; level++) {
+    const compressed = compress(data, level);
+    assert.deepEqual(decompress(compressed), data);
+  }
+});
+
+test("compressBound", () => {
+  assert.ok(compressBound(1000) >= 1000);
+});
+
+test("decompress limit applies", () => {
+  const data = new TextEncoder().encode("limited output".repeat(20));
+  const compressed = compress(data);
+
+  assert.throws(() =>
+    decompress(compressed, { maxDecompressedSize: data.length - 1 })
+  );
+  assert.deepEqual(
+    decompress(compressed, { maxDecompressedSize: data.length }),
+    data,
+  );
+});
+
+test("decompress rejects invalid limit option", () => {
+  const data = new TextEncoder().encode("test");
+  const compressed = compress(data);
+
+  assert.throws(
+    () => decompress(compressed, { maxDecompressedSize: -1 }),
+    RangeError,
+  );
+});
+
+test("stateful compressor", () => {
+  const compressor = new Compressor(1);
+  const data = new TextEncoder().encode("stateful compression".repeat(50));
+  const compressed = compressor.compress(data);
+
+  assert.deepEqual(decompress(compressed), data);
+  compressor.free();
+});
+
+test("stateful decompressor", () => {
+  const data = new TextEncoder().encode("stateful decompression".repeat(50));
+  const compressed = compress(data);
+  const decompressor = new Decompressor();
+
+  assert.deepEqual(decompressor.decompress(compressed), data);
+  decompressor.free();
+});


### PR DESCRIPTION
- Add Node-compatible npm package files for `@paddor/zrip`.
- Reuse generated WASM output from `jsr/build.sh` without tracking binary artifacts.
- Add `release-npm.yml` to pack, smoke-test, and publish from GitHub Actions with provenance.
- Document npm bootstrap and trusted publisher setup.