### PR TITLE
fix(jsr): include WASM modules when bundling

### DIFF
--- a/.github/workflows/jsr.yml
+++ b/.github/workflows/jsr.yml
@@ -3,6 +3,14 @@ name: jsr-publish
 on:
   push:
     branches: [main]
+  pull_request:
+    paths:
+      - ".github/workflows/jsr.yml"
+      - "Cargo.toml"
+      - "crates/**"
+      - "jsr/**"
+      - "npm/**"
+      - "src/**"
 
 jobs:
   publish:
@@ -15,9 +23,16 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           targets: wasm32-unknown-unknown
+      - uses: denoland/setup-deno@v2
+        with:
+          deno-version: v2.x
       - uses: actions/setup-node@v4
         with:
           node-version: lts/*
       - run: cargo install wasm-pack
       - run: cd jsr && bash build.sh
-      - run: cd jsr && npx --yes jsr publish
+      - run: sudo apt-get update && sudo apt-get install -y zstd
+      - run: cd jsr && deno task test
+      - run: cd npm && npm test
+      - if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        run: cd jsr && npx --yes jsr publish

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@
 
 ### Fixed
 
+- Fix JSR package initialization after `deno bundle` by importing WASM and
+  its generated bindings through the module graph.
 - Accept explicitly encoded dictionary ID zero without requiring a dictionary.
 - Ignore the unused frame descriptor bit while retaining reserved-bit checks.
 - Correct `FrameDecoder` skippable-frame lengths and reject truncated payloads.

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -14,6 +14,22 @@ cargo test
 cargo test --no-default-features --features alloc     # no_std tests
 ```
 
+## JSR / WebAssembly
+
+`jsr/build.sh` generates bundler bindings with native WASM imports. The npm
+build requests web bindings separately and writes them into `npm/src/pkg`.
+
+```bash
+cd jsr
+bash build.sh
+deno task test
+```
+
+Use Deno 2.8.3 or newer for `deno bundle` and install `zstd` for cross-checks.
+They cover the default SIMD path, forced scalar loading, synchronous bytes,
+and initialization races. Bundled default initialization runs without file or
+network permissions.
+
 ## Releasing
 
 `release-plz` runs on every push to `main`

--- a/jsr/build.sh
+++ b/jsr/build.sh
@@ -2,7 +2,9 @@
 set -e
 cd "$(dirname "$0")"
 
-PKG=src/pkg
+# The npm package uses web bindings; JSR uses native WASM imports.
+BINDGEN_TARGET=${1:-bundler}
+PKG=${2:-src/pkg}
 TMP=src/pkg-tmp
 
 rm -rf "$PKG" "$TMP"
@@ -10,17 +12,17 @@ mkdir -p "$PKG"
 
 echo "==> Building scalar WASM..."
 cd wasm
-RUSTFLAGS="" wasm-pack build --target web --release --out-dir "../$TMP"
+RUSTFLAGS="" wasm-pack build --target "$BINDGEN_TARGET" --release --out-dir "../$TMP"
 cd ..
 
-cp "$TMP/zrip_wasm.js" "$PKG/"
+cp "$TMP/"*.js "$PKG/"
 cp "$TMP/zrip_wasm.d.ts" "$PKG/"
 cp "$TMP/zrip_wasm_bg.wasm.d.ts" "$PKG/"
 mv "$TMP/zrip_wasm_bg.wasm" "$PKG/"
 
 echo "==> Building simd128 WASM..."
 cd wasm
-RUSTFLAGS="-C target-feature=+simd128" wasm-pack build --target web --release --out-dir "../$TMP"
+RUSTFLAGS="-C target-feature=+simd128" wasm-pack build --target "$BINDGEN_TARGET" --release --out-dir "../$TMP"
 cd ..
 
 mv "$TMP/zrip_wasm_bg.wasm" "$PKG/zrip_simd.wasm"
@@ -29,6 +31,9 @@ echo "==> Verifying JS glue is identical..."
 if ! diff -q "$TMP/zrip_wasm.js" "$PKG/zrip_wasm.js" > /dev/null 2>&1; then
     echo "WARNING: JS glue differs between scalar and simd128 builds!"
     exit 1
+fi
+if [ "$BINDGEN_TARGET" = bundler ]; then
+    diff "$TMP/zrip_wasm_bg.js" "$PKG/zrip_wasm_bg.js"
 fi
 
 rm -rf "$TMP"

--- a/jsr/bundle_test.ts
+++ b/jsr/bundle_test.ts
@@ -1,0 +1,47 @@
+import { strictEqual as assertEquals } from "node:assert";
+
+Deno.test("bundled initialization and roundtrips", async (test) => {
+  const directory = await Deno.makeTempDir();
+  try {
+    const output = `${directory}/bundle.js`;
+    const bundle = await new Deno.Command(Deno.execPath(), {
+      args: [
+        "bundle",
+        "--no-config",
+        "--output",
+        output,
+        new URL("./testdata/bundle.ts", import.meta.url).pathname,
+      ],
+    }).output();
+    assertEquals(bundle.code, 0, new TextDecoder().decode(bundle.stderr));
+
+    for (const mode of ["async", "scalar", "sync", "race"]) {
+      await test.step(mode, async () => {
+        // Default initialization gets no file or network permissions. Only the
+        // explicit bytes API may read a caller-supplied binary.
+        const sync = mode === "sync" || mode === "race";
+        const wasmPath =
+          new URL("./src/pkg/zrip_wasm_bg.wasm", import.meta.url).pathname;
+        const run = await new Deno.Command(Deno.execPath(), {
+          args: [
+            "run",
+            "--no-config",
+            "--no-prompt",
+            ...(sync ? [`--allow-read=${wasmPath}`] : []),
+            output,
+            mode,
+            ...(sync ? [wasmPath] : []),
+          ],
+          cwd: directory,
+        }).output();
+        assertEquals(run.code, 0, new TextDecoder().decode(run.stderr));
+        assertEquals(
+          new TextDecoder().decode(run.stdout).trim(),
+          "roundtrip passed",
+        );
+      });
+    }
+  } finally {
+    await Deno.remove(directory, { recursive: true });
+  }
+});

--- a/jsr/deno.json
+++ b/jsr/deno.json
@@ -6,6 +6,9 @@
   "exports": "./src/mod.ts",
   "publish": {
     "include": ["src/", "deno.json", "LICENSE", "README.md"],
-    "exclude": ["src/pkg/package.json", "!src/pkg/"]
+    "exclude": ["src/**/*_test.ts", "src/pkg/package.json", "!src/pkg/"]
+  },
+  "tasks": {
+    "test": "deno test --allow-read --allow-write --allow-run"
   }
 }

