### PR TITLE
Fix frame parsing and streaming error handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@
 - Added an npm release workflow that builds, smokes, and publishes
   `@paddor/zrip` from GitHub Actions with OIDC provenance.
 
+### Fixed
+
+- Accept explicitly encoded dictionary ID zero without requiring a dictionary.
+- Ignore the unused frame descriptor bit while retaining reserved-bit checks.
+- Correct `FrameDecoder` skippable-frame lengths and reject truncated payloads.
+- Reject incomplete streaming frame headers, including after a complete frame.
+- Discard failed decoder output and require `FrameDecoder::reset` after decoding
+  or reader errors, preventing later reads from returning rejected block data.
+- Keep `FrameEncoder` failed after write, flush, or finalization errors,
+  including partial writes and `WouldBlock`. Discard incomplete output and
+  create a new encoder after an error.
+
 ## [0.8.7]
 
 ### Changed

--- a/crates/core/src/frame/header.rs
+++ b/crates/core/src/frame/header.rs
@@ -44,10 +44,7 @@ pub fn parse_frame_header_after_magic(
     if reserved {
         return Err(DecompressError::BadFrameHeader);
     }
-    let unused = (descriptor & 0x10) != 0;
-    if unused {
-        return Err(DecompressError::BadFrameHeader);
-    }
+    // Descriptor bit 4 is unused and must be ignored by decoders.
 
     let mut offset = 1;
 

--- a/crates/core/src/frame/header.rs
+++ b/crates/core/src/frame/header.rs
@@ -87,7 +87,7 @@ pub fn parse_frame_header_after_magic(
             _ => unreachable!(),
         };
         offset += dict_id_size;
-        Some(id)
+        (id != 0).then_some(id)
     } else {
         None
     };

--- a/crates/decode/src/streaming.rs
+++ b/crates/decode/src/streaming.rs
@@ -25,12 +25,16 @@ enum State {
     },
     Checksum,
     Done,
+    Failed,
 }
 
 /// Streaming zstd decompressor implementing [`Read`].
 ///
 /// Wraps a reader of compressed data and yields decompressed bytes.
 /// Supports multi-frame streams and skippable frames.
+///
+/// After a decoding or reader error, further nonempty reads return errors.
+/// Call [`reset`](Self::reset) with a new reader to reuse the decoder.
 ///
 /// ```no_run
 /// use std::io::Read;
