### PR TITLE
Allow reusable contexts to omit frame checksums

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Added
 
+- Added reusable-context control over the standard frame content checksum for
+  formats that already authenticate decoded content.
 - Added npm package metadata, Node-compatible WASM initialization, and a dry
   pack/test path for `@paddor/zrip`.
 - Added an npm release workflow that builds, smokes, and publishes

--- a/crates/encode/src/context.rs
+++ b/crates/encode/src/context.rs
@@ -7,7 +7,7 @@ use alloc::vec::Vec;
 
 use crate::block_encoder::{self, BlockEncodeWorkspace};
 use crate::strategy::{self, LevelParams, Strategy};
-use crate::{block_looks_incompressible, dfast, fast, write_frame_header};
+use crate::{block_looks_incompressible, dfast, fast, write_frame_header_with_checksum};
 use zrip_core::Sequence;
 use zrip_core::dict::Dictionary;
 use zrip_core::error::CompressError;
@@ -114,6 +114,7 @@ impl PreparedDict {
 /// ```
 pub struct CompressContext {
     level: i32,
+    content_checksum: bool,
     prepared: Option<PreparedDict>,
     hash_table: Vec<u32>,
     hash_long: Vec<u32>,
@@ -137,6 +138,7 @@ impl CompressContext {
         };
         Ok(Self {
             level,
+            content_checksum: true,
             prepared: None,
             hash_table,
             hash_long,
@@ -181,6 +183,7 @@ impl CompressContext {
         let hash_long = vec![0u32; prepared.hash_long_snapshot.len()];
         Ok(Self {
             level,
+            content_checksum: true,
             prepared: Some(prepared),
             hash_table,
             hash_long,
@@ -191,6 +194,19 @@ impl CompressContext {
             workspace: BlockEncodeWorkspace::new(),
             combined: Vec::new(),
         })
+    }
+
+    /// Enables or disables the standard Zstandard frame content checksum.
+    ///
+    /// Checksums are enabled by default. Disabling them is useful when an
+    /// enclosing format already authenticates the decoded content.
+    pub const fn set_content_checksum(&mut self, enabled: bool) {
+        self.content_checksum = enabled;
+    }
+
+    /// Whether newly compressed frames include a content checksum.
+    pub const fn content_checksum(&self) -> bool {
+        self.content_checksum
     }
 
     /// Compresses `input` using the context's level and optional dictionary.
@@ -213,6 +229,7 @@ impl CompressContext {
             &mut self.output,
             &mut self.workspace,
             &mut self.combined,
+            self.content_checksum,
         )?;
         Ok(self.take_or_borrow_output())
     }
@@ -251,6 +268,7 @@ impl CompressContext {
             &mut self.output,
             &mut self.workspace,
             &mut self.combined,
+            self.content_checksum,
         )?;
         Ok(self.take_or_borrow_output())
     }
@@ -314,11 +332,12 @@ impl CompressContext {
 
         self.output.clear();
         self.output.reserve(input.len() + 32);
-        write_frame_header(
+        write_frame_header_with_checksum(
             &mut self.output,
             input.len(),
             Some(dict_id),
             params.window_log,
+            self.content_checksum,
         )?;
 
         if input.is_empty() {
@@ -474,9 +493,11 @@ impl CompressContext {
             }
         }
 
-        let hash = xxh64(input, 0);
-        let checksum = (hash & 0xFFFF_FFFF) as u32;
-        self.output.extend_from_slice(&checksum.to_le_bytes());
+        if self.content_checksum {
+            let hash = xxh64(input, 0);
+            let checksum = (hash & 0xFFFF_FFFF) as u32;
+            self.output.extend_from_slice(&checksum.to_le_bytes());
+        }
 
         Ok(self.take_or_borrow_output())
     }
@@ -511,6 +532,7 @@ impl CompressContext {
             &mut self.output,
             &mut self.workspace,
             &mut self.combined,
+            self.content_checksum,
         )?;
         Ok(self.take_or_borrow_output())
     }
@@ -538,6 +560,7 @@ fn compress_core(
     output: &mut Vec<u8>,
     workspace: &mut BlockEncodeWorkspace,
     combined: &mut Vec<u8>,
+    content_checksum: bool,
 ) -> Result<(), CompressError> {
     let mut params = params;
     strategy::apply_raw_literals_size_override(&mut params, input.len());
@@ -557,7 +580,13 @@ fn compress_core(
 
     output.clear();
     output.reserve(input.len() + 32);
-    write_frame_header(output, input.len(), dict_id, params.window_log)?;
+    write_frame_header_with_checksum(
+        output,
+        input.len(),
+        dict_id,
+        params.window_log,
+        content_checksum,
+    )?;
 
     if input.is_empty() {
         block_encoder::encode_raw_block(&[], true, output)?;
@@ -796,9 +825,11 @@ fn compress_core(
         }
     }
 
-    let hash = xxh64(input, 0);
-    let checksum = (hash & 0xFFFF_FFFF) as u32;
-    output.extend_from_slice(&checksum.to_le_bytes());
+    if content_checksum {
+        let hash = xxh64(input, 0);
+        let checksum = (hash & 0xFFFF_FFFF) as u32;
+        output.extend_from_slice(&checksum.to_le_bytes());
+    }
 
     Ok(())
 }

--- a/crates/encode/src/lib.rs
+++ b/crates/encode/src/lib.rs
@@ -50,7 +50,24 @@ pub(crate) fn write_frame_header(
     dict_id: Option<u32>,
     window_log: u32,
 ) -> Result<(), CompressError> {
-    write_frame_header_inner(output, Some(content_size), dict_id, window_log)
+    write_frame_header_inner(output, Some(content_size), dict_id, window_log, true)
+}
+
+#[cfg_attr(not(feature = "std"), allow(dead_code))]
+pub(crate) fn write_frame_header_with_checksum(
+    output: &mut impl OutputSink,
+    content_size: usize,
+    dict_id: Option<u32>,
+    window_log: u32,
+    content_checksum: bool,
+) -> Result<(), CompressError> {
+    write_frame_header_inner(
+        output,
+        Some(content_size),
+        dict_id,
+        window_log,
+        content_checksum,
+    )
 }
 
 #[cfg_attr(not(feature = "std"), allow(dead_code))]
@@ -59,7 +76,7 @@ pub(crate) fn write_frame_header_without_content_size(
     dict_id: Option<u32>,
     window_log: u32,
 ) -> Result<(), CompressError> {
-    write_frame_header_inner(output, None, dict_id, window_log)
+    write_frame_header_inner(output, None, dict_id, window_log, true)
 }
 
 fn write_frame_header_inner(
@@ -67,6 +84,7 @@ fn write_frame_header_inner(
     content_size: Option<usize>,
     dict_id: Option<u32>,
     window_log: u32,
+    content_checksum: bool,
 ) -> Result<(), CompressError> {
     output.extend_from_slice(&ZSTD_MAGIC.to_le_bytes())?;
 
@@ -90,7 +108,10 @@ fn write_frame_header_inner(
         Some(_) => 3,
     };
 
-    let descriptor = if single_segment { 0x20 } else { 0 } | 0x04 | (fcs_flag << 6) | dict_id_flag;
+    let descriptor = if single_segment { 0x20 } else { 0 }
+        | if content_checksum { 0x04 } else { 0 }
+        | (fcs_flag << 6)
+        | dict_id_flag;
     output.push(descriptor)?;
 
     if !single_segment {

--- a/tests/roundtrip.rs
+++ b/tests/roundtrip.rs
@@ -454,6 +454,24 @@ fn compress_context_roundtrip() {
     assert_eq!(&decompressed2, data2);
 }
 
+#[cfg(feature = "std")]
+#[test]
+fn compress_context_can_omit_content_checksum() {
+    let data = b"enclosing format already authenticates this payload".repeat(1_000);
+    let mut ctx = zrip::CompressContext::new(1).unwrap();
+    assert!(ctx.content_checksum());
+
+    ctx.set_content_checksum(false);
+    let compressed = ctx.compress(&data).unwrap().to_vec();
+    assert_eq!(compressed[4] & 0x04, 0);
+    assert_eq!(zrip::decompress(&compressed).unwrap(), data);
+
+    ctx.set_content_checksum(true);
+    let compressed = ctx.compress(&data).unwrap().to_vec();
+    assert_ne!(compressed[4] & 0x04, 0);
+    assert_eq!(zrip::decompress(&compressed).unwrap(), data);
+}
+
 #[cfg(all(feature = "std", not(miri)))]
 #[test]
 fn decompress_context_borrows_large_output_for_reuse() {


### PR DESCRIPTION
- Add `CompressContext` controls for optional Zstandard frame content checksums.
- Preserve checksums by default and cover checksum-free frames with round-trip tests.