--- a/jsr/src/mod.ts
+++ b/jsr/src/mod.ts
@@ -50,17 +50,21 @@
  * ```
  */
 
-import {
-  compress as wasmCompress,
-  compressBound as wasmCompressBound,
-  Compressor as _Compressor,
-  compressWithDict as wasmCompressWithDict,
-  decompress as wasmDecompress,
-  Decompressor as WasmDecompressor,
-  decompressWithDict as wasmDecompressWithDict,
-  Dictionary as _Dictionary,
-  initSync,
-} from "./pkg/zrip_wasm.js";
+import * as wasmBindings from "./pkg/zrip_wasm_bg.js";
+import type * as Wasm from "./pkg/zrip_wasm.js";
+
+// Use generated types for the bindings, including dynamically added methods
+// such as Symbol.dispose. The type-only import does not initialize WASM.
+const {
+  compress: wasmCompress,
+  compressBound: wasmCompressBound,
+  Compressor: _Compressor,
+  compressWithDict: wasmCompressWithDict,
+  decompress: wasmDecompress,
+  Decompressor: WasmDecompressor,
+  decompressWithDict: wasmDecompressWithDict,
+  Dictionary: _Dictionary,
+} = wasmBindings as unknown as typeof Wasm;
 
 /**
  * Reusable compression context. Amortizes internal allocations across
@@ -75,9 +79,9 @@ import {
  * compressor.free();
  * ```
  */