@@ -149,6 +153,12 @@ impl<R: Read> FrameDecoder<R> {
         loop {
             match self.state {
                 State::Done => return Ok(()),
+                State::Failed => {
+                    return Err(io::Error::new(
+                        io::ErrorKind::InvalidData,
+                        "decoder must be reset after an error",
+                    ));
+                }
                 State::FrameHeader => self.read_frame_header()?,
                 State::BlockHeader => self.read_block_header()?,
                 State::BlockData {
@@ -510,6 +520,9 @@ impl<R: Read> FrameDecoder<R> {
 
 impl<R: Read> Read for FrameDecoder<R> {
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        if buf.is_empty() {
+            return Ok(0);
+        }
         if self.output_pos >= self.output_buf.len() {
             if let State::Done = &self.state {
                 return Ok(0);
@@ -518,7 +531,12 @@ impl<R: Read> Read for FrameDecoder<R> {
             self.output_buf.clear();
             self.output_pos = 0;
 
-            self.fill_output()?;
+            if let Err(e) = self.fill_output() {
+                self.output_buf.clear();
+                self.output_pos = 0;
+                self.state = State::Failed;
+                return Err(e);
+            }
         }
 
         let available = &self.output_buf[self.output_pos..];

--- a/crates/decode/src/streaming.rs
+++ b/crates/decode/src/streaming.rs
@@ -168,7 +168,18 @@ impl<R: Read> FrameDecoder<R> {
 
     fn read_frame_header(&mut self) -> io::Result<()> {
         self.read_buf.resize(18, 0);
-        self.inner.read_exact(&mut self.read_buf[..5])?;
+        loop {
+            match self.inner.read(&mut self.read_buf[..1]) {
+                Ok(0) => {
+                    self.state = State::Done;
+                    return Ok(());
+                }
+                Ok(_) => break,
+                Err(e) if e.kind() == io::ErrorKind::Interrupted => continue,
+                Err(e) => return Err(e),
+            }
+        }
+        self.inner.read_exact(&mut self.read_buf[1..5])?;
 
         let magic = u32::from_le_bytes([
             self.read_buf[0],
@@ -504,17 +515,7 @@ impl<R: Read> Read for FrameDecoder<R> {
             self.output_buf.clear();
             self.output_pos = 0;
 
-            match self.fill_output() {
-                Ok(()) => {}
-                Err(e) if e.kind() == io::ErrorKind::UnexpectedEof => match &self.state {
-                    State::FrameHeader => {
-                        self.state = State::Done;
-                        return Ok(0);
-                    }
-                    _ => return Err(e),
-                },
-                Err(e) => return Err(e),
-            }
+            self.fill_output()?;
         }
 
         let available = &self.output_buf[self.output_pos..];

--- a/crates/decode/src/streaming.rs
+++ b/crates/decode/src/streaming.rs
@@ -189,17 +189,20 @@ impl<R: Read> FrameDecoder<R> {
         ]);
 
         if (magic & 0xFFFF_FFF0) == 0x184D_2A50 {
-            self.inner.read_exact(&mut self.read_buf[5..9])?;
+            self.inner.read_exact(&mut self.read_buf[5..8])?;
             let skip_size = u32::from_le_bytes([
+                self.read_buf[4],
                 self.read_buf[5],
                 self.read_buf[6],
                 self.read_buf[7],
-                self.read_buf[8],
-            ]) as usize;
-            io::copy(
-                &mut self.inner.by_ref().take(skip_size as u64),
+            ]);
+            let skipped = io::copy(
+                &mut self.inner.by_ref().take(u64::from(skip_size)),
                 &mut io::sink(),
             )?;
+            if skipped != u64::from(skip_size) {
+                return Err(io::ErrorKind::UnexpectedEof.into());
+            }
             return Ok(());
         }
 

--- a/crates/decode/src/streaming.rs
+++ b/crates/decode/src/streaming.rs
@@ -185,7 +185,7 @@ impl<R: Read> FrameDecoder<R> {
                     return Ok(());
                 }
                 Ok(_) => break,
-                Err(e) if e.kind() == io::ErrorKind::Interrupted => continue,
+                Err(e) if e.kind() == io::ErrorKind::Interrupted => {}
                 Err(e) => return Err(e),
             }
         }

--- a/crates/encode/src/streaming.rs
+++ b/crates/encode/src/streaming.rs
@@ -22,6 +22,10 @@ use zrip_core::xxhash::Xxh64State;
 /// to flush the final block, write the content checksum, and recover the
 /// writer.
 ///
+/// After a write, flush, or finalization error, the encoder cannot be reused.
+/// Later writes, flushes, [`finish`](Self::finish), and [`reset`](Self::reset)
+/// return errors. Discard the encoder and its incomplete output.
+///
 /// Internal buffers (hash tables, sequence scratch, block encoder workspace)
 /// are allocated once and reused across blocks. To reuse them across
 /// multiple frames, call [`reset`](Self::reset) instead of `finish`:
@@ -43,6 +47,7 @@ pub struct FrameEncoder<W: Write> {
     hasher: Xxh64State,
     header_written: bool,
     finished: bool,
+    failed: bool,
     workspace: BlockEncodeWorkspace,
     dict: Option<Dictionary>,
     first_block: bool,
@@ -105,6 +110,7 @@ impl<W: Write> FrameEncoder<W> {
             hasher: Xxh64State::new(0),
             header_written: false,
             finished: false,
+            failed: false,
             workspace: BlockEncodeWorkspace::new(),
             dict,
             first_block,
@@ -153,10 +159,13 @@ impl<W: Write> FrameEncoder<W> {
     }
 
     fn finish_frame(&mut self) -> io::Result<()> {
+        if self.failed {
+            return Err(io::Error::other("encoder cannot be reused after an error"));
+        }
         if self.finished {
             return Ok(());
         }
-        self.finished = true;
+        self.failed = true;
 
         if !self.header_written {
             self.write_header()?;
@@ -167,12 +176,12 @@ impl<W: Write> FrameEncoder<W> {
         let hash = self.hasher.finish();
         let checksum = (hash & 0xFFFF_FFFF) as u32;
         self.inner.write_all(&checksum.to_le_bytes())?;
+        self.finished = true;
+        self.failed = false;
         Ok(())
     }
 
     fn write_header(&mut self) -> io::Result<()> {
-        self.header_written = true;
-
         self.block_out.clear();
         write_frame_header_without_content_size(
             &mut self.block_out,
@@ -181,6 +190,7 @@ impl<W: Write> FrameEncoder<W> {
         )
         .map_err(io::Error::other)?;
         self.inner.write_all(&self.block_out)?;
+        self.header_written = true;
         Ok(())
     }
 
@@ -352,9 +362,14 @@ fn reduce_hash_table(table: &mut [u32], shift: u32) {
 
 impl<W: Write> Write for FrameEncoder<W> {
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        if self.failed {
+            return Err(io::Error::other("encoder cannot be reused after an error"));
+        }
         if self.finished {
             return Err(io::Error::other("encoder already finished"));
         }
+        // Any early return leaves the encoder failed, including partial writes.
+        self.failed = true;
 
         if !self.header_written {
             self.write_header()?;
@@ -374,13 +389,20 @@ impl<W: Write> Write for FrameEncoder<W> {
             }
         }
 
+        self.failed = false;
         Ok(consumed)
     }
 
     fn flush(&mut self) -> io::Result<()> {
+        if self.failed {
+            return Err(io::Error::other("encoder cannot be reused after an error"));
+        }
+        self.failed = true;
         if !self.buffer.is_empty() {
             self.flush_block(false)?;
         }
-        self.inner.flush()
+        self.inner.flush()?;
+        self.failed = false;
+        Ok(())
     }
 }

--- a/crates/encode/src/streaming.rs
+++ b/crates/encode/src/streaming.rs
@@ -15,6 +15,13 @@ use zrip_core::error::CompressError;
 use zrip_core::frame::MAX_BLOCK_SIZE;
 use zrip_core::xxhash::Xxh64State;
 
+#[derive(Clone, Copy)]
+enum EncoderState {
+    Ready,
+    Finished,
+    Failed,
+}
+
 /// Streaming zstd compressor implementing [`Write`].
 ///
 /// Buffers input until a full block (128 KiB) is ready, then compresses
@@ -46,8 +53,7 @@ pub struct FrameEncoder<W: Write> {
     rep_offsets: [u32; 3],
     hasher: Xxh64State,
     header_written: bool,
-    finished: bool,
-    failed: bool,
+    state: EncoderState,
     workspace: BlockEncodeWorkspace,
     dict: Option<Dictionary>,
     first_block: bool,
@@ -109,8 +115,7 @@ impl<W: Write> FrameEncoder<W> {
             rep_offsets,
             hasher: Xxh64State::new(0),
             header_written: false,
-            finished: false,
-            failed: false,
+            state: EncoderState::Ready,
             workspace: BlockEncodeWorkspace::new(),
             dict,
             first_block,
@@ -139,7 +144,7 @@ impl<W: Write> FrameEncoder<W> {
         self.finish_frame()?;
         let old = core::mem::replace(&mut self.inner, new_writer);
         self.header_written = false;
-        self.finished = false;
+        self.state = EncoderState::Ready;
         self.first_block = self.dict.is_some();
         self.rep_offsets = match &self.dict {
             Some(d) => *d.rep_offsets(),
@@ -159,13 +164,13 @@ impl<W: Write> FrameEncoder<W> {
     }
 
     fn finish_frame(&mut self) -> io::Result<()> {
-        if self.failed {
+        if matches!(self.state, EncoderState::Failed) {
             return Err(io::Error::other("encoder cannot be reused after an error"));
         }
-        if self.finished {
+        if matches!(self.state, EncoderState::Finished) {
             return Ok(());
         }
-        self.failed = true;
+        self.state = EncoderState::Failed;
 
         if !self.header_written {
             self.write_header()?;
@@ -176,8 +181,7 @@ impl<W: Write> FrameEncoder<W> {
         let hash = self.hasher.finish();
         let checksum = (hash & 0xFFFF_FFFF) as u32;
         self.inner.write_all(&checksum.to_le_bytes())?;
-        self.finished = true;
-        self.failed = false;
+        self.state = EncoderState::Finished;
         Ok(())
     }
 
@@ -362,14 +366,14 @@ fn reduce_hash_table(table: &mut [u32], shift: u32) {
 
 impl<W: Write> Write for FrameEncoder<W> {
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
-        if self.failed {
+        if matches!(self.state, EncoderState::Failed) {
             return Err(io::Error::other("encoder cannot be reused after an error"));
         }
-        if self.finished {
+        if matches!(self.state, EncoderState::Finished) {
             return Err(io::Error::other("encoder already finished"));
         }
         // Any early return leaves the encoder failed, including partial writes.
-        self.failed = true;
+        self.state = EncoderState::Failed;
 
         if !self.header_written {
             self.write_header()?;
@@ -389,20 +393,21 @@ impl<W: Write> Write for FrameEncoder<W> {
             }
         }
 
-        self.failed = false;
+        self.state = EncoderState::Ready;
         Ok(consumed)
     }
 
     fn flush(&mut self) -> io::Result<()> {
-        if self.failed {
+        if matches!(self.state, EncoderState::Failed) {
             return Err(io::Error::other("encoder cannot be reused after an error"));
         }
-        self.failed = true;
+        let state = self.state;
+        self.state = EncoderState::Failed;
         if !self.buffer.is_empty() {
             self.flush_block(false)?;
         }
         self.inner.flush()?;
-        self.failed = false;
+        self.state = state;
         Ok(())
     }
 }

--- a/tests/spec_conformance.rs
+++ b/tests/spec_conformance.rs
@@ -6,6 +6,32 @@
 // streaming FCS mismatch.
 
 #[test]
+fn explicit_zero_dictionary_id_needs_no_dictionary() {
+    for (flag, width) in [(1, 1), (2, 2), (3, 4)] {
+        let mut frame = zrip::compress(b"hello", 1).unwrap();
+        assert_eq!(frame[4] & 3, 0);
+        let offset = if frame[4] & 0x20 != 0 { 5 } else { 6 };
+        frame[4] |= flag;
+        frame.splice(offset..offset, vec![0; width]);
+        assert_eq!(zrip::decompress(&frame).unwrap(), b"hello");
+        #[cfg(feature = "std")]
+        {
+            use std::io::Read;
+            let mut output = Vec::new();
+            zrip::FrameDecoder::new(frame.as_slice())
+                .read_to_end(&mut output)
+                .unwrap();
+            assert_eq!(output, b"hello");
+        }
+        frame[offset] = 1;
+        assert!(matches!(
+            zrip::decompress(&frame),
+            Err(zrip::DecompressError::DictRequired)
+        ));
+    }
+}
+
+#[test]
 fn ignore_unused_frame_descriptor_bit() {
     let mut frame = zrip::compress(b"hello", 1).unwrap();
     frame[4] |= 0x10;

--- a/tests/spec_conformance.rs
+++ b/tests/spec_conformance.rs
@@ -5,6 +5,24 @@
 // Repeat_Mode without a prior table, bitstream exact consumption, and
 // streaming FCS mismatch.
 
+#[test]
+fn ignore_unused_frame_descriptor_bit() {
+    let mut frame = zrip::compress(b"hello", 1).unwrap();
+    frame[4] |= 0x10;
+    assert_eq!(zrip::decompress(&frame).unwrap(), b"hello");
+    #[cfg(feature = "std")]
+    {
+        use std::io::Read;
+        let mut output = Vec::new();
+        zrip::FrameDecoder::new(frame.as_slice())
+            .read_to_end(&mut output)
+            .unwrap();
+        assert_eq!(output, b"hello");
+    }
+    frame[4] |= 0x08;
+    assert!(zrip::decompress(&frame).is_err());
+}
+
 /// Parse a compressed frame far enough to return the offset of the sequence
 /// section's mode byte inside the first compressed block. Panics if the first
 /// block is not a compressed block or has zero sequences.

--- a/tests/streaming.rs
+++ b/tests/streaming.rs
@@ -60,6 +60,35 @@ fn streaming_encoder_all_levels() {
 // ===== Streaming decoder (FrameDecoder) =====
 
 #[test]
+fn frame_decoder_does_not_return_failed_block_output() {
+    use std::io::Read;
+    let valid = [
+        0x28, 0xb5, 0x2f, 0xfd, 0, 0, 0x29, 0, 0, b'h', b'e', b'l', b'l', b'o',
+    ];
+    let mut size_mismatch = valid.to_vec();
+    size_mismatch[4] = 0x20;
+    size_mismatch[5] = 4;
+    let reset_frame = zrip::compress(b"ok", 1).unwrap();
+    for (frame, limit) in [
+        (valid.to_vec(), 4),
+        (valid[..valid.len() - 3].to_vec(), 100),
+        (size_mismatch, 100),
+    ] {
+        let mut decoder = zrip::FrameDecoder::with_limit(frame.as_slice(), limit);
+        let mut output = [0xaa; 16];
+        assert!(decoder.read(&mut output).is_err());
+        for _ in 0..3 {
+            assert!(decoder.read(&mut output).is_err());
+            assert_eq!(output, [0xaa; 16]);
+        }
+        decoder.reset(reset_frame.as_slice());
+        let mut output = Vec::new();
+        decoder.read_to_end(&mut output).unwrap();
+        assert_eq!(output, b"ok");
+    }
+}
+
+#[test]
 fn frame_decoder_skippable_frames() {
     use std::io::{ErrorKind, Read};
     let frame = zrip::compress(b"hello", 1).unwrap();

--- a/tests/streaming.rs
+++ b/tests/streaming.rs
@@ -60,6 +60,38 @@ fn streaming_encoder_all_levels() {
 // ===== Streaming decoder (FrameDecoder) =====
 
 #[test]
+fn frame_decoder_rejects_partial_headers() {
+    use std::io::{ErrorKind, Read};
+    let frame = zrip::compress(b"hello", 1).unwrap();
+    let header_len = zrip::frame::header::parse_frame_header(&frame)
+        .unwrap()
+        .header_size;
+    for len in 1..header_len {
+        for prefix in [&[][..], frame.as_slice()] {
+            let mut input = prefix.to_vec();
+            input.extend_from_slice(&frame[..len]);
+            let mut decoder = zrip::FrameDecoder::new(input.as_slice());
+            let mut output = Vec::new();
+            assert_eq!(
+                decoder.read_to_end(&mut output).unwrap_err().kind(),
+                ErrorKind::UnexpectedEof
+            );
+        }
+    }
+    let mut output = Vec::new();
+    assert_eq!(
+        zrip::FrameDecoder::new(&[][..])
+            .read_to_end(&mut output)
+            .unwrap(),
+        0
+    );
+    zrip::FrameDecoder::new(frame.as_slice())
+        .read_to_end(&mut output)
+        .unwrap();
+    assert_eq!(output, b"hello");
+}
+
+#[test]
 fn frame_decoder_basic() {
     use std::io::Read;
     let data = b"Hello, streaming decoder!".repeat(1000);

--- a/tests/streaming.rs
+++ b/tests/streaming.rs
@@ -60,6 +60,33 @@ fn streaming_encoder_all_levels() {
 // ===== Streaming decoder (FrameDecoder) =====
 
 #[test]
+fn frame_decoder_skippable_frames() {
+    use std::io::{ErrorKind, Read};
+    let frame = zrip::compress(b"hello", 1).unwrap();
+    for payload in [&[][..], b"abc", &[0; 513]] {
+        let mut skippable = vec![0x50, 0x2a, 0x4d, 0x18];
+        skippable.extend_from_slice(&(payload.len() as u32).to_le_bytes());
+        skippable.extend_from_slice(payload);
+        let input = [skippable.as_slice(), &frame, &skippable, &frame, &skippable].concat();
+        let mut output = Vec::new();
+        zrip::FrameDecoder::new(input.as_slice())
+            .read_to_end(&mut output)
+            .unwrap();
+        assert_eq!(output, b"hellohello");
+        for len in 1..skippable.len() {
+            let mut output = Vec::new();
+            assert_eq!(
+                zrip::FrameDecoder::new(&skippable[..len])
+                    .read_to_end(&mut output)
+                    .unwrap_err()
+                    .kind(),
+                ErrorKind::UnexpectedEof
+            );
+        }
+    }
+}
+
+#[test]
 fn frame_decoder_rejects_partial_headers() {
     use std::io::{ErrorKind, Read};
     let frame = zrip::compress(b"hello", 1).unwrap();

--- a/tests/streaming.rs
+++ b/tests/streaming.rs
@@ -36,6 +36,77 @@ fn streaming_encoder_chunked_writes() {
 }
 
 #[test]
+fn streaming_encoder_errors_remain_errors_at_every_output_position() {
+    use std::cell::RefCell;
+    use std::io::{self, Write};
+    use std::rc::Rc;
+    struct FailOnceAfter {
+        remaining: usize,
+        failed: bool,
+        bytes: Rc<RefCell<Vec<u8>>>,
+    }
+    impl Write for FailOnceAfter {
+        fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+            if self.remaining == 0 && !self.failed {
+                self.failed = true;
+                return Err(io::ErrorKind::WouldBlock.into());
+            }
+            let len = if self.failed {
+                buf.len()
+            } else {
+                buf.len().min(self.remaining).min(3)
+            };
+            self.bytes.borrow_mut().extend_from_slice(&buf[..len]);
+            self.remaining = self.remaining.saturating_sub(len);
+            Ok(len)
+        }
+        fn flush(&mut self) -> io::Result<()> {
+            Ok(())
+        }
+    }
+    let data = b"hello world ".repeat(20);
+    let mut control = zrip::FrameEncoder::new(Vec::new(), 1).unwrap();
+    control.write_all(&data).unwrap();
+    let expected = control.finish().unwrap();
+    for offset in 0..=expected.len() {
+        let bytes = Rc::new(RefCell::new(Vec::new()));
+        let writer = FailOnceAfter {
+            remaining: offset,
+            failed: false,
+            bytes: Rc::clone(&bytes),
+        };
+        let new_writer = || FailOnceAfter {
+            remaining: usize::MAX,
+            failed: false,
+            bytes: Rc::new(RefCell::new(Vec::new())),
+        };
+        let mut enc = zrip::FrameEncoder::new(writer, 1).unwrap();
+        if offset == expected.len() {
+            enc.write_all(&data).unwrap();
+            enc.finish().unwrap();
+            assert_eq!(*bytes.borrow(), expected);
+            continue;
+        }
+        assert!(enc.write_all(&data).is_err() || enc.reset(new_writer()).is_err());
+        assert_eq!(*bytes.borrow(), expected[..offset]);
+        assert!(enc.write_all(b"retry").is_err(), "offset {offset}");
+        assert!(enc.flush().is_err(), "offset {offset}");
+        assert!(enc.reset(new_writer()).is_err(), "offset {offset}");
+        assert_eq!(*bytes.borrow(), expected[..offset]);
+        assert!(enc.finish().is_err(), "offset {offset}");
+    }
+    let writer = FailOnceAfter {
+        remaining: 6,
+        failed: false,
+        bytes: Rc::new(RefCell::new(Vec::new())),
+    };
+    let mut enc = zrip::FrameEncoder::new(writer, 1).unwrap();
+    assert!(enc.write_all(&vec![b'a'; 131_072]).is_err());
+    assert!(enc.write_all(b"retry").is_err());
+    assert!(enc.finish().is_err());
+}
+
+#[test]
 fn streaming_encoder_empty() {
     let encoder = zrip::FrameEncoder::new(Vec::new(), 1).unwrap();
     let compressed = encoder.finish().unwrap();


### PR DESCRIPTION
- Accept zero dictionary IDs and ignore the unused frame descriptor bit.
- Decode skippable frames correctly and reject incomplete frame headers.
- Discard failed decoder output and require `reset` after errors.
- Keep encoder write, flush, and finalization errors terminal.