-export const Compressor: typeof _Compressor = _Compressor;
+export const Compressor: typeof Wasm.Compressor = _Compressor;
 /** Type alias for {@linkcode Compressor} instances. */
-export type Compressor = _Compressor;
+export type Compressor = Wasm.Compressor;
 
 /**
  * Pre-parsed zstd dictionary for use with dictionary compression.
@@ -91,9 +95,9 @@ export type Compressor = _Compressor;
  * dict.free();
  * ```
  */
-export const Dictionary: typeof _Dictionary = _Dictionary;
+export const Dictionary: typeof Wasm.Dictionary = _Dictionary;
 /** Type alias for {@linkcode Dictionary} instances. */
-export type Dictionary = _Dictionary;
+export type Dictionary = Wasm.Dictionary;
 
 /** Options for decompression calls. */
 export interface DecompressOptions {
@@ -114,9 +118,9 @@ function maxDecompressedSize(options?: DecompressOptions): number | undefined {
   return max;
 }
 
-const decompressorInner = new WeakMap<Decompressor, WasmDecompressor>();
+const decompressorInner = new WeakMap<Decompressor, Wasm.Decompressor>();
 
-function getDecompressorInner(decompressor: Decompressor): WasmDecompressor {
+function getDecompressorInner(decompressor: Decompressor): Wasm.Decompressor {
   const inner = decompressorInner.get(decompressor);
   if (!inner) {
     throw new TypeError("invalid or freed Decompressor");
@@ -208,32 +212,46 @@ const SIMD_TEST = new Uint8Array([
 ]);
 
 let initialized = false;
+let initialization: Promise<void> | undefined;
 
-/**
- * Initialize the WASM module. Must be called before any other function.
- * Automatically detects WASM SIMD support and loads the appropriate binary.
- */
-export async function init(): Promise<void> {
+function finishInitialization(wasm: Record<string, unknown>): void {
+  // A synchronous caller may have initialized while the import was pending.
   if (initialized) return;
-
-  const simd = WebAssembly.validate(SIMD_TEST);
-  const wasmFile = simd ? "zrip_simd.wasm" : "zrip_wasm_bg.wasm";
-  const wasmUrl = new URL(`./pkg/${wasmFile}`, import.meta.url);
-  const response = await fetch(wasmUrl);
-  const bytes = await response.arrayBuffer();
-  initSync({ module: new WebAssembly.Module(bytes) });
+  wasmBindings.__wbg_set_wasm(wasm);
+  // wasm-bindgen emits this initializer when the module needs startup work.
+  if (typeof wasm.__wbindgen_start === "function") wasm.__wbindgen_start();
   initialized = true;
 }
 
 /**
- * Initialize synchronously with a pre-loaded WASM binary.
- * Use when you have already loaded the WASM bytes (e.g. via `Deno.readFileSync`
- * or `fs.readFileSync` in Node.js).
+ * Initialize the WASM module. Must be called before compression or decoding.
+ * Automatically detects WASM SIMD support and loads the appropriate binary.
  */
+export function init(): Promise<void> {
+  if (initialized) return Promise.resolve();
+  if (initialization) return initialization;
+
+  initialization = (async () => {
+    // Literal imports let bundlers include WASM and its generated JS bindings.
+    const wasm = WebAssembly.validate(SIMD_TEST)
+      ? await import("./pkg/zrip_simd.wasm")
+      : await import("./pkg/zrip_wasm_bg.wasm");
+    finishInitialization(wasm);
+  })().catch((error) => {
+    initialization = undefined;
+    throw error;
+  });
+  return initialization;
+}
+
+/** Initialize synchronously from preloaded WASM bytes. */
 export function initSyncFromBytes(bytes: BufferSource): void {
   if (initialized) return;
-  initSync({ module: new WebAssembly.Module(bytes) });
-  initialized = true;
+  const module = new WebAssembly.Module(bytes);
+  const instance = new WebAssembly.Instance(module, {
+    "./zrip_wasm_bg.js": wasmBindings,
+  });
+  finishInitialization(instance.exports);
 }
 
 /**

--- a/jsr/testdata/bundle.ts
+++ b/jsr/testdata/bundle.ts
@@ -1,0 +1,49 @@
+import {
+  compress,
+  Compressor,
+  decompress,
+  Decompressor,
+  init,
+  initSyncFromBytes,
+} from "../src/mod.ts";
+
+const mode = Deno.args[0];
+if (mode === "scalar") {
+  WebAssembly.validate = () => false;
+}
+const pending = mode === "race" ? init() : undefined;
+if (mode === "sync" || mode === "race") {
+  let rejected = false;
+  try {
+    initSyncFromBytes(new Uint8Array());
+  } catch (error) {
+    if (!(error instanceof WebAssembly.CompileError)) throw error;
+    rejected = true;
+  }
+  if (!rejected) throw new Error("invalid WASM bytes were accepted");
+  initSyncFromBytes(Deno.readFileSync(Deno.args[1]));
+}
+
+// Keep an allocated context alive while asynchronous initialization finishes.
+const early = mode === "race" ? new Compressor() : undefined;
+await Promise.all([pending, init(), init(), init()]);
+const compressor = early ?? new Compressor();
+const decompressor = new Decompressor();
+for (const text of ["", "bundled compression 😀".repeat(1000)]) {
+  const data = new TextEncoder().encode(text);
+  const compressed = compress(data);
+  const decoded = decompress(compressed);
+  const reused = decompressor.decompress(compressor.compress(data));
+  for (const output of [decoded, reused]) {
+    if (
+      output.length !== data.length ||
+      output.some((byte, i) => byte !== data[i])
+    ) {
+      throw new Error("roundtrip mismatch");
+    }
+  }
+  await init();
+}
+compressor.free();
+decompressor.free();
+console.log("roundtrip passed");

--- a/npm/build.sh
+++ b/npm/build.sh
@@ -2,21 +2,6 @@
 set -e
 cd "$(dirname "$0")"
 
-JSR_PKG=../jsr/src/pkg
-NPM_PKG=src/pkg
-
-if [ ! -f "$JSR_PKG/zrip_wasm.js" ] ||
-   [ ! -f "$JSR_PKG/zrip_wasm.d.ts" ] ||
-   [ ! -f "$JSR_PKG/zrip_wasm_bg.wasm.d.ts" ] ||
-   [ ! -f "$JSR_PKG/zrip_wasm_bg.wasm" ] ||
-   [ ! -f "$JSR_PKG/zrip_simd.wasm" ]; then
-  (cd ../jsr && bash build.sh)
-fi
-
-rm -rf "$NPM_PKG"
-mkdir -p "$NPM_PKG"
-cp "$JSR_PKG/zrip_wasm.js" "$NPM_PKG/"
-cp "$JSR_PKG/zrip_wasm.d.ts" "$NPM_PKG/"
-cp "$JSR_PKG/zrip_wasm_bg.wasm.d.ts" "$NPM_PKG/"
-cp "$JSR_PKG/zrip_wasm_bg.wasm" "$NPM_PKG/"
-cp "$JSR_PKG/zrip_simd.wasm" "$NPM_PKG/"
+# Node initialization uses wasm-bindgen's web API, independently of JSR's
+# native WASM imports. Build into the npm package without replacing JSR files.
+(cd ../jsr && bash build.sh web ../npm/src/pkg)


### PR DESCRIPTION
- Load WASM through literal module imports so `deno bundle` includes codec assets.
- Preserve `initSyncFromBytes()`, scalar/SIMD selection, and reusable contexts across concurrent initialization.
- Generate separate web bindings for the npm package.
- Cover bundled initialization and npm packaging in PR CI.
